### PR TITLE
Fix variable typo

### DIFF
--- a/md/actor.md
+++ b/md/actor.md
@@ -268,7 +268,7 @@ pool.each{|actor| overlord.add_worker(actor)}
 
 overlord.run! 
 
-pool.post('YAHOO')
+financial.post('YAHOO')
 
 #>> [2013-10-18 09:35:28 -0400] SENT 'YAHOO' from main to worker pool
 #>> [2013-10-18 09:35:28 -0400] RECEIVED 'YAHOO' to #<FinanceActor:0x0000010331af70>...


### PR DESCRIPTION
It seems like the variable `pool` should be replaced with `financial`.  Otherwise, the example from the README throws an error related to not being able to call `#post` on an Array.
