### PR TITLE
Dereferenceable mutex race condition

### DIFF
--- a/lib/concurrent/agent.rb
+++ b/lib/concurrent/agent.rb
@@ -28,6 +28,7 @@ module Concurrent
       @rescuers = []
       @validator = nil
       @timeout = opts[:timeout] || TIMEOUT
+      init_mutex
       set_deref_options(opts)
     end
 

--- a/lib/concurrent/contract.rb
+++ b/lib/concurrent/contract.rb
@@ -7,6 +7,7 @@ module Concurrent
 
     def initialize(opts = {})
       @state = :pending
+      init_mutex
       set_deref_options(opts)
     end
 

--- a/lib/concurrent/dereferenceable.rb
+++ b/lib/concurrent/dereferenceable.rb
@@ -21,8 +21,8 @@ module Concurrent
     #   returning the value returned from the proc (default: `nil`)
     def set_deref_options(opts = {})
       mutex.synchronize do
-        @dup_on_deref = opts[:dup_on_deref] || opts[:dup] || false
-        @freeze_on_deref = opts[:freeze_on_deref] || opts[:freeze] || false
+        @dup_on_deref = opts[:dup_on_deref] || opts[:dup]
+        @freeze_on_deref = opts[:freeze_on_deref] || opts[:freeze]
         @copy_on_deref = opts[:copy_on_deref] || opts[:copy]
         @do_nothing_on_deref = ! (@dup_on_deref || @freeze_on_deref || @copy_on_deref)
       end
@@ -33,7 +33,7 @@ module Concurrent
     def value
       return nil if @value.nil?
       return @value if @do_nothing_on_deref
-      return mutex.synchronize do
+      mutex.synchronize do
         value = @value
         value = @copy_on_deref.call(value) if @copy_on_deref
         value = value.dup if @dup_on_deref
@@ -45,9 +45,12 @@ module Concurrent
 
     protected
 
-    # @private
     def mutex # :nodoc:
-      @mutex ||= Mutex.new
+      @mutex
+    end
+
+    def init_mutex
+      @mutex = Mutex.new
     end
   end
 end

--- a/lib/concurrent/future.rb
+++ b/lib/concurrent/future.rb
@@ -12,6 +12,7 @@ module Concurrent
     include UsesGlobalThreadPool
 
     def initialize(*args, &block)
+      init_mutex
       unless block_given?
         @state = :fulfilled
       else

--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -41,6 +41,7 @@ module Concurrent
       @children = []
       @rescuers = []
 
+      init_mutex
       realize(*args) if root?
     end
 

--- a/lib/concurrent/scheduled_task.rb
+++ b/lib/concurrent/scheduled_task.rb
@@ -29,6 +29,7 @@ module Concurrent
       @state = :pending
       @schedule_time.freeze
       @task = block
+      init_mutex
       set_deref_options(opts)
 
       @thread = Thread.new{ work }

--- a/lib/concurrent/timer_task.rb
+++ b/lib/concurrent/timer_task.rb
@@ -198,6 +198,7 @@ module Concurrent
       @run_now = opts[:now] || opts[:run_now] || false
 
       @task = block
+      init_mutex
       set_deref_options(opts)
     end
 


### PR DESCRIPTION
Dereferenceable module lazy initializes its mutex without any other lock, opening the possibility of a race condition and visibility issues.
To fix this, we have to manually init the mutex in every class that includes it.
I think this solution is not very clean and is a little error prone, but AFAIK there isn't a better way to initialize module instance variables... maybe we can change the `mutex` method to raise an exception if the var is not set.

In this commit `set_deref_options` has been refactored a bit removing unnecessary code
