### PR TITLE
Updated JRuby optimizations in AtomicLong.

### DIFF
--- a/lib/concurrent/atomic.rb
+++ b/lib/concurrent/atomic.rb
@@ -47,7 +47,7 @@ module Concurrent
   module JavaAtomicFixnum
 
     def allocate_storage(init)
-      @atomic = java.utli.concurrent.atomic.AtomicLong.new(init)
+      @atomic = java.util.concurrent.atomic.AtomicLong.new(init)
     end
 
     def value
@@ -79,7 +79,7 @@ module Concurrent
       allocate_storage(init)
     end
 
-    if defined? java.utli.concurrent.atomic.AtomicLong.new
+    if defined? java.util
       include JavaAtomicFixnum
     else
       include MutexAtomicFixnum
@@ -89,5 +89,4 @@ module Concurrent
     alias_method :down, :decrement
 
   end
-
 end

--- a/spec/concurrent/atomic_spec.rb
+++ b/spec/concurrent/atomic_spec.rb
@@ -19,6 +19,14 @@ module Concurrent
           AtomicFixnum.new(10.01)
         }.should raise_error(ArgumentError)
       end
+
+      if jruby?
+
+        it 'supports JRuby-optimizations' do
+          java.util.concurrent.atomic.AtomicLong.should_receive(:new).with(any_args)
+          AtomicFixnum.new(10)
+        end
+      end
     end
 
     context '#value' do
@@ -69,7 +77,7 @@ module Concurrent
       it 'is aliased as #down' do
         AtomicFixnum.new(10).down.should eq 9
       end
-      
+
     end
   end
 end

--- a/spec/support/functions.rb
+++ b/spec/support/functions.rb
@@ -15,3 +15,7 @@ end
 def jruby?
   RbConfig::CONFIG['ruby_install_name']=~ /^jruby$/i 
 end
+
+def rbx?
+  RbConfig::CONFIG['ruby_install_name']=~ /^rbx$/i 
+end


### PR DESCRIPTION
@chrisseaton I wanted to understand Java integration in JRuby better so I started playing with AtomicLong. The `if defined? java...` statement didn't work as expected on my machine (OS X 10.9.2, rvm 1.25.18, jruby 1.7.11 (1.9.3p392), ruby 2.1.0p0). These updates work on my machine with the aforementioned versions of Ruby and the new test passes. Please take a look and let me know if this seems right.

I don't know why `if defined? java.util` works but `if defined? java.util.concurrent.atomic.AtomicLong` does not. My best guess is late binding. To experiment I put `puts java.util.concurrent.atomic.AtomicLong` in atomic.rb just prior to the `if defined? ...` statement and that caused `if defined? java.util.concurrent.atomic.AtomicLong` to work, as thought `puts` forced bindings all the way down to `AtomicLong`.

I'm working off the assumption that if `java.util` is defined then `java.util.concurrent.atomic.AtomicLong` will _also_ be defined. I'm not familiar enough with JRuby to know if this is a valid assumption.
