### PR TITLE
Use MVars for exchanger instead of mutexes and conditions.

### DIFF
--- a/lib/concurrent/exchanger.rb
+++ b/lib/concurrent/exchanger.rb
@@ -1,53 +1,30 @@
 module Concurrent
   class Exchanger
 
-    def initialize
-      @mutex = Mutex.new
-      @condition = Condition.new
-      @slot = new_slot
+    EMPTY = Object.new
+
+    def initialize(opts = {})
+      @first = MVar.new(EMPTY, opts)
+      @second = MVar.new(MVar::EMPTY, opts)
     end
 
     def exchange(value, timeout = nil)
-      @mutex.synchronize do
-
-        replace_slot_if_fulfilled
-
-        slot = @slot
-
-        if slot.state == :empty
-          slot.value_1 = value
-          slot.state = :waiting
-          wait_for_value(slot, timeout)
-          slot.value_2
+      first = @first.take(timeout)
+      if first == MVar::TIMEOUT
+        nil
+      elsif first == EMPTY
+        @first.put value
+        second = @second.take timeout
+        if second == MVar::TIMEOUT
+          nil
         else
-          slot.value_2 = value
-          slot.state = :fulfilled
-          @condition.broadcast
-          slot.value_1
+          second
         end
-
+      else
+        @first.put EMPTY
+        @second.put value
+        first
       end
-    end
-
-    Slot = Struct.new(:value_1, :value_2, :state)
-
-    private_constant :Slot
-
-    private
-
-    def replace_slot_if_fulfilled
-      @slot = new_slot if @slot.state == :fulfilled
-    end
-
-    def wait_for_value(slot, timeout)
-      remaining = Condition::Result.new(timeout)
-      while slot.state == :waiting && remaining.can_wait?
-        remaining = @condition.wait(@mutex, remaining.remaining_time)
-      end
-    end
-
-    def new_slot
-      Slot.new(nil, nil, :empty)
     end
 
   end

--- a/spec/concurrent/exchanger_spec.rb
+++ b/spec/concurrent/exchanger_spec.rb
@@ -62,41 +62,5 @@ module Concurrent
         end
       end
     end
-
-    context 'spurious wake ups' do
-
-      before(:each) do
-        def subject.simulate_spurious_wake_up
-          @mutex.synchronize do
-            @condition.broadcast
-          end
-        end
-      end
-
-      it 'should resist to spurious wake ups without timeout' do
-        @expected = false
-        Thread.new { exchanger.exchange(1); @expected = true }
-
-        sleep(0.1)
-        subject.simulate_spurious_wake_up
-
-        sleep(0.1)
-        @expected.should be_false
-      end
-
-      it 'should resist to spurious wake ups with timeout' do
-        @expected = false
-        Thread.new { exchanger.exchange(1, 0.3); @expected = true }
-
-        sleep(0.1)
-        subject.simulate_spurious_wake_up
-
-        sleep(0.1)
-        @expected.should be_false
-
-        sleep(0.2)
-        @expected.should be_true
-      end
-    end
   end
 end


### PR DESCRIPTION
@mighe have you considered using some of our higher level primitives to build on for your Exchanger? It's simpler - less code to maintain, we don't have to implement our own wait operation, we get the dereference options for free, and if we optimise MVar for specific Rubies, you'll get the benefit of those optimisations in your Exchanger.
