### PR TITLE
Added Concurrent::dataflow_with for explicitly setting the executor.

### DIFF
--- a/lib/concurrent/dataflow.rb
+++ b/lib/concurrent/dataflow.rb
@@ -61,10 +61,16 @@ module Concurrent
   # @raise [ArgumentError] if no block is given
   # @raise [ArgumentError] if any of the inputs are not +IVar+s
   def dataflow(*inputs, &block)
+    dataflow_with(Concurrent.configuration.global_task_pool, *inputs, &block)
+  end
+  module_function :dataflow
+
+  def dataflow_with(executor, *inputs, &block)
+    raise ArgumentError.new('an executor must be provided') if executor.nil?
     raise ArgumentError.new('no block given') unless block_given?
     raise ArgumentError.new('not all dependencies are IVars') unless inputs.all? { |input| input.is_a? IVar }
 
-    result = Future.new do
+    result = Future.new(executor: executor) do
       values = inputs.map { |input| input.value }
       block.call(*values)
     end
@@ -81,6 +87,5 @@ module Concurrent
 
     result
   end
-
-  module_function :dataflow
+  module_function :dataflow_with
 end

--- a/spec/concurrent/dataflow_spec.rb
+++ b/spec/concurrent/dataflow_spec.rb
@@ -5,26 +5,51 @@ module Concurrent
   describe 'dataflow' do
 
     let(:executor) { ImmediateExecutor.new }
-
-    before(:each) do
-      Concurrent.configure do |config|
-        config.global_task_pool = Concurrent::PerThreadExecutor.new
-      end
-    end
+    let(:root_executor) { PerThreadExecutor.new }
 
     it 'raises an exception when no block given' do
       expect { Concurrent::dataflow }.to raise_error(ArgumentError)
+      expect { Concurrent::dataflow_with(root_executor) }.to raise_error(ArgumentError)
+    end
+
+    specify '#dataflow uses the global task pool' do
+      input = Future.execute{0}
+      Concurrent.should_receive(:dataflow_with).once.
+        with(Concurrent.configuration.global_task_pool, input)
+      Concurrent::dataflow(input){0}
+    end
+
+    specify '#dataflow_with uses the given executor' do
+      input = Future.execute{0}
+      result = Future.new{0}
+
+      Future.should_receive(:new).with(executor: root_executor).and_return(result)
+      Concurrent::dataflow_with(root_executor, input){0}
+    end
+
+    specify '#dataflow_with raises an exception when no executor given' do
+      expect {
+        Concurrent::dataflow_with(nil){ nil }
+      }.to raise_error(ArgumentError)
     end
 
     it 'accepts zero or more dependencies' do
       Concurrent::dataflow(){0}
       Concurrent::dataflow(Future.execute{0}){0}
       Concurrent::dataflow(Future.execute{0}, Future.execute{0}){0}
+
+      Concurrent::dataflow_with(root_executor, ){0}
+      Concurrent::dataflow_with(root_executor, Future.execute{0}){0}
+      Concurrent::dataflow_with(root_executor, Future.execute{0}, Future.execute{0}){0}
     end
 
     it 'accepts uncompleted dependencies' do
       d = Future.new(executor: executor){0}
       Concurrent::dataflow(d){0}
+      d.execute
+
+      d = Future.new(executor: executor){0}
+      Concurrent::dataflow_with(root_executor, d){0}
       d.execute
     end
 
@@ -32,15 +57,24 @@ module Concurrent
       d = Future.new(executor: executor){0}
       d.execute
       Concurrent::dataflow(d){0}
+
+      d = Future.new(executor: executor){0}
+      d.execute
+      Concurrent::dataflow_with(root_executor, d){0}
     end
 
     it 'raises an exception if any dependencies are not IVars' do
       expect { Concurrent::dataflow(nil) }.to raise_error(ArgumentError)
       expect { Concurrent::dataflow(Future.execute{0}, nil) }.to raise_error(ArgumentError)
       expect { Concurrent::dataflow(nil, Future.execute{0}) }.to raise_error(ArgumentError)
+
+      expect { Concurrent::dataflow_with(root_executor, nil) }.to raise_error(ArgumentError)
+      expect { Concurrent::dataflow_with(root_executor, Future.execute{0}, nil) }.to raise_error(ArgumentError)
+      expect { Concurrent::dataflow_with(root_executor, nil, Future.execute{0}) }.to raise_error(ArgumentError)
     end
 
     it 'returns a Future' do
+      Concurrent::dataflow{0}.should be_a(Future)
       Concurrent::dataflow{0}.should be_a(Future)
     end
 
@@ -51,12 +85,24 @@ module Concurrent
         f = Concurrent::dataflow(d){0}
         f.should be_unscheduled
         d.execute
+
+        d = Future.new(executor: executor){0}
+        f = Concurrent::dataflow_with(root_executor, d){0}
+        f.should be_unscheduled
+        d.execute
       end
 
       specify 'if one dependency of two is completed' do
         d1 = Future.new(executor: executor){0}
         d2 = Future.new(executor: executor){0}
         f = Concurrent::dataflow(d1, d2){0}
+        d1.execute
+        f.should be_unscheduled
+        d2.execute
+
+        d1 = Future.new(executor: executor){0}
+        d2 = Future.new(executor: executor){0}
+        f = Concurrent::dataflow_with(root_executor, d1, d2){0}
         d1.execute
         f.should be_unscheduled
         d2.execute
@@ -70,12 +116,24 @@ module Concurrent
         f = Concurrent::dataflow(d){0}
         d.execute
         f.value.should eq 0
+
+        d = Future.new(executor: executor){0}
+        f = Concurrent::dataflow_with(root_executor, d){0}
+        d.execute
+        f.value.should eq 0
       end
 
       specify 'if there is more than one' do
         d1 = Future.new(executor: executor){0}
         d2 = Future.new(executor: executor){0}
         f = Concurrent::dataflow(d1, d2){0}
+        d1.execute
+        d2.execute
+        f.value.should eq 0
+
+        d1 = Future.new(executor: executor){0}
+        d2 = Future.new(executor: executor){0}
+        f = Concurrent::dataflow_with(root_executor, d1, d2){0}
         d1.execute
         d2.execute
         f.value.should eq 0
@@ -89,6 +147,11 @@ module Concurrent
         d.execute
         f = Concurrent::dataflow(d){0}
         f.value.should eq 0
+
+        d = Future.new(executor: executor){0}
+        d.execute
+        f = Concurrent::dataflow_with(root_executor, d){0}
+        f.value.should eq 0
       end
 
       specify 'if there is more than one' do
@@ -98,6 +161,13 @@ module Concurrent
         d2.execute
         f = Concurrent::dataflow(d1, d2){0}
         f.value.should eq 0
+
+        d1 = Future.new(executor: executor){0}
+        d2 = Future.new(executor: executor){0}
+        d1.execute
+        d2.execute
+        f = Concurrent::dataflow_with(root_executor, d1, d2){0}
+        f.value.should eq 0
       end
     end
 
@@ -105,9 +175,12 @@ module Concurrent
 
       specify 'if there is just one' do
         d = Future.new(executor: executor){14}
-        f = Concurrent::dataflow(d) do |v|
-          v
-        end
+        f = Concurrent::dataflow(d){|v| v }
+        d.execute
+        f.value.should eq 14
+
+        d = Future.new(executor: executor){14}
+        f = Concurrent::dataflow_with(root_executor, d){|v| v }
         d.execute
         f.value.should eq 14
       end
@@ -115,9 +188,14 @@ module Concurrent
       specify 'if there is more than one' do
         d1 = Future.new(executor: executor){14}
         d2 = Future.new(executor: executor){2}
-        f = Concurrent::dataflow(d1, d2) do |v1, v2|
-          v1 + v2
-        end
+        f = Concurrent::dataflow(d1, d2) {|v1, v2| v1 + v2}
+        d1.execute
+        d2.execute
+        f.value.should eq 16
+
+        d1 = Future.new(executor: executor){14}
+        d2 = Future.new(executor: executor){2}
+        f = Concurrent::dataflow_with(root_executor, d1, d2) {|v1, v2| v1 + v2}
         d1.execute
         d2.execute
         f.value.should eq 16
@@ -126,7 +204,7 @@ module Concurrent
 
     context 'module function' do
 
-      it 'can be called as Concurrent.dataflow' do
+      it 'can be called as Concurrent.dataflow and Concurrent.dataflow_with' do
 
         def fib_with_dot(n)
           if n < 2
@@ -134,7 +212,7 @@ module Concurrent
           else
             n1 = fib_with_dot(n - 1)
             n2 = fib_with_dot(n - 2)
-            Concurrent.dataflow(n1, n2) { n1.value + n2.value }
+            Concurrent.dataflow_with(root_executor, n1, n2) { n1.value + n2.value }
           end
         end
 
@@ -143,7 +221,7 @@ module Concurrent
         expected.value.should eq 377
       end
 
-      it 'can be called as Concurrent::dataflow' do
+      it 'can be called as Concurrent::dataflow and Concurrent::dataflow_with' do
 
         def fib_with_colons(n)
           if n < 2
@@ -151,7 +229,7 @@ module Concurrent
           else
             n1 = fib_with_colons(n - 1)
             n2 = fib_with_colons(n - 2)
-            Concurrent::dataflow(n1, n2) { n1.value + n2.value }
+            Concurrent::dataflow_with(root_executor, n1, n2) { n1.value + n2.value }
           end
         end
 


### PR DESCRIPTION
When the `:executor` option was added to `Future` it changed the fundamental behavior of `Concurrent::dataflow`. That function creates a new `Future` internally but there was no way to explicitly specify an executor for the factory. This caused the tests to break. Because Ruby does not allow for method overloading (and because `*args` and `opts = {}` do not work together in the same method) there was no easy way to add an `:executor` option to `Concurrent::dataflow`.

This PR adds a new `Concurrent::dataflow_with` method that expects an executor as the first argument. The method signature is:

``` ruby
def dataflow_with(executor, *inputs, &block)
```

The `Concurrent::dataflow` method now delegates to `Concurrent::dataflow_with` and explicitly passes the global task pool. Subsequently the behavior of `Concurrent::dataflow` remains the same as it was before.

@chrisseaton Since you created `Concurrent::dataflow` can you please take a look at this PR and let me know if it looks OK? The tests are now a little redundant but they cover both functions now.
