### PR TITLE
Added brute-force resets back to spec_helper to stabilize test suite.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,4 +28,14 @@ Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require Fil
 
 RSpec.configure do |config|
   config.order = 'random'
+
+  config.before(:each) do
+    #TODO: Better configuration management in individual test suites
+    reset_gem_configuration
+  end
+
+  config.after(:each) do
+    #TODO: Better thread management in individual test suites
+    kill_rogue_threads(false)
+  end
 end

--- a/spec/support/example_group_extensions.rb
+++ b/spec/support/example_group_extensions.rb
@@ -26,8 +26,8 @@ module Concurrent
       Concurrent.instance_variable_set(:@configuration, Concurrent::Configuration.new)
     end
 
-    def kill_rogue_threads
-      warn '[DEPRECATED] brute force thread control being used -- tests need updated'
+    def kill_rogue_threads(warning = true)
+      warn('[DEPRECATED] brute force thread control being used -- tests need updated') if warning
       Thread.list.each do |thread|
         thread.kill unless thread == Thread.current
       end


### PR DESCRIPTION
Our test suite has become very unstable lately. It has always depended on pretty brute-force reset logic in the spec_helper. I shouldn't have taken this approach in the first place and we need to improve my buggy tests in the next release or two. The immediate  need is to stabilize our test suite. I created this PR to trigger Travis and see if it helps. If so I'll merge it and we can begin working on individual test sets.
