### PR TITLE
Typo in documenation, brake -> break

### DIFF
--- a/lib/concurrent/actress.rb
+++ b/lib/concurrent/actress.rb
@@ -12,7 +12,7 @@ module Concurrent
   #
   # Actors are sharing a thread-pool by default which makes them very cheap to create and discard.
   # Thousands of actors can be created, allowing you to break the program into small maintainable pieces,
-  # without breaking the single responsibility principle.
+  # without violating the single responsibility principle.
   #
   # ## What is an actor model?
   #


### PR DESCRIPTION
I also reworked the sentence structure slightly.
