### PR TITLE
Delay root actor initialization

### DIFF
--- a/lib/concurrent/actress.rb
+++ b/lib/concurrent/actress.rb
@@ -145,7 +145,7 @@ module Concurrent
       Thread.current[:__current_actor__]
     end
 
-    # implements ROOT
+    # implements the root actor
     class Root
       include Context
       # to allow spawning of new actors, spawn needs to be called inside the parent Actor
@@ -158,8 +158,12 @@ module Concurrent
       end
     end
 
+    @root = Delay.new { Core.new(parent: nil, name: '/', class: Root).reference }
+
     # A root actor, a default parent of all actors spawned outside an actor
-    ROOT = Core.new(parent: nil, name: '/', class: Root).reference
+    def self.root
+      @root.value
+    end
 
     # Spawns a new actor.
     #
@@ -184,7 +188,7 @@ module Concurrent
       if Actress.current
         Core.new(spawn_optionify(*args).merge(parent: Actress.current), &block).reference
       else
-        ROOT.ask([:spawn, spawn_optionify(*args), block]).value
+        root.ask([:spawn, spawn_optionify(*args), block]).value
       end
     end
 

--- a/lib/concurrent/actress/core.rb
+++ b/lib/concurrent/actress/core.rb
@@ -17,7 +17,7 @@ module Concurrent
       #   @return [String] the name of this instance, it should be uniq (not enforced right now)
       # @!attribute [r] path
       #   @return [String] a path of this actor. It is used for easier orientation and logging.
-      #     Path is constructed recursively with: `parent.path + self.name` up to a {Actress::ROOT},
+      #     Path is constructed recursively with: `parent.path + self.name` up to a {Actress.root},
       #     e.g. `/an_actor/its_child`.
       #     (It will also probably form a supervision path (failures will be reported up to parents)
       #     in future versions.)

--- a/spec/concurrent/actress_spec.rb
+++ b/spec/concurrent/actress_spec.rb
@@ -67,14 +67,14 @@ module Concurrent
                   actor = Ping.spawn :ping, queue
 
                   # when spawn returns children are set
-                  Concurrent::Actress::ROOT.send(:core).instance_variable_get(:@children).should include(actor)
+                  Concurrent::Actress.root.send(:core).instance_variable_get(:@children).should include(actor)
 
                   actor << 'a' << 1
                   queue.pop.should eq 'a'
                   actor.ask(2).value.should eq 2
 
-                  actor.parent.should eq Concurrent::Actress::ROOT
-                  Concurrent::Actress::ROOT.path.should eq '/'
+                  actor.parent.should eq Concurrent::Actress.root
+                  Concurrent::Actress.root.path.should eq '/'
                   actor.path.should eq '/ping'
                   child = actor.ask(:child).value
                   child.path.should eq '/ping/pong'
@@ -105,7 +105,7 @@ module Concurrent
               subject &subject_definition
               after { terminate_actors subject }
               its(:path) { should eq '/ping' }
-              its(:parent) { pending('intermittent JRuby deadlock'); should eq ROOT }
+              its(:parent) { pending('intermittent JRuby deadlock'); should eq Actress.root }
               its(:name) { should eq 'ping' }
               it('executor should be global') { subject.executor.should eq Concurrent.configuration.global_task_pool }
               its(:reference) { should eq subject }


### PR DESCRIPTION
so it does not force global_task_initialization
see https://github.com/ruby-concurrency/concurrent-ruby/pull/100#discussion_r14215798
