### PR TITLE
"num_threads" should be "overflow_policy" as the former is unused

### DIFF
--- a/lib/concurrent/executor/ruby_cached_thread_pool.rb
+++ b/lib/concurrent/executor/ruby_cached_thread_pool.rb
@@ -19,7 +19,7 @@ module Concurrent
       opts = opts.merge(
         min_threads: 0,
         max_threads: DEFAULT_MAX_POOL_SIZE,
-        num_threads: overflow_policy,
+        overflow_policy: overflow_policy,
         max_queue: DEFAULT_MAX_QUEUE_SIZE,
         idletime: DEFAULT_THREAD_IDLETIMEOUT
       )


### PR DESCRIPTION
I was using the `CachedThreadPool` in a project and wanted to see the source code and came across an unused `num_threads` option which in this case I think should be `overflow_policy`.

Just wanted to provide that quick fix.
