### PR TITLE
Added ~ alias to all #value getter methods.

### DIFF
--- a/ext/com/concurrent_ruby/ext/AtomicReferenceLibrary.java
+++ b/ext/com/concurrent_ruby/ext/AtomicReferenceLibrary.java
@@ -80,7 +80,7 @@ public class AtomicReferenceLibrary implements Library {
             return context.nil;
         }
 
-        @JRubyMethod(name = {"get", "value"})
+        @JRubyMethod(name = {"get", "value", "~"})
         public IRubyObject get() {
             return reference;
         }

--- a/ext/concurrent_ruby_ext/rb_concurrent.c
+++ b/ext/concurrent_ruby_ext/rb_concurrent.c
@@ -29,6 +29,7 @@ void Init_concurrent_ruby_ext() {
   rb_define_method(rb_cAtomic, "get_and_set", ir_get_and_set, 1);
   rb_define_method(rb_cAtomic, "_compare_and_set", ir_compare_and_set, 2);
   rb_define_alias(rb_cAtomic, "value", "get");
+  rb_define_alias(rb_cAtomic, "~", "get");
   rb_define_alias(rb_cAtomic, "value=", "set");
   rb_define_alias(rb_cAtomic, "swap", "get_and_set");
 

--- a/lib/concurrent/atomic/atomic_boolean.rb
+++ b/lib/concurrent/atomic/atomic_boolean.rb
@@ -42,6 +42,7 @@ module Concurrent
     ensure
       @mutex.unlock
     end
+    alias_method :~, :value
 
     # @!macro [attach] atomic_boolean_method_value_set
     #
@@ -127,6 +128,7 @@ module Concurrent
       def value
         @atomic.get
       end
+      alias_method :~, :value
 
       # @!macro atomic_boolean_method_value_set
       #
@@ -184,6 +186,8 @@ module Concurrent
 
       # @!method make_false
       #   @!macro atomic_boolean_method_make_false
+
+      alias_method :~, :value
     end
 
     # @!macro atomic_boolean

--- a/lib/concurrent/atomic/atomic_fixnum.rb
+++ b/lib/concurrent/atomic/atomic_fixnum.rb
@@ -48,6 +48,7 @@ module Concurrent
     ensure
       @mutex.unlock
     end
+    alias_method :~, :value
 
     # @!macro [attach] atomic_fixnum_method_value_set
     #
@@ -134,6 +135,7 @@ module Concurrent
       def value
         @atomic.get
       end
+      alias_method :~, :value
 
       # @!macro atomic_fixnum_method_value_set
       def value=(value)
@@ -185,6 +187,8 @@ module Concurrent
 
       # @!method compare_and_set
       #   @!macro atomic_fixnum_method_compare_and_set
+
+      alias_method :~, :value
     end
 
     # @!macro atomic_fixnum

--- a/lib/concurrent/atomic/thread_local_var.rb
+++ b/lib/concurrent/atomic/thread_local_var.rb
@@ -101,6 +101,7 @@ module Concurrent
         value
       end
     end
+    alias_method :~, :value
 
     def value=(value)
       if value.nil?

--- a/lib/concurrent/atomic_reference/mutex_atomic.rb
+++ b/lib/concurrent/atomic_reference/mutex_atomic.rb
@@ -24,6 +24,7 @@ module Concurrent
       @mutex.synchronize { @value }
     end
     alias_method :value, :get
+    alias_method :~, :get
 
     # @!macro [attach] atomic_reference_method_set
     #

--- a/lib/concurrent/atomic_reference/rbx.rb
+++ b/lib/concurrent/atomic_reference/rbx.rb
@@ -13,6 +13,7 @@ module Concurrent
     include Concurrent::AtomicNumericCompareAndSetWrapper
 
     alias_method :value, :get
+    alias_method :~, :get
     alias_method :value=, :set
     alias_method :swap, :get_and_set
   end

--- a/lib/concurrent/channel/channel.rb
+++ b/lib/concurrent/channel/channel.rb
@@ -24,6 +24,7 @@ module Concurrent
       def value
         composite_value.nil? ? nil : composite_value[0]
       end
+      alias_method :~, :value
 
       def channel
         composite_value.nil? ? nil : composite_value[1]

--- a/lib/concurrent/delay.rb
+++ b/lib/concurrent/delay.rb
@@ -78,6 +78,7 @@ module Concurrent
     ensure
       mutex.unlock
     end
+    alias_method :~, :value
 
     # reconfigures the block returning the value if still #incomplete?
     # @yield the delayed operation to perform

--- a/lib/concurrent/dereferenceable.rb
+++ b/lib/concurrent/dereferenceable.rb
@@ -31,6 +31,7 @@ module Concurrent
     ensure
       mutex.unlock
     end
+    alias_method :~, :value
 
     alias_method :deref, :value
 

--- a/lib/concurrent/obligation.rb
+++ b/lib/concurrent/obligation.rb
@@ -48,6 +48,11 @@ module Concurrent
       deref
     end
 
+    # @return [Object] see Dereferenceable#deref
+    def ~
+      value(nil)
+    end
+
     # wait until Obligation is #complete?
     # @param [Numeric] timeout the maximum time in second to wait.
     # @return [Obligation] self

--- a/lib/concurrent/tvar.rb
+++ b/lib/concurrent/tvar.rb
@@ -21,6 +21,7 @@ module Concurrent
         Transaction::current.read(self)
       end
     end
+    alias_method :~, :value
 
     # Set the value of a `TVar`.
     def value=(value)


### PR DESCRIPTION
@mighe @chrisseaton @lucasallan @pitr-ch I saw this alias used in [another concurrency gem](https://github.com/meh/ruby-thread). I know it's only syntactic sugar, but I liked that it enabled this syntax:

``` ruby
require 'concurrent'

x = Concurrent::AtomicFixnum.new(42)
puts ~x
```

We regularly use the `<<` method an an alias for `post`, so there is synergy.

What do you think about this PR? If everyone likes this idiom I'll add a test for each of the updated classes. I don't feel strongly about it so I don't mind deleting the PR if others don't like it.
