### PR TITLE
Do not create un-GC-able symbols when creating ThreadLocalVars

### DIFF
--- a/lib/concurrent/atomic/thread_local_var.rb
+++ b/lib/concurrent/atomic/thread_local_var.rb
@@ -1,56 +1,19 @@
-require 'concurrent/atomic/atomic_fixnum'
+require 'concurrent/atomic'
 
 module Concurrent
 
-  module ThreadLocalSymbolAllocator
-
-    COUNTER = Concurrent::AtomicFixnum.new
-
-    protected
-
-    def allocate_symbol
-      # Warning: this symbol may never be deallocated
-      @symbol = :"thread_local_symbol_#{COUNTER.increment}"
-    end
-
-  end
-
-  module ThreadLocalOldStorage
-
-    include ThreadLocalSymbolAllocator
-
-    protected
+  module ThreadLocalRubyStorage
 
     def allocate_storage
-      allocate_symbol
+      @storage = Atomic.new Hash.new
     end
 
     def get
-      Thread.current[@symbol]
+      @storage.get[Thread.current]
     end
 
     def set(value)
-      Thread.current[@symbol] = value
-    end
-
-  end
-
-  module ThreadLocalNewStorage
-
-    include ThreadLocalSymbolAllocator
-
-    protected
-
-    def allocate_storage
-      allocate_symbol
-    end
-
-    def get
-      Thread.current.thread_variable_get(@symbol)
-    end
-
-    def set(value)
-      Thread.current.thread_variable_set(@symbol, value)
+      @storage.update { |s| s.merge Thread.current => value }
     end
 
   end
@@ -79,10 +42,8 @@ module Concurrent
 
     if RUBY_PLATFORM == 'java'
       include ThreadLocalJavaStorage
-    elsif Thread.current.respond_to?(:thread_variable_set)
-      include ThreadLocalNewStorage
     else
-      include ThreadLocalOldStorage
+      include ThreadLocalRubyStorage
     end
 
     def initialize(default = nil)

--- a/lib/concurrent/tvar.rb
+++ b/lib/concurrent/tvar.rb
@@ -1,7 +1,5 @@
 require 'set'
 
-require 'concurrent/atomic/thread_local_var'
-
 module Concurrent
 
   # A `TVar` is a transactional variable - a single-element container that
@@ -97,7 +95,7 @@ module Concurrent
 
       begin
         # Retry loop
-        
+
         loop do
 
           # Create a new transaction
@@ -149,8 +147,6 @@ module Concurrent
 
     ABORTED = Object.new
 
-    CURRENT_TRANSACTION = ThreadLocalVar.new(nil)
-
     ReadLogEntry = Struct.new(:tvar, :version)
     UndoLogEntry = Struct.new(:tvar, :value)
 
@@ -158,8 +154,8 @@ module Concurrent
 
     def initialize
       @write_set = Set.new
-      @read_log = []
-      @undo_log = []
+      @read_log  = []
+      @undo_log  = []
     end
 
     def read(tvar)
@@ -217,7 +213,7 @@ module Concurrent
       end
 
       unlock
-      
+
       true
     end
 
@@ -240,11 +236,11 @@ module Concurrent
     end
 
     def self.current
-      CURRENT_TRANSACTION.value
+      Thread.current[:current_tvar_transaction]
     end
 
     def self.current=(transaction)
-      CURRENT_TRANSACTION.value = transaction
+      Thread.current[:current_tvar_transaction] = transaction
     end
 
   end

--- a/spec/concurrent/atomic/thread_local_var_spec.rb
+++ b/spec/concurrent/atomic/thread_local_var_spec.rb
@@ -31,13 +31,9 @@ module Concurrent
         it 'uses ThreadLocalJavaStorage' do
           expect(subject.class.ancestors).to include(Concurrent::ThreadLocalJavaStorage)
         end
-      elsif rbx? || RbConfig::CONFIG['ruby_version'] =~ /^1\.9/
-        it 'uses ThreadLocalOldStorage' do
-          expect(subject.class.ancestors).to include(Concurrent::ThreadLocalOldStorage)
-        end
       else
         it 'uses ThreadLocalNewStorage' do
-          expect(subject.class.ancestors).to include(Concurrent::ThreadLocalNewStorage)
+          expect(subject.class.ancestors).to include(Concurrent::ThreadLocalRubyStorage)
         end
       end
     end


### PR DESCRIPTION
GC all data for a given thread local var when the var is GCed
cc @chrisseaton 
