### PR TITLE
JavaExecutor#wait_for_termination now honors a nil timeout (wait forever).

### DIFF
--- a/lib/concurrent/executor/executor.rb
+++ b/lib/concurrent/executor/executor.rb
@@ -250,8 +250,13 @@ module Concurrent
       end
 
       # @!macro executor_method_wait_for_termination
-      def wait_for_termination(timeout)
-        @executor.awaitTermination(1000 * timeout, java.util.concurrent.TimeUnit::MILLISECONDS)
+      def wait_for_termination(timeout = nil)
+        if timeout.nil?
+          ok = @executor.awaitTermination(60, java.util.concurrent.TimeUnit::SECONDS) until ok
+          true
+        else
+          @executor.awaitTermination(1000 * timeout, java.util.concurrent.TimeUnit::MILLISECONDS)
+        end
       end
 
       # @!macro executor_method_shutdown

--- a/spec/concurrent/executor/executor_service_shared.rb
+++ b/spec/concurrent/executor/executor_service_shared.rb
@@ -178,5 +178,12 @@ shared_examples :executor_service do
         expect(subject.wait_for_termination(0)).to be_falsey
       end
     end
+
+    it 'waits forever when no timeout value is given' do
+      subject.post{ sleep(0.5) }
+      sleep(0.1)
+      subject.shutdown
+      expect(subject.wait_for_termination).to be_truthy
+    end
   end
 end


### PR DESCRIPTION
Fixes Issue #134 
