### PR TITLE
Volatile semantics for atomic get set

### DIFF
--- a/ext/concurrent_ruby_ext/atomic_reference.c
+++ b/ext/concurrent_ruby_ext/atomic_reference.c
@@ -27,18 +27,31 @@ VALUE ir_initialize(int argc, VALUE* argv, VALUE self) {
 }
 
 VALUE ir_get(VALUE self) {
+#if HAVE_GCC_SYNC
+  __sync_synchronize();
+#elif defined _MSC_VER
+  MemoryBarrier();
+#elif __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+  OSMemoryBarrier();
+#endif
   return (VALUE) DATA_PTR(self);
 }
 
 VALUE ir_set(VALUE self, VALUE new_value) {
   DATA_PTR(self) = (void *) new_value;
+#if HAVE_GCC_SYNC
+  __sync_synchronize();
+#elif defined _MSC_VER
+  MemoryBarrier();
+#elif __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+  OSMemoryBarrier();
+#endif
   return new_value;
 }
 
 VALUE ir_get_and_set(VALUE self, VALUE new_value) {
-  VALUE old_value;
-  old_value = (VALUE) DATA_PTR(self);
-  DATA_PTR(self) = (void *) new_value;
+  VALUE old_value = ir_get(self);
+  ir_set(self, new_value);
   return old_value;
 }
 

--- a/ext/concurrent_ruby_ext/extconf.rb
+++ b/ext/concurrent_ruby_ext/extconf.rb
@@ -43,6 +43,13 @@ else
       end
     end
 
+    try_run(<<CODE,$CFLAGS) && ($defs << '-DHAVE_GCC_SYNC')
+      int main() {
+        __sync_synchronize();
+        return 0;
+      }
+CODE
+
     create_makefile(EXTENSION_NAME)
   rescue
     create_dummy_makefile


### PR DESCRIPTION
(As I wrote in the commit message:)

This patch ensures that a value `#set` on a CAtomic on one thread will
immediately be visible through `#get` on another thread. The intention is
that `Atomic#get` and `#set` should provide semantics like a Java `volatile`
variable. The whole point of storing a value in an Atomic is because it will
be shared and modified from multiple threads, so it seems wrong that `#get`
and `#set` provide no particular memory-visibility guarantees. This
patch fixes that problem.

It would be better to use a load barrier for `#get` and a store barrier for
for `#set`, but I don't know how to do that in a portable way. If maximum
performance is desired, it might be necessary to use inline assembly,
with `#if`s based on the processor architecture.

The other variants of Atomic should be patched to provide the same
guarantees. The documentation should also be amended.
