### PR TITLE
Allow to disable auto termination of global executors

### DIFF
--- a/spec/concurrent/actor_spec.rb
+++ b/spec/concurrent/actor_spec.rb
@@ -3,7 +3,6 @@ require 'concurrent/actor'
 
 module Concurrent
   module Actor
-    i_know_it_is_experimental!
     AdHoc = Utils::AdHoc
 
     # FIXME better tests!


### PR DESCRIPTION
It was causing trouble when the gem was used in test-suites of other projects.
