### PR TITLE
Add Promise.zip

### DIFF
--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -139,20 +139,32 @@ module Concurrent
       child
     end
 
-    # Builds a promise that produces the result of self and others in an Array
+    # Builds a promise that produces the result of promises in an Array
     # and fails if any of them fails.
     #
-    # @param [Array<Promise>] others
+    # @param [Array<Promise>] promises
     #
-    # @return [Promise]
-    def zip(*others)
-      others.reduce(self.then { |x| [x] }) do |p1, p2|
+    # @return [Promise<Array>]
+    def self.zip(*promises)
+      zero = fulfill([], executor: ImmediateExecutor.new)
+
+      promises.reduce(zero) do |p1, p2|
         p1.flat_map do |results|
           p2.then do |next_result|
             results << next_result
           end
         end
       end
+    end
+
+    # Builds a promise that produces the result of self and others in an Array
+    # and fails if any of them fails.
+    #
+    # @param [Array<Promise>] others
+    #
+    # @return [Promise<Array>]
+    def zip(*others)
+      self.class.zip(self, *others)
     end
 
     protected

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -315,6 +315,24 @@ module Concurrent
       end
     end
 
+    describe '.zip' do
+      let(:promise1) { Promise.new(executor: executor) { 1 } }
+      let(:promise2) { Promise.new(executor: executor) { 2 } }
+      let(:promise3) { Promise.new(executor: executor) { [3] } }
+
+      it 'yields the results as an array' do
+        composite = Promise.zip(promise1, promise2, promise3).execute.wait
+
+        expect(composite.value).to eq([1, 2, [3]])
+      end
+
+      it 'fails if one component fails' do
+        composite = Promise.zip(promise1, promise2, rejected_subject, promise3).execute.wait
+
+        expect(composite).to be_rejected
+      end
+    end
+
     context 'fulfillment' do
 
       it 'passes the result of each block to all its children' do


### PR DESCRIPTION
As discussed in #80. The only thing I'm wondering about is if `.zip` and `#zip` should take `*args` or an array. I chose `*args`, because it looks better when you convert to it from the other - `Promise.zip(*promises)` as opposed to `Promise.zip([promise1, promise2])` and looks very good for the simple case of `promise1.zip(promise2) { |(v1, v2)| ... }`.
