### PR TITLE
Updated README; removed warning when not installing native code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ This gem adheres to the rules of [semantic versioning](http://semver.org/).
 ### Supported Ruby versions
 
 MRI 1.9.3, 2.0, 2.1, JRuby (1.9 mode), and Rubinius 2.x.
-This library is pure Ruby and has no gem dependencies.
-It should be fully compatible with any interpreter that is compliant with Ruby 1.9.3 or newer.
+Although native code is used for performance optimizations on some platforms, all functionality
+is available in pure Ruby. This gem should be fully compatible with any interpreter that is
+compliant with Ruby 1.9.3 or newer.
 
 ### Examples
 

--- a/lib/concurrent/atomic.rb
+++ b/lib/concurrent/atomic.rb
@@ -25,7 +25,7 @@ begin
 
   require "concurrent/atomic_reference/#{ruby_engine}"
 rescue LoadError
-  warn 'Compiled extensions not installed, pure Ruby Atomic will be used.'
+  #warn 'Compiled extensions not installed, pure Ruby Atomic will be used.'
 end
 
 if defined? Concurrent::JavaAtomic


### PR DESCRIPTION
The warning message displayed when no native extensions are installed has caused unintended confusion with our users. I have removed it for now. For the next major release we need to revisit our approach to native extensions and possibly change our approach.
