### PR TITLE
Rejiggered README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,115 +35,68 @@
   </tr>
 </table>
 
-## Features & Documentation
-
-Please see the [Concurrent Ruby Wiki](https://github.com/ruby-concurrency/concurrent-ruby/wiki)
-or the [API documentation](http://ruby-concurrency.github.io/concurrent-ruby/frames.html)
-for more information or join our [mailing list](http://groups.google.com/group/concurrent-ruby).
-
-There are many concurrency abstractions in this library. These abstractions can be broadly categorized
-into several general groups:
-
-* Asynchronous concurrency abstractions including
-  [Agent](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Agent.html),
-  [Async](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Async.html),
-  [Future](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Future.html),
-  [Promise](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Promise.html),
-  [ScheduledTask](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/ScheduledTask.html),
-  and [TimerTask](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/TimerTask.html) 
-* Fast, light-weight [Actor model](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Actor.html) implementation. 
-* Thread-safe variables including
-  [I-Structures](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/IVar.html),
-  [M-Structures](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/MVar.html),
-  [thread-local variables](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/ThreadLocalVar.html),
-  and [software transactional memory](https://github.com/ruby-concurrency/concurrent-ruby/wiki/TVar-(STM))
-* Thread synchronization classes and algorithms including
-  [condition](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Condition.html),
-  [countdown latch](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/CountDownLatch.html),
-  [dataflow](https://github.com/ruby-concurrency/concurrent-ruby/wiki/Dataflow), 
-  [event](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Event.html),
-  [exchanger](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Exchanger.html),
-  and [timeout](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent.html#timeout-class_method)
-* Java-inspired [executors](https://github.com/ruby-concurrency/concurrent-ruby/wiki/Thread%20Pools) (thread pools and more)
-* [And many more](http://ruby-concurrency.github.io/concurrent-ruby/index.html)...
-
-### Semantic Versioning
-
-This gem adheres to the rules of [semantic versioning](http://semver.org/).
-
 ### Supported Ruby versions
 
-MRI 1.9.3, 2.0, 2.1, JRuby (1.9 mode), and Rubinius 2.x.
+MRI 1.9.3, 2.0, 2.1, JRuby (1.9 mode), and Rubinius 2.x are supported.
 Although native code is used for performance optimizations on some platforms, all functionality
 is available in pure Ruby. This gem should be fully compatible with any interpreter that is
 compliant with Ruby 1.9.3 or newer.
 
-### Examples
+## Features & Documentation
 
-Many more code examples can be found in the documentation for each class (linked above).
+We have a roadmap guiding our work toward the [v1.0.0 release](https://github.com/ruby-concurrency/concurrent-ruby/wiki/v1.0-Roadmap).
 
-Future and ScheduledTask:
+The primary site for documentation is the automatically generated [API documentation](http://ruby-concurrency.github.io/concurrent-ruby/frames.html)
 
-```ruby    
-require 'concurrent'
-require 'thread'   # for Queue
-require 'open-uri' # for open(uri)
+We also have a [mailing list](http://groups.google.com/group/concurrent-ruby).
 
-class Ticker
-  def get_year_end_closing(symbol, year)
-    uri = "http://ichart.finance.yahoo.com/table.csv?s=#{symbol}&a=11&b=01&c=#{year}&d=11&e=31&f=#{year}&g=m"
-    data = open(uri) {|f| f.collect{|line| line.strip } }
-    data[1].split(',')[4].to_f
-  end
-end
+This library contains a variety of concurrency abstractions at high and low levels. One of the high-level abstractions is likely to meet most common needs. 
 
-# Future
-price = Concurrent::Future.execute{ Ticker.new.get_year_end_closing('TWTR', 2013) }
-price.state #=> :pending
-sleep(1)    # do other stuff
-price.value #=> 63.65
-price.state #=> :fulfilled
+### High-level, general-purpose asynchronous concurrency abstractions
 
-# ScheduledTask
-task = Concurrent::ScheduledTask.execute(2){ Ticker.new.get_year_end_closing('INTC', 2013) }
-task.state #=> :pending
-sleep(3)   # do other stuff
-task.value #=> 25.96
-```
+* [Actor](./doc/actor/main.md): Implements the Actor Model, where concurrent actors exchange messages. 
+* [Agent](./doc/agent.md): A single atomic value that represents an identity.
+* [Async](./doc/async.md): A mixin module that provides simple asynchronous behavior to any standard class/object or object.
+* [Future](./doc/future.md): An asynchronous operation that produces a value.
+  * [Dataflow](./doc/dataflow.md): Built on Futures, Dataflow allows you to create a task that will be scheduled when all of its data dependencies are available.
+* [Promise](./doc/promise.md): Similar to Futures, with more features. 
+* [ScheduledTask](./doc/scheduled_task.md): Like a Future scheduled for a specific future time. 
+* [TimerTask](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/TimerTask.html): A Thread that periodically wakes up to perform work at regular intervals. 
 
-Actor:
 
-```ruby
-class Counter < Concurrent::Actor::Context
-  # Include context of an actor which gives this class access to reference
-  # and other information about the actor
+### Java-inspired ThreadPools and other executors
 
-  # use initialize as you wish
-  def initialize(initial_value)
-    @count = initial_value
-  end
+* See [ThreadPool](./doc/thread_pools.md) overview, which also contains a list of other Executors available.
 
-  # override on_message to define actor's behaviour
-  def on_message(message)
-    if Integer === message
-      @count += message
-    end
-  end
-end #
+### Thread-safe Observers
 
-# Create new actor naming the instance 'first'.
-# Return value is a reference to the actor, the actual actor is never returned.
-counter = Counter.spawn(:first, 5)
+* [Concurrent::Observable](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Observable.html) mixin module
+* [CopyOnNotifyObserverSet](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/CopyOnNotifyObserverSet.html)
+* [CopyOnWriteObserverSet](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/CopyOnWriteObserverSet.html)
 
-# Tell a message and forget returning self.
-counter.tell(1)
-counter << 1
-# (First counter now contains 7.)
+### Thread synchronization classes and algorithms
+Lower-level abstractions mainly used as building blocks. 
 
-# Send a messages asking for a result.
-counter.ask(0).class
-counter.ask(0).value
-```
+* [condition](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Condition.html)
+* [countdown latch](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/CountDownLatch.html)
+* [cyclic barrier](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/CyclicBarrier.html)
+* [event](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Event.html)
+* [exchanger](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Exchanger.html)
+* [timeout](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent.html#timeout-class_method)
+* [timer](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent.html#timer-class_method)
+
+### Thread-safe variables
+Lower-level abstractions mainly used as building blocks. 
+
+* [AtomicBoolean](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/AtomicBoolean.html)
+* [AtomicFixnum](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/AtomicFixnum.html)
+* AtomicReference (no docs currently available, check source)
+* [I-Structures](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/IVar.html) (IVar)
+* [M-Structures](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/MVar.html) (MVar)
+* [thread-local variables](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/ThreadLocalVar.html)
+* [software transactional memory](./doc/tvar.md) (TVar)
+
+
 
 ## Installing and Building
 

--- a/doc/actor/main.md
+++ b/doc/actor/main.md
@@ -24,6 +24,40 @@ It is simpler to reason about actors than about locks (and all their possible st
 
 ## How to use it
 
+An example:
+
+```ruby
+class Counter < Concurrent::Actor::Context
+  # Include context of an actor which gives this class access to reference
+  # and other information about the actor
+
+  # use initialize as you wish
+  def initialize(initial_value)
+    @count = initial_value
+  end
+
+  # override on_message to define actor's behaviour
+  def on_message(message)
+    if Integer === message
+      @count += message
+    end
+  end
+end #
+
+# Create new actor naming the instance 'first'.
+# Return value is a reference to the actor, the actual actor is never returned.
+counter = Counter.spawn(:first, 5)
+
+# Tell a message and forget returning self.
+counter.tell(1)
+counter << 1
+# (First counter now contains 7.)
+
+# Send a messages asking for a result.
+counter.ask(0).class
+counter.ask(0).value
+```
+
 {include:file:doc/actor/quick.out.rb}
 
 ## Messaging


### PR DESCRIPTION
Incorporating all of what was on wiki main page. Serves as a table of contents linking to other docs (narrative doc/*.md and/or generated yarddocs). Examples moved to docs relevant to those examples.
- Where appropriate docs exist, I link directly to md narrative docs in source `./doc`-- I use relative links, which will work on github, and will also work in yard generated docs (so long as you tell yard to include all files in ./doc!)
- Where no such narrative docs exist, I link to class yardocs at http://ruby-concurrency.github.io/concurrent-ruby/ -- I need to use full absolute URLs for those. 

Do you plan to leave the generated yarddocs at http://ruby-concurrency.github.io/concurrent-ruby/?  Another alternative would be using rdoc.info, although you do have more control generating your own in github pages. 

---

**Next:** Assuming you are happy with the current situation of generating yarddoc to github pages, if you can give me the command line (or other means?) you have been using to generate yarddocs in the past, I'll work on making sure that's all working right and possibly make it more convenient:
- Make sure yarddocs include narrative docs at `./doc/*.md`
- Maybe make a rake task to automatically generate yarddocs and upload them to github pages? Make it easier to keep docs updated with every release (maybe even automatically make the gem release task generate and upload docs?)
- Look into if there's a way to have generated yarddocs automatically include links to source on github, I always find it more convenient when it does that.
- Add links on relevant narrative `docs/*.md`, to generated yarddoc on http://ruby-concurrency.github.io/concurrent-ruby/, for classes discussed. 
