### PR TITLE
Fixed JavaThreadPoolExecutor queue bug when minimum pool size is zero.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please see the [roadmap](https://github.com/ruby-concurrency/concurrent-ruby/iss
 * Added missing synchronizations to `TimerSet`
 * Fixed bug with return value of `Concurrent::Actor::Utils::Pool#ask`
 * Fixed timing bug in `TimerTask`
+* Fixed bug when creating a `JavaThreadPoolExecutor` with minimum pool size of zero
 * Removed confusing warning when not using native extenstions
 * Improved documentation
 

--- a/lib/concurrent/executor/java_thread_pool_executor.rb
+++ b/lib/concurrent/executor/java_thread_pool_executor.rb
@@ -74,9 +74,7 @@ if RUBY_PLATFORM == 'java'
         raise ArgumentError.new('min_threads cannot be more than max_threads') if min_length > max_length
         raise ArgumentError.new("#{@overflow_policy} is not a valid overflow policy") unless OVERFLOW_POLICIES.keys.include?(@overflow_policy)
 
-        if min_length == 0 && @max_queue == 0
-          queue = java.util.concurrent.SynchronousQueue.new
-        elsif @max_queue == 0
+        if @max_queue == 0
           queue = java.util.concurrent.LinkedBlockingQueue.new
         else
           queue = java.util.concurrent.LinkedBlockingQueue.new(@max_queue)
@@ -90,7 +88,7 @@ if RUBY_PLATFORM == 'java'
         set_shutdown_hook
       end
 
-    # @!macro executor_module_method_can_overflow_question
+      # @!macro executor_module_method_can_overflow_question
       def can_overflow?
         @max_queue != 0
       end


### PR DESCRIPTION
Fixes #182 

The constructor was based on introspection of Java objects. Specifically this code:

``` ruby
pool = java.util.concurrent.Executors.newCachedThreadPool #=>  <Java::JavaUtilConcurrent::ThreadPoolExecutor:0x3d36e4cd>
pool.queue #=> #<Java::JavaUtilConcurrent::SynchronousQueue:0x525b461a>
```

I copied this behavior without reading the documentation of [SynchronousQueue](http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/SynchronousQueue.html). In retrospect, it is clear that a synchronous queue, which always blocks and has a fixed size of zero, is not the behavior we want.
