### PR TITLE
Add set_deref_options call to Promise constructor

### DIFF
--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -204,6 +204,7 @@ module Concurrent
       @children = []
 
       init_obligation
+      set_deref_options(opts)
     end
 
     # @return [Promise]


### PR DESCRIPTION
Fixes unintitialised variable warnings, and matches delay.rb.

I spotted these warnings while (I think) waiting for a Promise to be fulfilled:

```
/home/rkd/.rvm/gems/ruby-2.1.5@diameter/gems/concurrent-ruby-0.7.1/lib/concurrent/dereferenceable.rb:101: warning: instance variable @do_nothing_on_deref not initialized
/home/rkd/.rvm/gems/ruby-2.1.5@diameter/gems/concurrent-ruby-0.7.1/lib/concurrent/dereferenceable.rb:102: warning: instance variable @copy_on_deref not initialized
/home/rkd/.rvm/gems/ruby-2.1.5@diameter/gems/concurrent-ruby-0.7.1/lib/concurrent/dereferenceable.rb:103: warning: instance variable @dup_on_deref not initialized
/home/rkd/.rvm/gems/ruby-2.1.5@diameter/gems/concurrent-ruby-0.7.1/lib/concurrent/dereferenceable.rb:104: warning: instance variable @freeze_on_deref not initialized
```

and saw that promise.rb was calling apply_deref_options (and documenting the relevant constructor values) but not set_deref_options.
