### PR TITLE
Exclude GC-dependent ThreadLocalVar test on Rbx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ branches:
 
 matrix:
   allow_failures:
-    - rvm: rbx-2
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: 1.9.3

--- a/spec/concurrent/atomic/thread_local_var_spec.rb
+++ b/spec/concurrent/atomic/thread_local_var_spec.rb
@@ -51,17 +51,20 @@ module Concurrent
           expect(var.instance_variable_get(:@storage).keys.size).to be == 1
         end
 
-        it 'does not leave values behind when bind is not used' do
-          tries = Array.new(10) do
-            var = ThreadLocalVar.new(0)
-            10.times.map do |i|
-              Thread.new { var.value = i; var.value }
-            end.each(&:join)
-            var.value = 0
-            GC.start
-            var.instance_variable_get(:@storage).keys.size == 1
+        unless rbx?
+          #NOTE: This test depends on GC which works differently under Rbx
+          it 'does not leave values behind when bind is not used' do
+            tries = Array.new(10) do
+              var = ThreadLocalVar.new(0)
+              10.times.map do |i|
+                Thread.new { var.value = i; var.value }
+              end.each(&:join)
+              var.value = 0
+              GC.start
+              var.instance_variable_get(:@storage).keys.size == 1
+            end
+            expect(tries.any?).to be_truthy
           end
-          expect(tries.any?).to be_truthy
         end
       end
     end


### PR DESCRIPTION
Addresses #209 

This test depends on garbage collection being run. The garbage collector in Rubinius runs concurrently with running code. Therefore the `GC.start` call cannot be guaranteed to complete before the expectation is checked. This makes the test fail consistently on Rubinius. The logic _should_ work the same on Rubinius since the code is pure Ruby. So this PR guards the test so that it only runs on MRI.
