### PR TITLE
Updated MRI and JRuby Travis build targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.0.0
   - 1.9.3
   - ruby-head
-  - jruby-1.7.18
+  - jruby-1.7.17
   - jruby-head
   - rbx-2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: ruby
 
 rvm:
-  - 2.1.2
+  - 2.2.0
+  - 2.1.4
   - 2.0.0
   - 1.9.3
   - ruby-head
-  - jruby-19mode
+  - jruby-1.7.18
   - jruby-head
   - rbx-2
 


### PR DESCRIPTION
With the release of MRI 2.2.0 and the impending release of JRuby 9000 it is time to update our Travis targets:

* Added MRI `2.2.0`
* Updated MRI `2.1.2` to `2.1.4`
* Removed `jruby-19mode` (TravisCI [known issue](https://github.com/travis-ci/travis-ci/issues/3067))
* Added `jruby-1.7.17` in place of the broken `jruby-19mode` target
