### PR TITLE
Added :args to Future and Promise options hash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-### Next Release v0.7.2 (24 January 2015)
+### Next Release v0.8.0 (25 January 2015)
+
+* Better variable isolation in `Promise` and `Future` via an `:args` option
+
+## Current Release v0.7.2 (24 January 2015)
 
 * New `Semaphore` class based on [java.util.concurrent.Semaphore](http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Semaphore.html)
 * New `Promise.all?` and `Promise.any?` class methods
@@ -15,7 +19,7 @@
 * Tests now run on new Travis build environment
 * Multiple documentation updates
 
-## Current Release v0.7.1 (4 December 2014)
+### Release v0.7.1 (4 December 2014)
 
 Please see the [roadmap](https://github.com/ruby-concurrency/concurrent-ruby/issues/142) for more information on the next planned release.
 

--- a/lib/concurrent/options_parser.rb
+++ b/lib/concurrent/options_parser.rb
@@ -23,6 +23,10 @@ module Concurrent
       end
     end
 
+    def get_arguments_from(opts = {})
+      [*opts.fetch(:args, [])]
+    end
+
     # Get the requested `Executor` based on the values set in the options hash.
     #
     # @param [Hash] opts the options defining the requested executor

--- a/spec/concurrent/future_spec.rb
+++ b/spec/concurrent/future_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require_relative 'dereferenceable_shared'
 require_relative 'obligation_shared'
 require_relative 'observable_shared'
+require_relative 'thread_arguments_shared'
 
 module Concurrent
 
@@ -17,6 +18,18 @@ module Concurrent
     end
 
     context 'behavior' do
+
+      # thread_arguments
+
+      def get_ivar_from_no_args
+        Concurrent::Future.execute{|*args| args }
+      end
+
+      def get_ivar_from_args(opts)
+        Concurrent::Future.execute(opts){|*args| args }
+      end
+
+      it_should_behave_like :thread_arguments
 
       # obligation
 

--- a/spec/concurrent/options_parser_spec.rb
+++ b/spec/concurrent/options_parser_spec.rb
@@ -9,6 +9,50 @@ module Concurrent
     let(:task_pool){ ImmediateExecutor.new }
     let(:operation_pool){ ImmediateExecutor.new }
 
+    context '#get_arguments_from' do
+
+      it 'returns an empty array when opts is not given' do
+        args = OptionsParser::get_arguments_from
+        expect(args).to be_a Array
+        expect(args).to be_empty
+      end
+
+      it 'returns an empty array when opts is an empty hash' do
+        args = OptionsParser::get_arguments_from({})
+        expect(args).to be_a Array
+        expect(args).to be_empty
+      end
+
+      it 'returns an empty array when there is no :args key' do
+        args = OptionsParser::get_arguments_from(foo: 'bar')
+        expect(args).to be_a Array
+        expect(args).to be_empty
+      end
+
+      it 'returns an empty array when the :args key has a nil value' do
+        args = OptionsParser::get_arguments_from(args: nil)
+        expect(args).to be_a Array
+        expect(args).to be_empty
+      end
+
+      it 'returns a one-element array when the :args key has a non-array value' do
+        args = OptionsParser::get_arguments_from(args: 'foo')
+        expect(args).to eq ['foo']
+      end
+
+      it 'returns an array when when the :args key has an array value' do
+        expected = [1, 2, 3, 4]
+        args = OptionsParser::get_arguments_from(args: expected)
+        expect(args).to eq expected
+      end
+
+      it 'returns the given array when the :args key has a complex array value' do
+        expected = [(1..10).to_a, (20..30).to_a, (100..110).to_a]
+        args = OptionsParser::get_arguments_from(args: expected)
+        expect(args).to eq expected
+      end
+    end
+
     context '#get_executor_from' do
 
       it 'returns the given :executor' do

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require_relative 'obligation_shared'
+require_relative 'thread_arguments_shared'
 
 module Concurrent
 
@@ -23,7 +24,24 @@ module Concurrent
       Promise.reject(rejected_reason, executor: executor)
     end
 
-    it_should_behave_like :obligation
+    context 'behavior' do
+
+      # thread_arguments
+
+      def get_ivar_from_no_args
+        Concurrent::Promise.execute{|*args| args }
+      end
+
+      def get_ivar_from_args(opts)
+        Concurrent::Promise.execute(opts){|*args| args }
+      end
+
+      it_should_behave_like :thread_arguments
+
+      # obligation
+
+      it_should_behave_like :obligation
+    end
 
     it 'includes Dereferenceable' do
       promise = Promise.new{ nil }

--- a/spec/concurrent/thread_arguments_shared.rb
+++ b/spec/concurrent/thread_arguments_shared.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+shared_examples :thread_arguments do
+
+  it 'passes an empty array when opts is not given' do
+    future = get_ivar_from_no_args
+    expect(future.value).to eq []
+  end
+
+  it 'passes an empty array when opts is an empty hash' do
+    future = get_ivar_from_args({})
+    expect(future.value).to eq []
+  end
+
+  it 'passes an empty array when there is no :args key' do
+    future = get_ivar_from_args(foo: 'bar')
+    expect(future.value).to eq []
+  end
+
+  it 'passes an empty array when the :args key has a nil value' do
+    future = get_ivar_from_args(args: nil)
+    expect(future.value).to eq []
+  end
+
+  it 'passes a one-element array when the :args key has a non-array value' do
+    future = get_ivar_from_args(args: 'foo')
+    expect(future.value).to eq ['foo']
+  end
+
+  it 'passes an array when when the :args key has an array value' do
+    expected = [1, 2, 3, 4]
+    future = get_ivar_from_args(args: expected)
+    expect(future.value).to eq expected
+  end
+
+  it 'passes the given array when the :args key has a complex array value' do
+    expected = [(1..10).to_a, (20..30).to_a, (100..110).to_a]
+    future = get_ivar_from_args(args: expected)
+    expect(future.value).to eq expected
+  end
+
+  it 'allows the given arguments array to be dereferenced' do
+    expected = [1, 2, 3, 4]
+    future = get_ivar_from_args(args: expected)
+    expect(future.value).to eq expected
+  end
+end


### PR DESCRIPTION
This PR addresses the enhancement discussed in #223. It adds an `:args` option to the constructor and factory of `Future` and `Promise`. The value of this option, when set, can be either a single value or an array of zero or more values. When the `args` option is given the values will be passed to the underlying executor and, subsequently, passed to the task block. Providing `:args` isolates the scope of the variables so that they can be re-assigned within the closing scope. The passed variables are still mutable object references that can be modified within the task block.