### PR TITLE
Implementation of Concurrent::JavaSemaphore in pure Java.

### DIFF
--- a/ext/ConcurrentRubyExtService.java
+++ b/ext/ConcurrentRubyExtService.java
@@ -8,6 +8,7 @@ public class ConcurrentRubyExtService implements BasicLibraryService {
         new com.concurrent_ruby.ext.AtomicReferenceLibrary().load(runtime, false);
         new com.concurrent_ruby.ext.JavaAtomicBooleanLibrary().load(runtime, false);
         new com.concurrent_ruby.ext.JavaAtomicFixnumLibrary().load(runtime, false);
+        new com.concurrent_ruby.ext.JavaSemaphoreLibrary().load(runtime, false);
         return true;
     }
 }

--- a/ext/com/concurrent_ruby/ext/JavaSemaphoreLibrary.java
+++ b/ext/com/concurrent_ruby/ext/JavaSemaphoreLibrary.java
@@ -1,0 +1,144 @@
+package com.concurrent_ruby.ext;
+
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+import org.jruby.Ruby;
+import org.jruby.RubyBoolean;
+import org.jruby.RubyClass;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyModule;
+import org.jruby.RubyNumeric;
+import org.jruby.RubyObject;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.ObjectAllocator;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+public class JavaSemaphoreLibrary {
+
+    public void load(Ruby runtime, boolean wrap) throws IOException {
+        RubyModule concurrentMod = runtime.defineModule("Concurrent");
+        RubyClass atomicCls = concurrentMod.defineClassUnder("JavaSemaphore", runtime.getObject(), JRUBYREFERENCE_ALLOCATOR);
+
+        atomicCls.defineAnnotatedMethods(JavaSemaphore.class);
+
+    }
+
+    private static final ObjectAllocator JRUBYREFERENCE_ALLOCATOR = new ObjectAllocator() {
+        public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
+            return new JavaSemaphore(runtime, klazz);
+        }
+    };
+
+    @JRubyClass(name = "JavaSemaphore", parent = "Object")
+    public static class JavaSemaphore extends RubyObject {
+
+        private JRubySemaphore semaphore;
+
+        public JavaSemaphore(Ruby runtime, RubyClass metaClass) {
+            super(runtime, metaClass);
+        }
+
+        @JRubyMethod
+        public IRubyObject initialize(ThreadContext context, IRubyObject value) {
+            this.semaphore = new JRubySemaphore(rubyFixnumToInt(value, "count"));
+            return context.nil;
+        }
+
+        @JRubyMethod
+        public IRubyObject acquire(ThreadContext context, IRubyObject value) throws InterruptedException {
+            this.semaphore.acquire(rubyFixnumToInt(value, "permits"));
+            return context.nil;
+        }
+
+        @JRubyMethod(name = "available_permits")
+        public IRubyObject availablePermits(ThreadContext context) {
+            return new RubyFixnum(getRuntime(), this.semaphore.availablePermits());
+        }
+
+        @JRubyMethod(name = "drain_permits")
+        public IRubyObject drainPermits(ThreadContext context) {
+            return new RubyFixnum(getRuntime(), this.semaphore.drainPermits());
+        }
+
+        @JRubyMethod
+        public IRubyObject acquire(ThreadContext context) throws InterruptedException {
+            this.semaphore.acquire(1);
+            return context.nil;
+        }
+
+        @JRubyMethod(name = "try_acquire")
+        public IRubyObject tryAcquire(ThreadContext context) throws InterruptedException {
+           return RubyBoolean.newBoolean(getRuntime(), semaphore.tryAcquire(1));
+        }
+
+        @JRubyMethod(name = "try_acquire")
+        public IRubyObject tryAcquire(ThreadContext context, IRubyObject permits) throws InterruptedException {
+           return RubyBoolean.newBoolean(getRuntime(), semaphore.tryAcquire(rubyFixnumToInt(permits, "permits")));
+        }
+
+        @JRubyMethod(name = "try_acquire")
+        public IRubyObject tryAcquire(ThreadContext context, IRubyObject permits, IRubyObject timeout) throws InterruptedException {
+             return RubyBoolean.newBoolean(getRuntime(),
+                        semaphore.tryAcquire(
+                                rubyFixnumToInt(permits, "permits"),
+                                rubyNumericToLong(timeout, "timeout"),
+                                java.util.concurrent.TimeUnit.SECONDS)
+                );
+        }
+
+        @JRubyMethod
+        public IRubyObject release(ThreadContext context) {
+            this.semaphore.release(1);
+            return RubyBoolean.newBoolean(getRuntime(), true);
+        }
+
+        @JRubyMethod
+        public IRubyObject release(ThreadContext context, IRubyObject value) {
+            this.semaphore.release(rubyFixnumToInt(value, "permits"));
+            return RubyBoolean.newBoolean(getRuntime(), true);
+        }
+
+        @JRubyMethod(name = "reduce_permits")
+        public IRubyObject reducePermits(ThreadContext context, IRubyObject reduction) throws InterruptedException {
+            this.semaphore.publicReducePermits(rubyFixnumToInt(reduction, "reduction"));
+            return context.nil;
+        }
+
+        private int rubyFixnumToInt(IRubyObject value, String paramName) {
+            if (value instanceof RubyFixnum && ((RubyFixnum) value).getLongValue() > 0) {
+                RubyFixnum fixNum = (RubyFixnum) value;
+                return (int) fixNum.getLongValue();
+            } else {
+                throw getRuntime().newArgumentError(paramName + " must be in integer greater than zero");
+            }
+        }
+
+        private long rubyNumericToLong(IRubyObject value, String paramName) {
+            if (value instanceof RubyNumeric && ((RubyNumeric) value).getDoubleValue() > 0) {
+                RubyNumeric fixNum = (RubyNumeric) value;
+                return fixNum.getLongValue();
+            } else {
+                throw getRuntime().newArgumentError(paramName + " must be in float greater than zero");
+            }
+        }
+
+        class JRubySemaphore extends Semaphore {
+
+            public JRubySemaphore(int permits) {
+                super(permits);
+            }
+
+            public JRubySemaphore(int permits, boolean value) {
+                super(permits, value);
+            }
+
+            public void publicReducePermits(int i) {
+                reducePermits(i);
+            }
+
+        }
+    }
+}
+

--- a/lib/concurrent/atomic/semaphore.rb
+++ b/lib/concurrent/atomic/semaphore.rb
@@ -109,7 +109,7 @@ module Concurrent
     end
 
     # @!macro [attach] semaphore_method_reduce_permits
-    # 
+    #
     #   @api private
     #
     #   Shrinks the number of available permits by the indicated reduction.
@@ -126,7 +126,7 @@ module Concurrent
         fail ArgumentError, 'reduction must be an non-negative integer'
       end
       @mutex.synchronize { @free -= reduction }
-      nil 
+      nil
     end
 
     private
@@ -153,73 +153,12 @@ module Concurrent
   if RUBY_PLATFORM == 'java'
 
     # @!macro semaphore
-    #     
+    #
     #   A counting semaphore. Conceptually, a semaphore maintains a set of permits. Each {#acquire} blocks if necessary
     #   until a permit is available, and then takes it. Each {#release} adds a permit,
     #   potentially releasing a blocking acquirer.
     #   However, no actual permit objects are used; the Semaphore just keeps a count of the number available and
     #   acts accordingly.
-    class JavaSemaphore
-      # @!macro semaphore_method_initialize
-      def initialize(count)
-        unless count.is_a?(Fixnum) && count >= 0
-          fail(ArgumentError,
-               'count must be in integer greater than or equal zero')
-        end
-        @semaphore = java.util.concurrent.Semaphore.new(count)
-      end
-
-      # @!macro semaphore_method_acquire
-      def acquire(permits = 1)
-        unless permits.is_a?(Fixnum) && permits > 0
-          fail ArgumentError, 'permits must be an integer greater than zero'
-        end
-        @semaphore.acquire(permits)
-      end
-
-      # @!macro semaphore_method_available_permits
-      def available_permits
-        @semaphore.availablePermits
-      end
-
-      # @!macro semaphore_method_drain_permits
-      def drain_permits
-        @semaphore.drainPermits
-      end
-
-      # @!macro semaphore_method_try_acquire
-      def try_acquire(permits = 1, timeout = nil)
-        unless permits.is_a?(Fixnum) && permits > 0
-          fail ArgumentError, 'permits must be an integer greater than zero'
-        end
-        if timeout.nil?
-          @semaphore.tryAcquire(permits)
-        else
-          @semaphore.tryAcquire(permits,
-                                 timeout,
-                                 java.util.concurrent.TimeUnit::SECONDS)
-        end
-      end
-
-      # @!macro semaphore_method_release
-      def release(permits = 1)
-        unless permits.is_a?(Fixnum) && permits > 0
-          fail ArgumentError, 'permits must be an integer greater than zero'
-        end
-        @semaphore.release(permits)
-        true
-      end
-
-      # @!macro semaphore_method_reduce_permits
-      def reduce_permits(reduction)
-        unless reduction.is_a?(Fixnum) && reduction >= 0
-          fail ArgumentError, 'reduction must be an non-negative integer'
-        end
-        @semaphore.reducePermits(reduction)
-      end
-    end
-
-    # @!macro semaphore
     class Semaphore < JavaSemaphore
     end
 


### PR DESCRIPTION
@jdantonio Another good performance improvement:

```Ruby
# Benchmark script
require 'concurrent'
require 'benchmark'

NUM = 50_000_000

if defined? JRUBY_VERSION
  puts "~~~ JRuby version: #{JRUBY_VERSION}"

  Benchmark.bm do |stats|
    e = Concurrent::JavaSemaphore.new(NUM)

    puts "Benchmarking Concurrent::JavaSemaphore#acquire..."
    stats.report do
      NUM.times { e.acquire(1) }
    end
    
    e = Concurrent::JavaSemaphore.new(NUM)

    puts "Benchmarking Concurrent::JavaSemaphore#try_acquire..."
    stats.report do
      NUM.times { e.try_acquire }
    end
    
    e = Concurrent::JavaSemaphore.new(NUM)

    puts "Benchmarking Concurrent::JavaSemaphore#available_permits..."
    stats.report do
      NUM.times { e.available_permits }
    end
  end

end
```

Pure Java
```
~~~ JRuby version: 1.7.19
       user     system      total        real
Benchmarking Concurrent::JavaSemaphore#acquire...
  10.900000   0.070000  10.970000 ( 10.648000)
Benchmarking Concurrent::JavaSemaphore#try_acquire...
   7.420000   0.050000   7.470000 (  7.590000)
Benchmarking Concurrent::JavaSemaphore#available_permits...
   7.650000   0.110000   7.760000 (  7.982000)
```

JRuby

```
~~~ JRuby version: 1.7.19
       user     system      total        real
Benchmarking Concurrent::JavaSemaphore#acquire...
  45.410000   0.430000  45.840000 ( 46.746000)
Benchmarking Concurrent::JavaSemaphore#try_acquire...
  49.820000   0.350000  50.170000 ( 50.669000)
Benchmarking Concurrent::JavaSemaphore#available_permits...
  21.690000   0.160000  21.850000 ( 22.052000)
```