### PR TITLE
Format documentation text to use less than 100 columns

### DIFF
--- a/lib/concurrent/actor.rb
+++ b/lib/concurrent/actor.rb
@@ -81,7 +81,8 @@ module Concurrent
 
     # @overload spawn_optionify(context_class, name, *args)
     #   @param [AbstractContext] context_class to be spawned
-    #   @param [String, Symbol] name of the instance, it's used to generate the {Core#path} of the actor
+    #   @param [String, Symbol] name of the instance, it's used to generate the
+    #     {Core#path} of the actor
     #   @param args for context_class instantiation
     # @overload spawn_optionify(opts)
     #   see {Core#initialize} opts

--- a/lib/concurrent/actor/behaviour/buffer.rb
+++ b/lib/concurrent/actor/behaviour/buffer.rb
@@ -2,11 +2,12 @@ module Concurrent
   module Actor
     module Behaviour
 
-      # Any message reaching this behaviour is buffered. Only one message is is scheduled
-      # at any given time. Others are kept in buffer until another one can be scheduled.
-      # This effectively means that messages handled by behaviours before buffer have higher priority
-      # and they can be processed before messages arriving into buffer. This allows for
-      # the processing of internal actor messages like (`:link`, `:supervise`) first.
+      # Any message reaching this behaviour is buffered. Only one message is is
+      # scheduled at any given time. Others are kept in buffer until another one
+      # can be scheduled. This effectively means that messages handled by
+      # behaviours before buffer have higher priority and they can be processed
+      # before messages arriving into buffer. This allows for the processing of
+      # internal actor messages like (`:link`, `:supervise`) first.
       class Buffer < Abstract
         def initialize(core, subsequent)
           super core, subsequent

--- a/lib/concurrent/actor/context.rb
+++ b/lib/concurrent/actor/context.rb
@@ -39,16 +39,19 @@ module Concurrent
         @envelope = nil
       end
 
-      # if you want to pass the message to next behaviour, usually {Behaviour::ErrorsOnUnknownMessage}
+      # if you want to pass the message to next behaviour, usually
+      # {Behaviour::ErrorsOnUnknownMessage}
       def pass
         core.behaviour!(Behaviour::ExecutesContext).pass envelope
       end
 
-      # Defines an actor responsible for dead letters. Any rejected message send with
-      # {Reference#tell} is sent there, a message with ivar is considered already monitored for
-      # failures. Default behaviour is to use {AbstractContext#dead_letter_routing} of the parent,
-      # so if no {AbstractContext#dead_letter_routing} method is overridden in parent-chain the message ends up in
-      # `Actor.root.dead_letter_routing` agent which will log warning.
+      # Defines an actor responsible for dead letters. Any rejected message send
+      # with {Reference#tell} is sent there, a message with ivar is considered
+      # already monitored for failures. Default behaviour is to use
+      # {AbstractContext#dead_letter_routing} of the parent, so if no
+      # {AbstractContext#dead_letter_routing} method is overridden in
+      # parent-chain the message ends up in `Actor.root.dead_letter_routing`
+      # agent which will log warning.
       # @return [Reference]
       def dead_letter_routing
         parent.dead_letter_routing

--- a/lib/concurrent/actor/core.rb
+++ b/lib/concurrent/actor/core.rb
@@ -4,9 +4,11 @@ module Concurrent
     require 'set'
 
     # Core of the actor
-    # @note Whole class should be considered private. An user should use {Context}s and {Reference}s only.
-    # @note devel: core should not block on anything, e.g. it cannot wait on children to terminate
-    #   that would eat up all threads in task pool and deadlock
+    # @note Whole class should be considered private. An user should use
+    #   {Context}s and {Reference}s only.
+    # @note devel: core should not block on anything, e.g. it cannot wait on
+    #   children to terminate that would eat up all threads in task pool and
+    #   deadlock
     class Core
       include TypeCheck
       include Concurrent::Logging
@@ -36,11 +38,14 @@ module Concurrent
       # @option opts [Executor] executor, default is `Concurrent.configuration.global_task_pool`
       # @option opts [true, false] link, atomically link the actor to its parent
       # @option opts [true, false] supervise, atomically supervise the actor by its parent
-      # @option opts [Array<Array(Behavior::Abstract, Array<Object>)>] behaviour_definition, array of pairs
-      #   where each pair is behaviour class and its args, see {Behaviour.basic_behaviour_definition}
-      # @option opts [IVar, nil] initialized, if present it'll be set or failed after {Context} initialization
-      # @option opts [Proc, nil] logger a proc accepting (level, progname, message = nil, &block) params,
-      #   can be used to hook actor instance to any logging system
+      # @option opts [Array<Array(Behavior::Abstract, Array<Object>)>]
+      #   behaviour_definition, array of pairs where each pair is behaviour
+      #   class and its args, see {Behaviour.basic_behaviour_definition}
+      # @option opts [IVar, nil] initialized, if present it'll be set or failed
+      #   after {Context} initialization
+      # @option opts [Proc, nil] logger a proc accepting (level, progname,
+      #   message = nil, &block) params, can be used to hook actor instance to
+      #   any logging system
       # @param [Proc] block for class instantiation
       def initialize(opts = {}, &block)
         synchronize do

--- a/lib/concurrent/agent.rb
+++ b/lib/concurrent/agent.rb
@@ -32,8 +32,8 @@ module Concurrent
     #
     # @option opts [String] :dup_on_deref (false) call `#dup` before returning the data
     # @option opts [String] :freeze_on_deref (false) call `#freeze` before returning the data
-    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing the internal value and
-    #   returning the value returned from the proc
+    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing
+    #   the internal value and returning the value returned from the proc
     def initialize(initial, opts = {})
       @value                = initial
       @rescuers             = []
@@ -63,7 +63,7 @@ module Concurrent
     #             rescue(NoMethodError){|ex| puts "Bam!" }.
     #             rescue(ArgumentError){|ex| puts "Pow!" }.
     #             rescue{|ex| puts "Boom!" }
-    #   
+    #
     #   score << proc{|current| raise ArgumentError }
     #   sleep(0.1)
     #   #=> puts "Pow!"

--- a/lib/concurrent/atomic/condition.rb
+++ b/lib/concurrent/atomic/condition.rb
@@ -1,13 +1,14 @@
 module Concurrent
 
-  # Condition is a better implementation of standard Ruby ConditionVariable.
-  # The biggest difference is the wait return value: Condition#wait returns
-  # Condition::Result which make possible to know if waiting thread has been woken up
-  # by an another thread (using #signal or #broadcast) or due to timeout.
+  # Condition is a better implementation of standard Ruby ConditionVariable. The
+  # biggest difference is the wait return value: Condition#wait returns
+  # Condition::Result which make possible to know if waiting thread has been
+  # woken up by an another thread (using #signal or #broadcast) or due to
+  # timeout.
   #
-  # Every #wait must be guarded by a locked Mutex or a ThreadError will be risen.
-  # Although it's not mandatory, it's recommended to call also #signal and #broadcast within
-  # the same mutex
+  # Every #wait must be guarded by a locked Mutex or a ThreadError will be
+  # risen. Although it's not mandatory, it's recommended to call also #signal
+  # and #broadcast within the same mutex
   class Condition
 
     class Result
@@ -17,12 +18,14 @@ module Concurrent
 
       attr_reader :remaining_time
 
-      # @return [Boolean] true if current thread has been waken up by a #signal or a #broadcast call, otherwise false
+      # @return [Boolean] true if current thread has been waken up by a #signal
+      #  or a #broadcast call , otherwise false
       def woken_up?
         @remaining_time.nil? || @remaining_time > 0
       end
 
-      # @return [Boolean] true if current thread has been waken up due to a timeout, otherwise false
+      # @return [Boolean] true if current thread has been waken up due to a
+      #   timeout, otherwise false
       def timed_out?
         @remaining_time != nil && @remaining_time <= 0
       end

--- a/lib/concurrent/atomic/copy_on_notify_observer_set.rb
+++ b/lib/concurrent/atomic/copy_on_notify_observer_set.rb
@@ -11,10 +11,12 @@ module Concurrent
       @observers = {}
     end
 
-    # Adds an observer to this set
-    # If a block is passed, the observer will be created by this method and no other params should be passed
+    # Adds an observer to this set. If a block is passed, the observer will be
+    # created by this method and no other params should be passed
+    #
     # @param [Object] observer the observer to add
-    # @param [Symbol] func the function to call on the observer during notification. Default is :update
+    # @param [Symbol] func the function to call on the observer during notification.
+    #   Default is :update
     # @return [Object] the added observer
     def add_observer(observer=nil, func=:update, &block)
       if observer.nil? && block.nil?

--- a/lib/concurrent/atomic/copy_on_write_observer_set.rb
+++ b/lib/concurrent/atomic/copy_on_write_observer_set.rb
@@ -11,9 +11,11 @@ module Concurrent
     end
 
     # Adds an observer to this set
-    # If a block is passed, the observer will be created by this method and no other params should be passed
+    # If a block is passed, the observer will be created by this method and no
+    #   other params should be passed
     # @param [Object] observer the observer to add
-    # @param [Symbol] func the function to call on the observer during notification. Default is :update
+    # @param [Symbol] func the function to call on the observer during notification.
+    #   Default is :update
     # @return [Object] the added observer
     def add_observer(observer=nil, func=:update, &block)
       if observer.nil? && block.nil?

--- a/lib/concurrent/atomic/cyclic_barrier.rb
+++ b/lib/concurrent/atomic/cyclic_barrier.rb
@@ -8,7 +8,8 @@ module Concurrent
     # Create a new `CyclicBarrier` that waits for `parties` threads
     #
     # @param [Fixnum] parties the number of parties
-    # @yield an optional block that will be executed that will be executed after the last thread arrives and before the others are released
+    # @yield an optional block that will be executed that will be executed after
+    #  the last thread arrives and before the others are released
     #
     # @raise [ArgumentError] if `parties` is not an integer or is less than zero
     def initialize(parties, &block)
@@ -31,10 +32,14 @@ module Concurrent
       @number_waiting
     end
 
-    # Blocks on the barrier until the number of waiting threads is equal to `parties` or until `timeout` is reached or `reset` is called
-    # If a block has been passed to the constructor, it will be executed once by the last arrived thread before releasing the others
-    # @param [Fixnum] timeout the number of seconds to wait for the counter or `nil` to block indefinitely
-    # @return [Boolean] `true` if the `count` reaches zero else false on `timeout` or on `reset` or if the barrier is broken
+    # Blocks on the barrier until the number of waiting threads is equal to
+    # `parties` or until `timeout` is reached or `reset` is called
+    # If a block has been passed to the constructor, it will be executed once by
+    #  the last arrived thread before releasing the others
+    # @param [Fixnum] timeout the number of seconds to wait for the counter or
+    #  `nil` to block indefinitely
+    # @return [Boolean] `true` if the `count` reaches zero else false on
+    #  `timeout` or on `reset` or if the barrier is broken
     def wait(timeout = nil)
       @mutex.synchronize do
 
@@ -55,7 +60,8 @@ module Concurrent
 
 
     # resets the barrier to its initial state
-    # If there is at least one waiting thread, it will be woken up, the `wait` method will return false and the barrier will be broken
+    # If there is at least one waiting thread, it will be woken up, the `wait`
+    # method will return false and the barrier will be broken
     # If the barrier is broken, this method restores it to the original state
     #
     # @return [nil]

--- a/lib/concurrent/atomic/semaphore.rb
+++ b/lib/concurrent/atomic/semaphore.rb
@@ -154,11 +154,12 @@ module Concurrent
 
     # @!macro semaphore
     #
-    #   A counting semaphore. Conceptually, a semaphore maintains a set of permits. Each {#acquire} blocks if necessary
-    #   until a permit is available, and then takes it. Each {#release} adds a permit,
-    #   potentially releasing a blocking acquirer.
-    #   However, no actual permit objects are used; the Semaphore just keeps a count of the number available and
-    #   acts accordingly.
+    #   A counting semaphore. Conceptually, a semaphore maintains a set of
+    #   permits. Each {#acquire} blocks if necessary until a permit is
+    #   available, and then takes it. Each {#release} adds a permit, potentially
+    #   releasing a blocking acquirer.
+    #   However, no actual permit objects are used; the Semaphore just keeps a
+    #   count of the number available and acts accordingly.
     class Semaphore < JavaSemaphore
     end
 

--- a/lib/concurrent/collection/blocking_ring_buffer.rb
+++ b/lib/concurrent/collection/blocking_ring_buffer.rb
@@ -42,7 +42,8 @@ module Concurrent
       end
     end
 
-    # @return [Object] the first available value and removes it from the buffer. If buffer is empty it blocks until an element is available
+    # @return [Object] the first available value and removes it from the buffer.
+    #   If buffer is empty it blocks until an element is available
     def take
       @mutex.synchronize do
         wait_while_empty
@@ -52,7 +53,8 @@ module Concurrent
       end
     end
 
-    # @return [Object] the first available value and without removing it from the buffer. If buffer is empty returns nil
+    # @return [Object] the first available value and without removing it from
+    #   the buffer. If buffer is empty returns nil
     def peek
       @mutex.synchronize { @buffer.peek }
     end

--- a/lib/concurrent/collection/ring_buffer.rb
+++ b/lib/concurrent/collection/ring_buffer.rb
@@ -50,7 +50,8 @@ module Concurrent
       result
     end
 
-    # @return [Object] the first available value and without removing it from the buffer. If buffer is empty returns nil
+    # @return [Object] the first available value and without removing it from
+    #   the buffer. If buffer is empty returns nil
     def peek
       @buffer[@first]
     end

--- a/lib/concurrent/delay.rb
+++ b/lib/concurrent/delay.rb
@@ -11,7 +11,7 @@ module Concurrent
   # Where a `Future` schedules an operation for immediate execution and
   # performs the operation asynchronously, a `Delay` (as the name implies)
   # delays execution of the operation until the result is actually needed.
-  # 
+  #
   # When a `Delay` is created its state is set to `pending`. The value and
   # reason are both `nil`. The first time the `#value` method is called the
   # enclosed opration will be run and the calling thread will block. Other
@@ -39,10 +39,12 @@ module Concurrent
     # @yield the delayed operation to perform
     #
     # @param [Hash] opts the options to create a message with
-    # @option opts [String] :dup_on_deref (false) call `#dup` before returning the data
-    # @option opts [String] :freeze_on_deref (false) call `#freeze` before returning the data
-    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing the internal value and
-    #   returning the value returned from the proc
+    # @option opts [String] :dup_on_deref (false) call `#dup` before returning
+    #   the data
+    # @option opts [String] :freeze_on_deref (false) call `#freeze` before
+    #   returning the data
+    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing
+    #   the internal value and returning the value returned from the proc
     #
     # @raise [ArgumentError] if no block is given
     def initialize(opts = {}, &block)

--- a/lib/concurrent/dereferenceable.rb
+++ b/lib/concurrent/dereferenceable.rb
@@ -4,14 +4,20 @@ module Concurrent
   # the `#value` of a concurrent object is a mutable reference. Which is always the
   # case unless the value is a `Fixnum`, `Symbol`, or similar "primitive" data type.
   # Most classes in this library that expose a `#value` getter method do so using the
-  # `Dereferenceable` mixin module. 
-  # 
+  # `Dereferenceable` mixin module.
+  #
   # Objects with this mixin can be configured with a few options that can help protect
   # the program from potentially dangerous operations.
-  # 
-  # * `:dup_on_deref` when true  will call the `#dup` method on the `value` object every time the `#value` method is called (default: false)
-  # * `:freeze_on_deref` when true  will call the `#freeze` method on the `value` object every time the `#value` method is called (default: false)
-  # * `:copy_on_deref` when given a `Proc` object the `Proc` will be run every time the `#value` method is called. The `Proc` will be given the current `value` as its only parameter and the result returned by the block will be the return value of the `#value` call. When `nil` this option will be ignored (default: nil)
+  #
+  # * `:dup_on_deref` when true will call the `#dup` method on the `value`
+  #     object every time the `#value` method is called (default: false)
+  # * `:freeze_on_deref` when true  will call the `#freeze` method on the `value` object
+  #     every time the `#value` method is called (default: false)
+  # * `:copy_on_deref` when given a `Proc` object the `Proc` will be run every
+  #     time the `#value` method is called. The `Proc` will be given the current
+  #     `value` as its only parameter and the result returned by the block will
+  #     be the return value of the `#value` call. When `nil` this option will be
+  #     ignored (default: nil)
   module Dereferenceable
 
     # Return the value this object represents after applying the options specified
@@ -28,7 +34,7 @@ module Concurrent
     # Setting both `:dup_on_deref` to `true` and `:freeze_on_deref` to `true` is
     # as close to the behavior of a "pure" functional language (like Erlang, Clojure,
     # or Haskell) as we are likely to get in Ruby.
-    # 
+    #
     # This method is thread-safe and synchronized with the internal `#mutex`.
     #
     # @return [Object] the current value of the object
@@ -63,7 +69,7 @@ module Concurrent
       @mutex
     end
 
-    # Initializes the internal `Mutex`. 
+    # Initializes the internal `Mutex`.
     #
     # @note This method *must* be called from within the constructor of the including class.
     #
@@ -82,8 +88,8 @@ module Concurrent
     # @param [Hash] opts the options defining dereference behavior.
     # @option opts [String] :dup_on_deref (false) call `#dup` before returning the data
     # @option opts [String] :freeze_on_deref (false) call `#freeze` before returning the data
-    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing the internal value and
-    #   returning the value returned from the proc
+    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing
+    #   the internal value and returning the value returned from the proc
     def set_deref_options(opts = {})
       mutex.lock
       @dup_on_deref = opts[:dup_on_deref] || opts[:dup]

--- a/lib/concurrent/exchanger.rb
+++ b/lib/concurrent/exchanger.rb
@@ -9,7 +9,8 @@ module Concurrent
     end
 
     # @param [Object] value the value to exchange with an other thread
-    # @param [Numeric] timeout the maximum time in second to wait for one other thread. nil (default value) means no timeout
+    # @param [Numeric] timeout the maximum time in second to wait for one other
+    #   thread. nil (default value) means no timeout
     # @return [Object] the value exchanged by the other thread; nil if timed out
     def exchange(value, timeout = nil)
       first = @first.take(timeout)

--- a/lib/concurrent/future.rb
+++ b/lib/concurrent/future.rb
@@ -23,12 +23,12 @@ module Concurrent
     #   global task pool (for short-running tasks)
     # @option opts [object] :executor when provided will run all operations on
     #   this executor rather than the global thread pool (overrides :operation)
-    # @option opts [object, Array] :args zero or more arguments to be passed the task block on execution
-    #
+    # @option opts [object, Array] :args zero or more arguments to be passed the task
+    #   block on execution
     # @option opts [String] :dup_on_deref (false) call `#dup` before returning the data
     # @option opts [String] :freeze_on_deref (false) call `#freeze` before returning the data
-    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing the internal value and
-    #   returning the value returned from the proc
+    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing
+    #   the internal value and returning the value returned from the proc
     #
     # @raise [ArgumentError] if no block is given
     def initialize(opts = {}, &block)
@@ -73,12 +73,13 @@ module Concurrent
     #   global task pool (for short-running tasks)
     # @option opts [object] :executor when provided will run all operations on
     #   this executor rather than the global thread pool (overrides :operation)
-    # @option opts [object, Array] :args zero or more arguments to be passed the task block on execution
+    # @option opts [object, Array] :args zero or more arguments to be passed the
+    #   task block on execution
     #
     # @option opts [String] :dup_on_deref (false) call `#dup` before returning the data
     # @option opts [String] :freeze_on_deref (false) call `#freeze` before returning the data
-    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing the internal value and
-    #   returning the value returned from the proc
+    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing
+    #   the internal value and returning the value returned from the proc
     #
     # @return [Future] the newly created `Future` in the `:pending` state
     #

--- a/lib/concurrent/ivar.rb
+++ b/lib/concurrent/ivar.rb
@@ -6,24 +6,32 @@ require 'concurrent/observable'
 
 module Concurrent
 
-  # An `IVar` is like a future that you can assign. As a future is a value that is being computed that you can wait on, an `IVar` is a value that is waiting to be assigned, that you can wait on. `IVars` are single assignment and deterministic.
+  # An `IVar` is like a future that you can assign. As a future is a value that
+  # is being computed that you can wait on, an `IVar` is a value that is waiting
+  # to be assigned, that you can wait on. `IVars` are single assignment and
+  # deterministic.
   #
-  # Then, express futures as an asynchronous computation that assigns an `IVar`. The `IVar` becomes the primitive on which [futures](Future) and [dataflow](Dataflow) are built.
+  # Then, express futures as an asynchronous computation that assigns an `IVar`.
+  # The `IVar` becomes the primitive on which [futures](Future) and
+  # [dataflow](Dataflow) are built.
   #
   # An `IVar` is a single-element container that is normally created empty, and
-  # can only be set once. The I in `IVar` stands for immutable. Reading an `IVar`
-  # normally blocks until it is set. It is safe to set and read an `IVar` from
-  # different threads.
+  # can only be set once. The I in `IVar` stands for immutable. Reading an
+  # `IVar` normally blocks until it is set. It is safe to set and read an `IVar`
+  # from different threads.
   #
   # If you want to have some parallel task set the value in an `IVar`, you want
-  # a `Future`. If you want to create a graph of parallel tasks all executed when
-  # the values they depend on are ready you want `dataflow`. `IVar` is generally
-  # a low-level primitive.
+  # a `Future`. If you want to create a graph of parallel tasks all executed
+  # when the values they depend on are ready you want `dataflow`. `IVar` is
+  # generally a low-level primitive.
   #
   # **See Also:**
   #
-  # * For the theory: Arvind, R. Nikhil, and K. Pingali. [I-Structures: Data structures for parallel computing](http://dl.acm.org/citation.cfm?id=69562). In Proceedings of Workshop on Graph Reduction, 1986.
-  # * For recent application: [DataDrivenFuture in Habanero Java from Rice](http://www.cs.rice.edu/~vs3/hjlib/doc/edu/rice/hj/api/HjDataDrivenFuture.html).
+  # * For the theory: Arvind, R. Nikhil, and K. Pingali.
+  #     [I-Structures: Data structures for parallel computing](http://dl.acm.org/citation.cfm?id=69562).
+  #     In Proceedings of Workshop on Graph Reduction, 1986.
+  # * For recent application:
+  #     [DataDrivenFuture in Habanero Java from Rice](http://www.cs.rice.edu/~vs3/hjlib/doc/edu/rice/hj/api/HjDataDrivenFuture.html).
   #
   # @example Create, set and get an `IVar`
   #   ivar = Concurrent::IVar.new
@@ -42,10 +50,12 @@ module Concurrent
     #
     # @param [Object] value the initial value
     # @param [Hash] opts the options to create a message with
-    # @option opts [String] :dup_on_deref (false) call `#dup` before returning the data
-    # @option opts [String] :freeze_on_deref (false) call `#freeze` before returning the data
-    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing the internal value and
-    #   returning the value returned from the proc
+    # @option opts [String] :dup_on_deref (false) call `#dup` before returning
+    #   the data
+    # @option opts [String] :freeze_on_deref (false) call `#freeze` before
+    #   returning the data
+    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing
+    #   the internal value and returning the value returned from the proc
     def initialize(value = NO_VALUE, opts = {})
       init_obligation
       self.observers = CopyOnWriteObserverSet.new
@@ -60,13 +70,15 @@ module Concurrent
 
     # Add an observer on this object that will receive notification on update.
     #
-    # Upon completion the `IVar` will notify all observers in a thread-safe way. The `func`
-    # method of the observer will be called with three arguments: the `Time` at which the
-    # `Future` completed the asynchronous operation, the final `value` (or `nil` on rejection),
-    # and the final `reason` (or `nil` on fulfillment).
+    # Upon completion the `IVar` will notify all observers in a thread-safe way.
+    # The `func` method of the observer will be called with three arguments: the
+    # `Time` at which the `Future` completed the asynchronous operation, the
+    # final `value` (or `nil` on rejection), and the final `reason` (or `nil` on
+    # fulfillment).
     #
     # @param [Object] observer the object that will be notified of changes
-    # @param [Symbol] func symbol naming the method to call when this `Observable` has changes`
+    # @param [Symbol] func symbol naming the method to call when this
+    #   `Observable` has changes`
     def add_observer(observer = nil, func = :update, &block)
       raise ArgumentError.new('cannot provide both an observer and a block') if observer && block
       direct_notification = false
@@ -91,7 +103,8 @@ module Concurrent
     # Set the `IVar` to a value and wake or notify all threads waiting on it.
     #
     # @param [Object] value the value to store in the `IVar`
-    # @raise [Concurrent::MultipleAssignmentError] if the `IVar` has already been set or otherwise completed
+    # @raise [Concurrent::MultipleAssignmentError] if the `IVar` has already
+    #   been set or otherwise completed
     def set(value)
       complete(true, value, nil)
     end
@@ -99,7 +112,8 @@ module Concurrent
     # Set the `IVar` to failed due to some error and wake or notify all threads waiting on it.
     #
     # @param [Object] reason for the failure
-    # @raise [Concurrent::MultipleAssignmentError] if the `IVar` has already been set or otherwise completed
+    # @raise [Concurrent::MultipleAssignmentError] if the `IVar` has already
+    #   been set or otherwise completed
     def fail(reason = StandardError.new)
       complete(false, nil, reason)
     end

--- a/lib/concurrent/mvar.rb
+++ b/lib/concurrent/mvar.rb
@@ -4,33 +4,35 @@ require 'concurrent/atomic/event'
 
 module Concurrent
 
-  # An `MVar` is a synchronized single element container. They are empty or contain one item.
-  # Taking a value from an empty `MVar` blocks, as does putting a value into a full one.
-  # You can either think of them as blocking queue of length one, or a special kind of
-  # mutable variable. 
-  # 
-  # On top of the fundamental `#put` and `#take` operations, we also provide a `#mutate`
-  # that is atomic with respect to operations on the same instance. These operations all
-  # support timeouts. 
-  # 
-  # We also support non-blocking operations `#try_put!` and `#try_take!`, a `#set!` that
-  # ignores existing values, a `#value` that returns the value without removing it or
-  # returns `MVar::EMPTY`, and a `#modify!` that yields `MVar::EMPTY` if the `MVar` is
-  # empty and can be used to set `MVar::EMPTY`. You shouldn't use these operations in the
-  # first instance. 
-  # 
+  # An `MVar` is a synchronized single element container. They are empty or
+  # contain one item. Taking a value from an empty `MVar` blocks, as does
+  # putting a value into a full one. You can either think of them as blocking
+  # queue of length one, or a special kind of mutable variable.
+  #
+  # On top of the fundamental `#put` and `#take` operations, we also provide a
+  # `#mutate` that is atomic with respect to operations on the same instance.
+  # These operations all support timeouts.
+  #
+  # We also support non-blocking operations `#try_put!` and `#try_take!`, a
+  # `#set!` that ignores existing values, a `#value` that returns the value
+  # without removing it or returns `MVar::EMPTY`, and a `#modify!` that yields
+  # `MVar::EMPTY` if the `MVar` is empty and can be used to set `MVar::EMPTY`.
+  # You shouldn't use these operations in the first instance.
+  #
   # `MVar` is a [Dereferenceable](Dereferenceable).
-  # 
+  #
   # `MVar` is related to M-structures in Id, `MVar` in Haskell and `SyncVar` in Scala.
   #
   # Note that unlike the original Haskell paper, our `#take` is blocking. This is how
   # Haskell and Scala do it today.
-  # 
+  #
   # **See Also:**
-  # 
-  # 1. P. Barth, R. Nikhil, and Arvind. [M-Structures: Extending a parallel, non-
-  # strict, functional language with state](http://dl.acm.org/citation.cfm?id=652538). In Proceedings of the 5th ACM Conference on Functional Programming Languages and Computer Architecture (FPCA), 1991.
-  # 2. S. Peyton Jones, A. Gordon, and S. Finne. [Concurrent Haskell](http://dl.acm.org/citation.cfm?id=237794). In Proceedings of the 23rd Symposium on Principles of Programming Languages (PoPL), 1996.
+  #
+  # 1. P. Barth, R. Nikhil, and Arvind. [M-Structures: Extending a parallel, non- strict, functional language with state](http://dl.acm.org/citation.cfm?id=652538). In Proceedings of the 5th
+  # ACM Conference on Functional Programming Languages and Computer Architecture (FPCA), 1991.
+  # 2. S. Peyton Jones, A. Gordon, and S. Finne. [Concurrent Haskell](http://dl.acm.org/citation.cfm?id=237794).
+  # In Proceedings of the 23rd Symposium on Principles of Programming Languages
+  # (PoPL), 1996.
   class MVar
 
     include Dereferenceable
@@ -45,15 +47,17 @@ module Concurrent
     # Create a new `MVar`, either empty or with an initial value.
     #
     # @param [Hash] opts the options controlling how the future will be processed
-    # @option opts [Boolean] :operation (false) when `true` will execute the future on the global
-    #   operation pool (for long-running operations), when `false` will execute the future on the
-    #   global task pool (for short-running tasks)
+    # @option opts [Boolean] :operation (false) when `true` will execute the
+    #   future on the global operation pool (for long-running operations), when
+    #   `false` will execute the future on the global task pool (for
+    #   short-running tasks)
     # @option opts [object] :executor when provided will run all operations on
     #   this executor rather than the global thread pool (overrides :operation)
     # @option opts [String] :dup_on_deref (false) call `#dup` before returning the data
-    # @option opts [String] :freeze_on_deref (false) call `#freeze` before returning the data
-    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing the internal value and
-    #   returning the value returned from the proc
+    # @option opts [String] :freeze_on_deref (false) call `#freeze` before
+    #   returning the data
+    # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing
+    #   the internal value and returning the value returned from the proc
     def initialize(value = EMPTY, opts = {})
       @value = value
       @mutex = Mutex.new

--- a/lib/concurrent/observable.rb
+++ b/lib/concurrent/observable.rb
@@ -3,39 +3,49 @@ require 'concurrent/atomic/copy_on_write_observer_set'
 
 module Concurrent
 
-  # The [observer pattern](http://en.wikipedia.org/wiki/Observer_pattern) is one of the most useful design pattern.
-  # 
+  # The [observer pattern](http://en.wikipedia.org/wiki/Observer_pattern) is one
+  # of the most useful design patterns.
+  #
   # The workflow is very simple:
   # - an `observer` can register itself to a `subject` via a callback
   # - many `observers` can be registered to the same `subject`
   # - the `subject` notifies all registered observers when its status changes
-  # - an `observer` can deregister itself when is no more interested to receive event notifications
-  # 
-  # In a single threaded environment the whole pattern is very easy: the `subject` can use a simple data structure to manage all its subscribed `observer`s and every `observer` can react directly to every event without caring about synchronization.
-  # 
-  # In a multi threaded environment things are more complex.
-  # The `subject` must synchronize the access to its data structure and to do so currently we're using two specialized ObserverSet: CopyOnWriteObserverSet and CopyOnNotifyObserverSet.
-  # 
-  # When implementing and `observer` there's a very important rule to remember: **there are no guarantees about the thread that will execute the callback**
-  # 
+  # - an `observer` can deregister itself when is no more interested to receive
+  #     event notifications
+  #
+  # In a single threaded environment the whole pattern is very easy: the
+  # `subject` can use a simple data structure to manage all its subscribed
+  # `observer`s and every `observer` can react directly to every event without
+  # caring about synchronization.
+  #
+  # In a multi threaded environment things are more complex. The `subject` must
+  # synchronize the access to its data structure and to do so currently we're
+  # using two specialized ObserverSet: CopyOnWriteObserverSet and
+  # CopyOnNotifyObserverSet.
+  #
+  # When implementing and `observer` there's a very important rule to remember:
+  # **there are no guarantees about the thread that will execute the callback**
+  #
   # Let's take this example
   # ```
   # class Observer
   #   def initialize
   #     @count = 0
   #   end
-  # 
+  #
   #   def update
   #     @count += 1
   #   end
   # end
-  # 
+  #
   # obs = Observer.new
   # [obj1, obj2, obj3, obj4].each { |o| o.add_observer(obs) }
   # # execute [obj1, obj2, obj3, obj4]
   # ```
-  # 
-  # `obs` is wrong because the variable `@count` can be accessed by different threads at the same time, so it should be synchronized (using either a Mutex or an AtomicFixum)
+  #
+  # `obs` is wrong because the variable `@count` can be accessed by different
+  # threads at the same time, so it should be synchronized (using either a Mutex
+  # or an AtomicFixum)
   module Observable
 
     # @return [Object] the added observer

--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -9,160 +9,175 @@ module Concurrent
 
   # Promises are inspired by the JavaScript [Promises/A](http://wiki.commonjs.org/wiki/Promises/A)
   # and [Promises/A+](http://promises-aplus.github.io/promises-spec/) specifications.
-  # 
-  # > A promise represents the eventual value returned from the single completion of an operation.
-  # 
-  # Promises are similar to futures and share many of the same behaviours. Promises are far more
-  # robust, however. Promises can be chained in a tree structure where each promise may have zero
-  # or more children. Promises are chained using the `then` method. The result of a call to `then`
-  # is always another promise. Promises are resolved asynchronously (with respect to the main thread)
-  # but in a strict order: parents are guaranteed to be resolved before their children, children
-  # before their younger siblings. The `then` method takes two parameters: an optional block to
-  # be executed upon parent resolution and an optional callable to be executed upon parent failure.
-  # The result of each promise is passed to each of its children upon resolution. When a promise
-  # is rejected all its children will be summarily rejected and will receive the reason. 
-  # 
-  # Promises have four possible states: *unscheduled*, *pending*, *rejected*, and *fulfilled*. A
-  # Promise created using `.new` will be *unscheduled*. It is scheduled by calling the `execute`
-  # method. Upon execution the Promise and all its children will be set to *pending*. When a promise
-  # is *pending* it will remain in that state until processing is complete. A completed Promise is
-  # either *rejected*, indicating that an exception was thrown during processing, or *fulfilled*,
-  # indicating it succeeded. If a Promise is *fulfilled* its `value` will be updated to reflect
-  # the result of the operation. If *rejected* the `reason` will be updated with a reference to
-  # the thrown exception. The predicate methods `unscheduled?`, `pending?`, `rejected?`, and
-  # `fulfilled?` can be called at any time to obtain the state of the Promise, as can the `state`
-  # method, which returns a symbol. A Promise created using `.execute` will be *pending*, a Promise
-  # created using `.fulfill(value)` will be *fulfilled* with the given value and a Promise created
-  # using `.reject(reason)` will be *rejected* with the given reason. 
-  # 
-  # Retrieving the value of a promise is done through the `value` (alias: `deref`) method. Obtaining
-  # the value of a promise is a potentially blocking operation. When a promise is *rejected* a call
-  # to `value` will return `nil` immediately. When a promise is *fulfilled* a call to `value` will
-  # immediately return the current value. When a promise is *pending* a call to `value` will block
-  # until the promise is either *rejected* or *fulfilled*. A *timeout* value can be passed to `value`
-  # to limit how long the call will block. If `nil` the call will block indefinitely. If `0` the call
-  # will not block. Any other integer or float value will indicate the maximum number of seconds to block. 
-  # 
+  #
+  # > A promise represents the eventual value returned from the single
+  # > completion of an operation.
+  #
+  # Promises are similar to futures and share many of the same behaviours.
+  # Promises are far more robust, however. Promises can be chained in a tree
+  # structure where each promise may have zero or more children. Promises are
+  # chained using the `then` method. The result of a call to `then` is always
+  # another promise. Promises are resolved asynchronously (with respect to the
+  # main thread) but in a strict order: parents are guaranteed to be resolved
+  # before their children, children before their younger siblings. The `then`
+  # method takes two parameters: an optional block to be executed upon parent
+  # resolution and an optional callable to be executed upon parent failure. The
+  # result of each promise is passed to each of its children upon resolution.
+  # When a promise is rejected all its children will be summarily rejected and
+  # will receive the reason.
+  #
+  # Promises have four possible states: *unscheduled*, *pending*, *rejected*,
+  # and *fulfilled*. A Promise created using `.new` will be *unscheduled*. It is
+  # scheduled by calling the `execute` method. Upon execution the Promise and
+  # all its children will be set to *pending*. When a promise is *pending* it
+  # will remain in that state until processing is complete. A completed Promise
+  # is either *rejected*, indicating that an exception was thrown during
+  # processing, or *fulfilled*, indicating it succeeded. If a Promise is
+  # *fulfilled* its `value` will be updated to reflect the result of the
+  # operation. If *rejected* the `reason` will be updated with a reference to
+  # the thrown exception. The predicate methods `unscheduled?`, `pending?`,
+  # `rejected?`, and `fulfilled?` can be called at any time to obtain the state
+  # of the Promise, as can the `state` method, which returns a symbol. A Promise
+  # created using `.execute` will be *pending*, a Promise created using
+  # `.fulfill(value)` will be *fulfilled* with the given value and a Promise
+  # created using `.reject(reason)` will be *rejected* with the given reason.
+  #
+  # Retrieving the value of a promise is done through the `value` (alias:
+  # `deref`) method. Obtaining the value of a promise is a potentially blocking
+  # operation. When a promise is *rejected* a call to `value` will return `nil`
+  # immediately. When a promise is *fulfilled* a call to `value` will
+  # immediately return the current value. When a promise is *pending* a call to
+  # `value` will block until the promise is either *rejected* or *fulfilled*. A
+  # *timeout* value can be passed to `value` to limit how long the call will
+  # block. If `nil` the call will block indefinitely. If `0` the call will not
+  # block. Any other integer or float value will indicate the maximum number of
+  # seconds to block.
+  #
   # Promises run on the global thread pool.
-  # 
+  #
   # ### Examples
-  # 
+  #
   # Start by requiring promises
-  # 
+  #
   # ```ruby
   # require 'concurrent'
   # ```
-  # 
+  #
   # Then create one
-  # 
+  #
   # ```ruby
   # p = Concurrent::Promise.execute do
   #       # do something
   #       42
   #     end
   # ```
-  # 
-  # Promises can be chained using the `then` method. The `then` method accepts a block, to be executed
-  # on fulfillment, and a callable argument to be executed on rejection. The result of the each promise
-  # is passed as the block argument to chained promises. 
-  # 
+  #
+  # Promises can be chained using the `then` method. The `then` method accepts a
+  # block, to be executed on fulfillment, and a callable argument to be executed
+  # on rejection. The result of the each promise is passed as the block argument
+  # to chained promises.
+  #
   # ```ruby
   # p = Concurrent::Promise.new{10}.then{|x| x * 2}.then{|result| result - 10 }.execute
   # ```
-  # 
+  #
   # And so on, and so on, and so on...
-  # 
+  #
   # ```ruby
   # p = Concurrent::Promise.fulfill(20).
   #     then{|result| result - 10 }.
   #     then{|result| result * 3 }.
   #     then{|result| result % 5 }.execute
   # ```
-  # 
+  #
   # The initial state of a newly created Promise depends on the state of its parent:
   # - if parent is *unscheduled* the child will be *unscheduled*
   # - if parent is *pending* the child will be *pending*
   # - if parent is *fulfilled* the child will be *pending*
   # - if parent is *rejected* the child will be *pending* (but will ultimately be *rejected*)
-  # 
-  # Promises are executed asynchronously from the main thread. By the time a child Promise finishes 
-  # nitialization it may be in a different state that its parent (by the time a child is created its parent
-  # may have completed execution and changed state). Despite being asynchronous, however, the order of
-  # execution of Promise objects in a chain (or tree) is strictly defined. 
-  # 
-  # There are multiple ways to create and execute a new `Promise`. Both ways provide identical behavior:
-  # 
+  #
+  # Promises are executed asynchronously from the main thread. By the time a
+  # child Promise finishes nitialization it may be in a different state that its
+  # parent (by the time a child is created its parent may have completed
+  # execution and changed state). Despite being asynchronous, however, the order
+  # of execution of Promise objects in a chain (or tree) is strictly defined.
+  #
+  # There are multiple ways to create and execute a new `Promise`. Both ways
+  # provide identical behavior:
+  #
   # ```ruby
   # # create, operate, then execute
   # p1 = Concurrent::Promise.new{ "Hello World!" }
   # p1.state #=> :unscheduled
   # p1.execute
-  # 
+  #
   # # create and immediately execute
   # p2 = Concurrent::Promise.new{ "Hello World!" }.execute
-  # 
+  #
   # # execute during creation
   # p3 = Concurrent::Promise.execute{ "Hello World!" }
   # ```
-  # 
+  #
   # Once the `execute` method is called a `Promise` becomes `pending`:
-  # 
+  #
   # ```ruby
   # p = Concurrent::Promise.execute{ "Hello, world!" }
   # p.state    #=> :pending
   # p.pending? #=> true
   # ```
-  # 
+  #
   # Wait a little bit, and the promise will resolve and provide a value:
-  # 
+  #
   # ```ruby
   # p = Concurrent::Promise.execute{ "Hello, world!" }
   # sleep(0.1)
-  # 
+  #
   # p.state      #=> :fulfilled
   # p.fulfilled? #=> true
   # p.value      #=> "Hello, world!"
   # ```
-  # 
+  #
   # If an exception occurs, the promise will be rejected and will provide
   # a reason for the rejection:
-  # 
+  #
   # ```ruby
   # p = Concurrent::Promise.execute{ raise StandardError.new("Here comes the Boom!") }
   # sleep(0.1)
-  # 
+  #
   # p.state     #=> :rejected
   # p.rejected? #=> true
   # p.reason    #=> "#<StandardError: Here comes the Boom!>"
   # ```
-  # 
+  #
   # #### Rejection
-  # 
-  # When a promise is rejected all its children will be rejected and will receive the rejection `reason`
-  # as the rejection callable parameter:
-  # 
+  #
+  # When a promise is rejected all its children will be rejected and will
+  # receive the rejection `reason` as the rejection callable parameter:
+  #
   # ```ruby
   # p = [ Concurrent::Promise.execute{ Thread.pass; raise StandardError } ]
-  # 
+  #
   # c1 = p.then(Proc.new{ |reason| 42 })
   # c2 = p.then(Proc.new{ |reason| raise 'Boom!' })
-  # 
+  #
   # sleep(0.1)
-  # 
+  #
   # c1.state  #=> :rejected
   # c2.state  #=> :rejected
   # ```
-  # 
-  # Once a promise is rejected it will continue to accept children that will receive immediately rejection
-  # (they will be executed asynchronously).
-  # 
+  #
+  # Once a promise is rejected it will continue to accept children that will
+  # receive immediately rejection (they will be executed asynchronously).
+  #
   # #### Aliases
-  # 
-  # The `then` method is the most generic alias: it accepts a block to be executed upon parent fulfillment
-  # and a callable to be executed upon parent rejection. At least one of them should be passed. The default
-  # block is `{ |result| result }` that fulfills the child with the parent value. The default callable is
-  # `{ |reason| raise reason }` that rejects the child with the parent reason. 
-  # 
+  #
+  # The `then` method is the most generic alias: it accepts a block to be
+  # executed upon parent fulfillment and a callable to be executed upon parent
+  # rejection. At least one of them should be passed. The default block is `{
+  # |result| result }` that fulfills the child with the parent value. The
+  # default callable is `{ |reason| raise reason }` that rejects the child with
+  # the parent reason.
+  #
   # - `on_success { |result| ... }` is the same as `then {|result| ... }`
   # - `rescue { |reason| ... }` is the same as `then(Proc.new { |reason| ... } )`
   # - `rescue` is aliased by `catch` and `on_error`
@@ -179,18 +194,19 @@ module Concurrent
     #   @option opts [Promise] :parent the parent `Promise` when building a chain/tree
     #   @option opts [Proc] :on_fulfill fulfillment handler
     #   @option opts [Proc] :on_reject rejection handler
-    #
-    #   @option opts [Boolean] :operation (false) when `true` will execute the future on the global
-    #     operation pool (for long-running operations), when `false` will execute the future on the
-    #     global task pool (for short-running tasks)
+    #   @option opts [Boolean] :operation (false) when `true` will execute the
+    #     future on the global operation pool (for long-running operations),
+    #     when `false` will execute the future on the global task pool (for
+    #     short-running tasks)
     #   @option opts [object] :executor when provided will run all operations on
     #     this executor rather than the global thread pool (overrides :operation)
-    #   @option opts [object, Array] :args zero or more arguments to be passed the task block on execution
-    #
+    #   @option opts [object, Array] :args zero or more arguments to be passed
+    #    the task block on execution
     #   @option opts [String] :dup_on_deref (false) call `#dup` before returning the data
-    #   @option opts [String] :freeze_on_deref (false) call `#freeze` before returning the data
-    #   @option opts [String] :copy_on_deref (nil) call the given `Proc` passing the internal value and
-    #     returning the value returned from the proc
+    #   @option opts [String] :freeze_on_deref (false) call `#freeze` before
+    #     returning the data
+    #   @option opts [String] :copy_on_deref (nil) call the given `Proc` passing
+    #     the internal value and returning the value returned from the proc
     #
     # @see http://wiki.commonjs.org/wiki/Promises/A
     # @see http://promises-aplus.github.io/promises-spec/

--- a/lib/concurrent/tvar.rb
+++ b/lib/concurrent/tvar.rb
@@ -57,28 +57,31 @@ module Concurrent
   end
 
   # Run a block that reads and writes `TVar`s as a single atomic transaction.
-  # With respect to the value of `TVar` objects, the transaction is atomic,
-  # in that it either happens or it does not, consistent, in that the `TVar`
+  # With respect to the value of `TVar` objects, the transaction is atomic, in
+  # that it either happens or it does not, consistent, in that the `TVar`
   # objects involved will never enter an illegal state, and isolated, in that
   # transactions never interfere with each other. You may recognise these
   # properties from database transactions.
-  # 
+  #
   # There are some very important and unusual semantics that you must be aware of:
-  # 
-  # *   Most importantly, the block that you pass to atomically may be executed more than once. In most cases your code should be free of side-effects, except for via TVar.
-  # 
-  # *   If an exception escapes an atomically block it will abort the transaction.
-  # 
-  # *   It is undefined behaviour to use callcc or Fiber with atomically.
-  # 
-  # *   If you create a new thread within an atomically, it will not be part of the transaction. Creating a thread counts as a side-effect.
-  # 
+  #
+  # * Most importantly, the block that you pass to atomically may be executed
+  #     more than once. In most cases your code should be free of
+  #     side-effects, except for via TVar.
+  #
+  # * If an exception escapes an atomically block it will abort the transaction.
+  #
+  # * It is undefined behaviour to use callcc or Fiber with atomically.
+  #
+  # * If you create a new thread within an atomically, it will not be part of
+  #     the transaction. Creating a thread counts as a side-effect.
+  #
   # Transactions within transactions are flattened to a single transaction.
-  # 
+  #
   # @example
   #   a = new TVar(100_000)
   #   b = new TVar(100)
-  #   
+  #
   #   Concurrent::atomically do
   #     a.value -= 10
   #     b.value += 10

--- a/lib/concurrent/utility/processor_count.rb
+++ b/lib/concurrent/utility/processor_count.rb
@@ -11,18 +11,21 @@ module Concurrent
       @physical_processor_count = Delay.new(executor: immediate_executor) { compute_physical_processor_count }
     end
 
-    # Number of processors seen by the OS and used for process scheduling. For performance
-    # reasons the calculated value will be memoized on the first call.
+    # Number of processors seen by the OS and used for process scheduling. For
+    # performance reasons the calculated value will be memoized on the first
+    # call.
     #
-    # When running under JRuby the Java runtime call `java.lang.Runtime.getRuntime.availableProcessors`
-    # will be used. According to the Java documentation this "value may change
-    # during a particular invocation of the virtual machine... [applications]
-    # should therefore occasionally poll this property." Subsequently the result
-    # will NOT be memoized under JRuby.
+    # When running under JRuby the Java runtime call
+    # `java.lang.Runtime.getRuntime.availableProcessors` will be used. According
+    # to the Java documentation this "value may change during a particular
+    # invocation of the virtual machine... [applications] should therefore
+    # occasionally poll this property." Subsequently the result will NOT be
+    # memoized under JRuby.
     #
-    # On Windows the Win32 API will be queried for the `NumberOfLogicalProcessors from Win32_Processor`.
-    # This will return the total number "logical processors for the current instance of the processor",
-    # which taked into account hyperthreading.
+    # On Windows the Win32 API will be queried for the
+    # `NumberOfLogicalProcessors from Win32_Processor`. This will return the
+    # total number "logical processors for the current instance of the
+    # processor", which taked into account hyperthreading.
     #
     # * AIX: /usr/sbin/pmcycles (AIX 5+), /usr/sbin/lsdev
     # * BSD: /sbin/sysctl
@@ -46,14 +49,15 @@ module Concurrent
       @processor_count.value
     end
 
-    # Number of physical processor cores on the current system. For performance reasons
-    # the calculated value will be memoized on the first call.
+    # Number of physical processor cores on the current system. For performance
+    # reasons the calculated value will be memoized on the first call.
     #
-    # On Windows the Win32 API will be queried for the `NumberOfCores from Win32_Processor`.
-    # This will return the total number "of cores for the current instance of the processor."
-    # On Unix-like operating systems either the `hwprefs` or `sysctl` utility will be called
-    # in a subshell and the returned value will be used. In the rare case where none of these
-    # methods work or an exception is raised the function will simply return 1.
+    # On Windows the Win32 API will be queried for the `NumberOfCores from
+    # Win32_Processor`. This will return the total number "of cores for the
+    # current instance of the processor." On Unix-like operating systems either
+    # the `hwprefs` or `sysctl` utility will be called in a subshell and the
+    # returned value will be used. In the rare case where none of these methods
+    # work or an exception is raised the function will simply return 1.
     #
     # @return [Integer] number physical processor cores on the current system
     #

--- a/spec/concurrent/actor_spec.rb
+++ b/spec/concurrent/actor_spec.rb
@@ -251,7 +251,8 @@ module Concurrent
       it 'links' do
         queue   = Queue.new
         failure = nil
-        # failure = AdHoc.spawn(:failure) { -> m { terminate! } } # FIXME this leads to weird message processing ordering
+        # FIXME this leads to weird message processing ordering
+        # failure = AdHoc.spawn(:failure) { -> m { terminate! } }
         monitor = AdHoc.spawn!(:monitor) do
           failure = AdHoc.spawn(:failure) { -> m { m } }
           failure << :link

--- a/spec/concurrent/atomic/thread_local_var_spec.rb
+++ b/spec/concurrent/atomic/thread_local_var_spec.rb
@@ -58,7 +58,8 @@ module Concurrent
             var = ThreadLocalVar.new(0)
             5.times.map { |i| Thread.new { var.value = i; var.value } }.each(&:join)
             var.value = 0
-            # TODO find out why long sleep is necessary, does it take longer for threads to be collected?
+            # TODO: find out why long sleep is necessary, does it take longer for
+            #   threads to be collected?
             sleep 0.1 * 2**i
             GC.start
 


### PR DESCRIPTION
I have changed the documentation comments not to use more than 100 columns.
I used [rubocop](https://github.com/bbatsov/rubocop) to help me find lines in the project with more than 100 columns. 

I actually would rather use 80 columns, but the number of rubocop offenses due to code lines and not comment ones were too much.

I have mostly used Emacs' `fill-region-as-paragraph` to reformat the comments, with `fill-column` set to 80.