### PR TITLE
Fix ScheduledTask sometimes not accepting an interval of 0

### DIFF
--- a/lib/concurrent/scheduled_task.rb
+++ b/lib/concurrent/scheduled_task.rb
@@ -25,8 +25,9 @@ module Concurrent
     # @since 0.5.0
     def execute
       if compare_and_set_state(:pending, :unscheduled)
-        @schedule_time = TimerSet.calculate_schedule_time(@intended_time)
-        Concurrent::timer(@schedule_time.to_f - Time.now.to_f) { @executor.post(&method(:process_task)) }
+        now = Time.now
+        @schedule_time = TimerSet.calculate_schedule_time(@intended_time, now)
+        Concurrent::timer(@schedule_time.to_f - now.to_f) { @executor.post(&method(:process_task)) }
         self
       end
     end

--- a/spec/concurrent/scheduled_task_spec.rb
+++ b/spec/concurrent/scheduled_task_spec.rb
@@ -130,6 +130,10 @@ module Concurrent
         end
       end
 
+      it 'allows setting the execution interval to 0' do
+        expect { 1000.times { ScheduledTask.execute(0) { } } }.not_to raise_error
+      end
+
       it 'sets the sate to :pending' do
         task = ScheduledTask.new(1){ nil }
         task.execute


### PR DESCRIPTION
ScheduledTask measured `Time.now` in 2 places with some computation in
between and it sometimes arrived at an inconsistent result.

Sorry for the ugly spec - this is basically the way I reproduced it and I didn't want to bind too much to the implementation by stubbing out `TimerSet.calculate_schedule_time` with a sleep.

Also - it only happened on jruby for me - maybe the clock is more accurate?