### PR TITLE
Remove unnecessary `require 'spec_helper'`

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--format progress

--- a/spec/concurrent/actor_spec.rb
+++ b/spec/concurrent/actor_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'concurrent/actor'
 
 module Concurrent

--- a/spec/concurrent/agent_spec.rb
+++ b/spec/concurrent/agent_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'dereferenceable_shared'
 require_relative 'observable_shared'
 

--- a/spec/concurrent/async_spec.rb
+++ b/spec/concurrent/async_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe Async do

--- a/spec/concurrent/atomic/atomic_boolean_spec.rb
+++ b/spec/concurrent/atomic/atomic_boolean_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 shared_examples :atomic_boolean do
 
   describe 'construction' do

--- a/spec/concurrent/atomic/atomic_fixnum_spec.rb
+++ b/spec/concurrent/atomic/atomic_fixnum_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 shared_examples :atomic_fixnum do
 
   context 'construction' do

--- a/spec/concurrent/atomic/condition_spec.rb
+++ b/spec/concurrent/atomic/condition_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe Condition do

--- a/spec/concurrent/atomic/copy_on_notify_observer_set_spec.rb
+++ b/spec/concurrent/atomic/copy_on_notify_observer_set_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'observer_set_shared'
 
 module Concurrent

--- a/spec/concurrent/atomic/copy_on_write_observer_set_spec.rb
+++ b/spec/concurrent/atomic/copy_on_write_observer_set_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'observer_set_shared'
 
 module Concurrent

--- a/spec/concurrent/atomic/count_down_latch_spec.rb
+++ b/spec/concurrent/atomic/count_down_latch_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 shared_examples :count_down_latch do
 
   let(:latch) { described_class.new(3) }

--- a/spec/concurrent/atomic/cyclic_barrier_spec.rb
+++ b/spec/concurrent/atomic/cyclic_barrier_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe CyclicBarrier do

--- a/spec/concurrent/atomic/event_spec.rb
+++ b/spec/concurrent/atomic/event_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe Event do

--- a/spec/concurrent/atomic/observer_set_shared.rb
+++ b/spec/concurrent/atomic/observer_set_shared.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 shared_examples "an observer set" do
 
   let (:observer_set) { described_class.new }

--- a/spec/concurrent/atomic/semaphore_spec.rb
+++ b/spec/concurrent/atomic/semaphore_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 shared_examples :semaphore do
   let(:semaphore) { described_class.new(3) }
 

--- a/spec/concurrent/atomic/thread_local_var_spec.rb
+++ b/spec/concurrent/atomic/thread_local_var_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'rbconfig'
 
 module Concurrent

--- a/spec/concurrent/atomic_spec.rb
+++ b/spec/concurrent/atomic_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 shared_examples :atomic do
 
   specify :test_construct do

--- a/spec/concurrent/channel/buffered_channel_spec.rb
+++ b/spec/concurrent/channel/buffered_channel_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe BufferedChannel do

--- a/spec/concurrent/channel/channel_spec.rb
+++ b/spec/concurrent/channel/channel_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe Channel do

--- a/spec/concurrent/channel/probe_spec.rb
+++ b/spec/concurrent/channel/probe_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative '../observable_shared'
 
 module Concurrent
@@ -11,9 +10,9 @@ module Concurrent
     describe 'behavior' do
 
       # observable
-      
+
       subject{ Channel::Probe.new }
-      
+
       def trigger_observable(observable)
         observable.set('value')
       end

--- a/spec/concurrent/channel/unbuffered_channel_spec.rb
+++ b/spec/concurrent/channel/unbuffered_channel_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe UnbufferedChannel do

--- a/spec/concurrent/collection/blocking_ring_buffer_spec.rb
+++ b/spec/concurrent/collection/blocking_ring_buffer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe BlockingRingBuffer do

--- a/spec/concurrent/collection/priority_queue_spec.rb
+++ b/spec/concurrent/collection/priority_queue_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 shared_examples :priority_queue do
 
   subject{ described_class.new }

--- a/spec/concurrent/collection/ring_buffer_spec.rb
+++ b/spec/concurrent/collection/ring_buffer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe RingBuffer do

--- a/spec/concurrent/configuration_spec.rb
+++ b/spec/concurrent/configuration_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe Configuration do

--- a/spec/concurrent/dataflow_spec.rb
+++ b/spec/concurrent/dataflow_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe 'dataflow' do
@@ -233,7 +231,7 @@ module Concurrent
         sleep(0.1)
         expect(expected.value).to eq 13
       end
-      
+
     end
   end
 end

--- a/spec/concurrent/delay_spec.rb
+++ b/spec/concurrent/delay_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'dereferenceable_shared'
 require_relative 'obligation_shared'
 

--- a/spec/concurrent/dereferenceable_shared.rb
+++ b/spec/concurrent/dereferenceable_shared.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 shared_examples :dereferenceable do
 
   it 'defaults :dup_on_deref to false' do

--- a/spec/concurrent/exchanger_spec.rb
+++ b/spec/concurrent/exchanger_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe Exchanger do

--- a/spec/concurrent/executor/cached_thread_pool_shared.rb
+++ b/spec/concurrent/executor/cached_thread_pool_shared.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'thread_pool_shared'
 
 shared_examples :cached_thread_pool do

--- a/spec/concurrent/executor/executor_service_shared.rb
+++ b/spec/concurrent/executor/executor_service_shared.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'global_thread_pool_shared'
 
 shared_examples :executor_service do

--- a/spec/concurrent/executor/fixed_thread_pool_shared.rb
+++ b/spec/concurrent/executor/fixed_thread_pool_shared.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'thread_pool_shared'
 require 'thread'
 

--- a/spec/concurrent/executor/global_thread_pool_shared.rb
+++ b/spec/concurrent/executor/global_thread_pool_shared.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 shared_examples :global_thread_pool do
 
   context '#post' do

--- a/spec/concurrent/executor/immediate_executor_spec.rb
+++ b/spec/concurrent/executor/immediate_executor_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'executor_service_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/indirect_immediate_executor_spec.rb
+++ b/spec/concurrent/executor/indirect_immediate_executor_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'executor_service_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/java_cached_thread_pool_spec.rb
+++ b/spec/concurrent/executor/java_cached_thread_pool_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 if Concurrent::TestHelpers.jruby?
 
   require_relative 'cached_thread_pool_shared'

--- a/spec/concurrent/executor/java_fixed_thread_pool_spec.rb
+++ b/spec/concurrent/executor/java_fixed_thread_pool_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 if Concurrent::TestHelpers.jruby?
 
   require_relative 'fixed_thread_pool_shared'

--- a/spec/concurrent/executor/java_single_thread_executor_spec.rb
+++ b/spec/concurrent/executor/java_single_thread_executor_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 if Concurrent::TestHelpers.jruby?
 
   require_relative 'executor_service_shared'

--- a/spec/concurrent/executor/java_thread_pool_executor_spec.rb
+++ b/spec/concurrent/executor/java_thread_pool_executor_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 if Concurrent::TestHelpers.jruby?
 
   require_relative 'thread_pool_executor_shared'

--- a/spec/concurrent/executor/per_thread_executor_spec.rb
+++ b/spec/concurrent/executor/per_thread_executor_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'executor_service_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/ruby_cached_thread_pool_spec.rb
+++ b/spec/concurrent/executor/ruby_cached_thread_pool_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'cached_thread_pool_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/ruby_fixed_thread_pool_spec.rb
+++ b/spec/concurrent/executor/ruby_fixed_thread_pool_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'fixed_thread_pool_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/ruby_single_thread_executor_spec.rb
+++ b/spec/concurrent/executor/ruby_single_thread_executor_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'executor_service_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/ruby_thread_pool_executor_spec.rb
+++ b/spec/concurrent/executor/ruby_thread_pool_executor_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'thread_pool_executor_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/safe_task_executor_spec.rb
+++ b/spec/concurrent/executor/safe_task_executor_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe SafeTaskExecutor do

--- a/spec/concurrent/executor/serialized_execution_spec.rb
+++ b/spec/concurrent/executor/serialized_execution_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'executor_service_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/thread_pool_class_cast_spec.rb
+++ b/spec/concurrent/executor/thread_pool_class_cast_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe SingleThreadExecutor do

--- a/spec/concurrent/executor/thread_pool_executor_shared.rb
+++ b/spec/concurrent/executor/thread_pool_executor_shared.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'thread_pool_shared'
 
 shared_examples :thread_pool_executor do
@@ -174,7 +173,7 @@ shared_examples :thread_pool_executor do
       expect(subject.remaining_capacity).to eq expected_max
     end
   end
-  
+
   context '#fallback_policy' do
 
     let!(:min_threads){ 1 }
@@ -230,7 +229,7 @@ shared_examples :thread_pool_executor do
         all_tasks_posted = Concurrent::Event.new
 
         latch = Concurrent::CountDownLatch.new(max_threads)
-        
+
         initial_executed = Concurrent::AtomicFixnum.new(0)
         subsequent_executed = Concurrent::AtomicFixnum.new(0)
 
@@ -243,7 +242,7 @@ shared_examples :thread_pool_executor do
         # Wait for all those tasks to be taken off the queue onto a
         # worker thread and start executing
         latch.wait
-        
+
         # Fill up the queue (with a task that won't complete until
         # all tasks are posted)
         max_queue.times do
@@ -277,7 +276,7 @@ shared_examples :thread_pool_executor do
         all_tasks_posted = Concurrent::Event.new
 
         latch = Concurrent::CountDownLatch.new(max_threads)
-        
+
         initial_executed = Concurrent::AtomicFixnum.new(0)
         subsequent_executed = Concurrent::AtomicFixnum.new(0)
 
@@ -290,7 +289,7 @@ shared_examples :thread_pool_executor do
         # Wait for all those tasks to be taken off the queue onto a
         # worker thread and start executing
         latch.wait
-        
+
         # Fill up the queue (with a task that won't complete until
         # all tasks are posted)
         max_queue.times do
@@ -320,7 +319,7 @@ shared_examples :thread_pool_executor do
         expect(subsequent_executed.value).to be 0
       end
     end
-    
+
     context ':discard' do
 
       subject do
@@ -337,7 +336,7 @@ shared_examples :thread_pool_executor do
         all_tasks_posted = Concurrent::Event.new
 
         latch = Concurrent::CountDownLatch.new(max_threads)
-        
+
         initial_executed = Concurrent::AtomicFixnum.new(0)
         subsequent_executed = Concurrent::AtomicFixnum.new(0)
 
@@ -350,7 +349,7 @@ shared_examples :thread_pool_executor do
         # Wait for all those tasks to be taken off the queue onto a
         # worker thread and start executing
         latch.wait
-        
+
         # Fill up the queue (with a task that won't complete until
         # all tasks are posted)
         max_queue.times do
@@ -382,7 +381,7 @@ shared_examples :thread_pool_executor do
         all_tasks_posted = Concurrent::Event.new
 
         latch = Concurrent::CountDownLatch.new(max_threads)
-        
+
         initial_executed = Concurrent::AtomicFixnum.new(0)
         subsequent_executed = Concurrent::AtomicFixnum.new(0)
 
@@ -395,7 +394,7 @@ shared_examples :thread_pool_executor do
         # Wait for all those tasks to be taken off the queue onto a
         # worker thread and start executing
         latch.wait
-        
+
         # Fill up the queue (with a task that won't complete until
         # all tasks are posted)
         max_queue.times do
@@ -475,7 +474,7 @@ shared_examples :thread_pool_executor do
         Thread.new do
           5.times{ subject.post{ trigger.wait } }
         end
-        
+
         expect(Thread.list.length).to be < initial + 1 + 5
 
         # Let the executor tasks complete.

--- a/spec/concurrent/executor/thread_pool_shared.rb
+++ b/spec/concurrent/executor/thread_pool_shared.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'executor_service_shared'
 
 shared_examples :thread_pool do

--- a/spec/concurrent/executor/timer_set_spec.rb
+++ b/spec/concurrent/executor/timer_set_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe TimerSet do
@@ -114,7 +112,7 @@ module Concurrent
         subject.post(interval * i) { expected << Time.now - start; latch.count_down }
       end
 
-      expect(latch.wait((tests * interval) + 1)).to be true 
+      expect(latch.wait((tests * interval) + 1)).to be true
 
       (1..tests).each do |i|
         delta = expected.pop

--- a/spec/concurrent/future_spec.rb
+++ b/spec/concurrent/future_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'dereferenceable_shared'
 require_relative 'obligation_shared'
 require_relative 'observable_shared'
@@ -70,9 +69,9 @@ module Concurrent
       it_should_behave_like :dereferenceable
 
       # observable
-      
+
       subject{ Future.new{ nil } }
-      
+
       def trigger_observable(observable)
         observable.execute
         sleep(0.1)

--- a/spec/concurrent/ivar_spec.rb
+++ b/spec/concurrent/ivar_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'dereferenceable_shared'
 require_relative 'obligation_shared'
 require_relative 'observable_shared'
@@ -62,9 +61,9 @@ module Concurrent
       it_should_behave_like :dereferenceable
 
       # observable
-      
+
       subject{ IVar.new }
-      
+
       def trigger_observable(observable)
         observable.set('value')
       end

--- a/spec/concurrent/lazy_register_spec.rb
+++ b/spec/concurrent/lazy_register_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
   describe LazyRegister do
 

--- a/spec/concurrent/mvar_spec.rb
+++ b/spec/concurrent/mvar_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'dereferenceable_shared'
 
 module Concurrent
@@ -159,7 +158,7 @@ module Concurrent
 
         putter = Thread.new {
           sleep(0.1)
-          m.put 14 
+          m.put 14
         }
 
         expect(m.modify{ |v| v + 2 }).to eq 14

--- a/spec/concurrent/obligation_shared.rb
+++ b/spec/concurrent/obligation_shared.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 shared_examples :obligation do
 
   context '#state' do

--- a/spec/concurrent/obligation_spec.rb
+++ b/spec/concurrent/obligation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe Obligation do

--- a/spec/concurrent/observable_shared.rb
+++ b/spec/concurrent/observable_shared.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 shared_examples :observable do
 
   let(:observer_set) do
@@ -64,9 +62,9 @@ shared_examples :observable do
       }.to raise_error(ArgumentError)
     end
   end
-  
+
   context '#delete_observer' do
-  
+
     it 'deletes the given observer if called before first notification' do
       expect(subject.count_observers).to eq 0
       subject.add_observer(observer)
@@ -84,7 +82,7 @@ shared_examples :observable do
       expect(subject.delete_observer(observer)).to eq observer
     end
   end
-  
+
   context '#delete_observers' do
 
     it 'deletes all observers when called before first notification' do
@@ -98,9 +96,9 @@ shared_examples :observable do
       expect(subject.delete_observers).to eq subject
     end
   end
-  
+
   context '#count_observers' do
-  
+
     it 'returns zero for a new observable object' do
       expect(subject.count_observers).to eq 0
     end
@@ -152,7 +150,7 @@ shared_examples :observable do
 
     it 'does not notify any observers removed with #delete_observer' do
       latch = Concurrent::CountDownLatch.new(5)
-      
+
       obs = observer_class.new{ latch.count_down }
       subject.add_observer(obs)
       subject.delete_observer(obs)

--- a/spec/concurrent/observable_spec.rb
+++ b/spec/concurrent/observable_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe Observable do

--- a/spec/concurrent/options_parser_spec.rb
+++ b/spec/concurrent/options_parser_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe OptionsParser do

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'obligation_shared'
 require_relative 'thread_arguments_shared'
 
@@ -356,113 +355,113 @@ module Concurrent
       let(:promise1) { Promise.new(executor: executor) { 1 } }
       let(:promise2) { Promise.new(executor: executor) { 2 } }
       let(:promise3) { Promise.new(executor: executor) { [3] } }
-  
+
       describe '.all?' do
-  
+
         it 'returns a new Promise' do
           composite = Promise.all?(promise1, promise2, promise3).execute
           expect(composite).to be_a Concurrent::Promise
         end
-  
+
         it 'does not execute the returned Promise' do
           composite = Promise.all?(promise1, promise2, promise3)
           expect(composite).to be_unscheduled
         end
-  
+
         it 'executes the #then condition when all components succeed' do
           counter = Concurrent::AtomicFixnum.new(0)
           latch = Concurrent::CountDownLatch.new(1)
-  
+
           composite = Promise.all?(promise1, promise2, promise3).
             then { counter.up; latch.count_down }.
             rescue { counter.down; latch.count_down }.
             execute
-  
+
           latch.wait(1)
-  
+
           expect(counter.value).to eq 1
         end
-  
+
         it 'executes the #then condition when no promises are given' do
           counter = Concurrent::AtomicFixnum.new(0)
           latch = Concurrent::CountDownLatch.new(1)
-  
+
           composite = Promise.all?.
             then { counter.up; latch.count_down }.
             rescue { counter.down; latch.count_down }.
             execute
-  
+
           latch.wait(1)
-  
+
           expect(counter.value).to eq 1
         end
-  
+
         it 'executes the #rescue handler if even one component fails' do
           counter = Concurrent::AtomicFixnum.new(0)
           latch = Concurrent::CountDownLatch.new(1)
-  
+
           composite = Promise.all?(promise1, promise2, rejected_subject, promise3).
             then { counter.up; latch.count_down }.
             rescue { counter.down; latch.count_down }.
             execute
-  
+
           latch.wait(1)
-  
+
           expect(counter.value).to eq -1
         end
       end
-  
+
       describe '.any?' do
-  
+
         it 'returns a new Promise' do
           composite = Promise.any?(promise1, promise2, promise3).execute
           expect(composite).to be_a Concurrent::Promise
         end
-  
+
         it 'does not execute the returned Promise' do
           composite = Promise.any?(promise1, promise2, promise3)
           expect(composite).to be_unscheduled
         end
-  
+
         it 'executes the #then condition when any components succeed' do
           counter = Concurrent::AtomicFixnum.new(0)
           latch = Concurrent::CountDownLatch.new(1)
-  
+
           composite = Promise.any?(promise1, promise2, rejected_subject, promise3).
             then { counter.up; latch.count_down }.
             rescue { counter.down; latch.count_down }.
             execute
-  
+
           latch.wait(1)
-  
+
           expect(counter.value).to eq 1
         end
-  
+
         it 'executes the #then condition when no promises are given' do
           counter = Concurrent::AtomicFixnum.new(0)
           latch = Concurrent::CountDownLatch.new(1)
-  
+
           composite = Promise.any?.
             then { counter.up; latch.count_down }.
             rescue { counter.down; latch.count_down }.
             execute
-  
+
           latch.wait(1)
-  
+
           expect(counter.value).to eq 1
         end
-  
+
         it 'executes the #rescue handler if all componenst fail' do
           counter = Concurrent::AtomicFixnum.new(0)
           latch = Concurrent::CountDownLatch.new(1)
-  
+
           composite = Promise.any?(rejected_subject, rejected_subject, rejected_subject, rejected_subject).
             then { counter.up; latch.count_down }.
             rescue { counter.down; latch.count_down }.
             execute
-  
+
           latch.wait(1)
-  
+
           expect(counter.value).to eq -1
         end
       end

--- a/spec/concurrent/scheduled_task_spec.rb
+++ b/spec/concurrent/scheduled_task_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'timecop'
 require_relative 'obligation_shared'
 require_relative 'observable_shared'

--- a/spec/concurrent/thread_arguments_shared.rb
+++ b/spec/concurrent/thread_arguments_shared.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 shared_examples :thread_arguments do
 

--- a/spec/concurrent/timer_task_spec.rb
+++ b/spec/concurrent/timer_task_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative 'dereferenceable_shared'
 require_relative 'observable_shared'
 

--- a/spec/concurrent/tvar_spec.rb
+++ b/spec/concurrent/tvar_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe TVar do

--- a/spec/concurrent/utility/processor_count_spec.rb
+++ b/spec/concurrent/utility/processor_count_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe '#processor_count' do

--- a/spec/concurrent/utility/timeout_spec.rb
+++ b/spec/concurrent/utility/timeout_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe '#timeout' do

--- a/spec/concurrent/utility/timer_spec.rb
+++ b/spec/concurrent/utility/timer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Concurrent
 
   describe '#timer' do


### PR DESCRIPTION
This PR adds the Rspec dot file, allowing you to omit the require 'spec_helper' line in the beginning of spec files.

This PR also sets the default output format of Rspec to progress.

(it's the same thing I did [here](https://github.com/jdantonio/functional-ruby/pull/23))