### PR TITLE
default `count` in CountDownLatch to 1

### DIFF
--- a/lib/concurrent/atomic/count_down_latch.rb
+++ b/lib/concurrent/atomic/count_down_latch.rb
@@ -20,7 +20,7 @@ module Concurrent
     #   @param [Fixnum] count the initial count
     #
     #   @raise [ArgumentError] if `count` is not an integer or is less than zero
-    def initialize(count)
+    def initialize(count = 1)
       unless count.is_a?(Fixnum) && count >= 0
         raise ArgumentError.new('count must be in integer greater than or equal zero')
       end
@@ -75,7 +75,7 @@ module Concurrent
     class JavaCountDownLatch
 
       # @!macro count_down_latch_method_initialize
-      def initialize(count)
+      def initialize(count = 1)
         unless count.is_a?(Fixnum) && count >= 0
           raise ArgumentError.new('count must be in integer greater than or equal zero')
         end

--- a/spec/concurrent/atomic/count_down_latch_spec.rb
+++ b/spec/concurrent/atomic/count_down_latch_spec.rb
@@ -18,6 +18,11 @@ shared_examples :count_down_latch do
         described_class.new('foo')
       }.to raise_error(ArgumentError)
     end
+
+    it 'defaults the count to 1' do
+      latch = described_class.new
+      expect(latch.count).to eq 1
+    end
   end
 
   describe '#count' do


### PR DESCRIPTION
it's very common to use a CountDownLatch with a count of 1.  Default
`count` to 1 so that users can just call `new` and get a valid object
with a count of 1.

I'd like to use this to [replace the Latch implementation in Rails](https://github.com/rails/rails/blob/a0580e974b4a058a983de6c593e4573bd94b76f0/activesupport/lib/active_support/concurrency/latch.rb).