### PR TITLE
Monotonic Condition::clock_time for JRuby 1.7.x

### DIFF
--- a/lib/concurrent/atomic/condition.rb
+++ b/lib/concurrent/atomic/condition.rb
@@ -72,11 +72,14 @@ module Concurrent
       def clock_time
         Process.clock_gettime Process::CLOCK_MONOTONIC
       end
+    elsif RUBY_PLATFORM == 'java'
+      def clock_time
+        java.lang.System.nanoTime() / 1_000_000_000.0
+      end
     else
       def clock_time
         Time.now.to_f
       end
     end
-
   end
 end


### PR DESCRIPTION
Added a `Condition#clock_time` implementation for JRuby 1.7.x systems that uses [System.nanoTime()](http://docs.oracle.com/javase/1.5.0/docs/api/java/lang/System.html#nanoTime()). Follows up issue #245 and PR #253.