### PR TITLE
Promise extends IVar

### DIFF
--- a/lib/concurrent/agent.rb
+++ b/lib/concurrent/agent.rb
@@ -24,18 +24,7 @@ module Concurrent
     #
     # @param [Object] initial the initial value
     #
-    # @!macro [attach] executor_and_deref_options
-    #  
-    #   @param [Hash] opts the options used to define the behavior at update and deref
-    #     and to specify the executor on which to perform actions
-    #   @option opts [Executor] :executor when set use the given `Executor` instance.
-    #     Three special values are also supported: `:task` returns the global task pool,
-    #     `:operation` returns the global operation pool, and `:immediate` returns a new
-    #     `ImmediateExecutor` object.
-    #   @option opts [Boolean] :dup_on_deref (false) call `#dup` before returning the data
-    #   @option opts [Boolean] :freeze_on_deref (false) call `#freeze` before returning the data
-    #   @option opts [Proc] :copy_on_deref (nil) call the given `Proc` passing
-    #     the internal value and returning the value returned from the proc
+    # @!macro executor_and_deref_options
     def initialize(initial, opts = {})
       @value                = initial
       @rescuers             = []

--- a/lib/concurrent/async.rb
+++ b/lib/concurrent/async.rb
@@ -82,14 +82,11 @@ module Concurrent
         self.define_singleton_method(method) do |*args2|
           Async::validate_argc(@delegate, method, *args2)
           ivar = Concurrent::IVar.new
-          value, reason = nil, nil
           @serializer.post(@executor.value) do
             begin
-              value = @delegate.send(method, *args2, &block)
+              ivar.set(@delegate.send(method, *args2, &block))
             rescue => reason
-              # caught
-            ensure
-              ivar.complete(reason.nil?, value, reason)
+              ivar.fail(reason)
             end
           end
           ivar.value if @blocking

--- a/lib/concurrent/atomic/copy_on_notify_observer_set.rb
+++ b/lib/concurrent/atomic/copy_on_notify_observer_set.rb
@@ -33,11 +33,10 @@ module Concurrent
       begin
         @mutex.lock
         @observers[observer] = func
+        observer
       ensure
         @mutex.unlock
       end
-
-        observer
     end
 
     # @param [Object] observer the observer to remove
@@ -45,9 +44,9 @@ module Concurrent
     def delete_observer(observer)
       @mutex.lock
       @observers.delete(observer)
-      @mutex.unlock
-
       observer
+    ensure
+      @mutex.unlock
     end
 
     # Deletes all observers
@@ -55,18 +54,17 @@ module Concurrent
     def delete_observers
       @mutex.lock
       @observers.clear
-      @mutex.unlock
-
       self
+    ensure
+      @mutex.unlock
     end
 
     # @return [Integer] the observers count
     def count_observers
       @mutex.lock
-      result = @observers.count
+      @observers.count
+    ensure
       @mutex.unlock
-
-      result
     end
 
     # Notifies all registered observers with optional args
@@ -75,7 +73,6 @@ module Concurrent
     def notify_observers(*args, &block)
       observers = duplicate_observers
       notify_to(observers, *args, &block)
-
       self
     end
 
@@ -86,7 +83,6 @@ module Concurrent
     def notify_and_delete_observers(*args, &block)
       observers = duplicate_and_clear_observers
       notify_to(observers, *args, &block)
-
       self
     end
 
@@ -96,17 +92,17 @@ module Concurrent
       @mutex.lock
       observers = @observers.dup
       @observers.clear
-      @mutex.unlock
-
       observers
+    ensure
+      @mutex.unlock
     end
 
     def duplicate_observers
       @mutex.lock
       observers = @observers.dup
-      @mutex.unlock
-
       observers
+    ensure
+      @mutex.unlock
     end
 
     def notify_to(observers, *args)

--- a/lib/concurrent/channel/buffered_channel.rb
+++ b/lib/concurrent/channel/buffered_channel.rb
@@ -40,7 +40,7 @@ module Concurrent
           @probe_set.put(probe)
           true
         else
-          shift_buffer if probe.set_unless_assigned(peek_buffer, self)
+          shift_buffer if probe.set?([peek_buffer, self])
         end
 
       end
@@ -76,7 +76,7 @@ module Concurrent
           push_into_buffer(value)
           true
         else
-          @probe_set.take.set_unless_assigned(value, self)
+          @probe_set.take.set?([value, self])
         end
       end
     end

--- a/lib/concurrent/channel/buffered_channel.rb
+++ b/lib/concurrent/channel/buffered_channel.rb
@@ -40,7 +40,7 @@ module Concurrent
           @probe_set.put(probe)
           true
         else
-          shift_buffer if probe.set?([peek_buffer, self])
+          shift_buffer if probe.try_set([peek_buffer, self])
         end
 
       end
@@ -76,7 +76,7 @@ module Concurrent
           push_into_buffer(value)
           true
         else
-          @probe_set.take.set?([value, self])
+          @probe_set.take.try_set([value, self])
         end
       end
     end

--- a/lib/concurrent/channel/channel.rb
+++ b/lib/concurrent/channel/channel.rb
@@ -3,37 +3,12 @@ require 'concurrent/ivar'
 module Concurrent
   module Channel
 
-    class Probe < Concurrent::IVar
-
-      def initialize(value = NO_VALUE, opts = {})
-        super(value, opts)
-      end
-
-      def set_unless_assigned(value, channel)
-        mutex.synchronize do
-          return false if [:fulfilled, :rejected].include? @state
-
-          set_state(true, [value, channel], nil)
-          event.set
-          true
-        end
-      end
-
-      alias_method :composite_value, :value
-
-      def value
-        composite_value.nil? ? nil : composite_value[0]
-      end
-
-      def channel
-        composite_value.nil? ? nil : composite_value[1]
-      end
-    end
+    Probe = IVar
 
     def self.select(*channels)
       probe = Probe.new
       channels.each { |channel| channel.select(probe) }
-      result = probe.composite_value
+      result = probe.value
       channels.each { |channel| channel.remove_probe(probe) }
       result
     end

--- a/lib/concurrent/channel/unbuffered_channel.rb
+++ b/lib/concurrent/channel/unbuffered_channel.rb
@@ -12,8 +12,7 @@ module Concurrent
     end
 
     def push(value)
-      # TODO set_unless_assigned define on IVar as #set_state? or #try_set_state
-      until @probe_set.take.set_unless_assigned(value, self)
+      until @probe_set.take.set?([value, self])
       end
     end
 

--- a/lib/concurrent/channel/unbuffered_channel.rb
+++ b/lib/concurrent/channel/unbuffered_channel.rb
@@ -12,7 +12,7 @@ module Concurrent
     end
 
     def push(value)
-      until @probe_set.take.set?([value, self])
+      until @probe_set.take.try_set([value, self])
       end
     end
 

--- a/lib/concurrent/delay.rb
+++ b/lib/concurrent/delay.rb
@@ -52,9 +52,20 @@ module Concurrent
 
     # Create a new `Delay` in the `:pending` state.
     #
-    # @yield the delayed operation to perform
+    # @!macro [attach] executor_and_deref_options
+    #  
+    #   @param [Hash] opts the options used to define the behavior at update and deref
+    #     and to specify the executor on which to perform actions
+    #   @option opts [Executor] :executor when set use the given `Executor` instance.
+    #     Three special values are also supported: `:task` returns the global task pool,
+    #     `:operation` returns the global operation pool, and `:immediate` returns a new
+    #     `ImmediateExecutor` object.
+    #   @option opts [Boolean] :dup_on_deref (false) call `#dup` before returning the data
+    #   @option opts [Boolean] :freeze_on_deref (false) call `#freeze` before returning the data
+    #   @option opts [Proc] :copy_on_deref (nil) call the given `Proc` passing
+    #     the internal value and returning the value returned from the proc
     #
-    # @!macro executor_and_deref_options
+    # @yield the delayed operation to perform
     #
     # @raise [ArgumentError] if no block is given
     def initialize(opts = {}, &block)

--- a/lib/concurrent/delay.rb
+++ b/lib/concurrent/delay.rb
@@ -60,7 +60,7 @@ module Concurrent
     def initialize(opts = {}, &block)
       raise ArgumentError.new('no block given') unless block_given?
 
-      super(&nil)
+      super()
       init_obligation(self)
       set_deref_options(opts)
       @task_executor = get_executor_from(opts)

--- a/lib/concurrent/dereferenceable.rb
+++ b/lib/concurrent/dereferenceable.rb
@@ -47,7 +47,7 @@ module Concurrent
 
     # Set the internal value of this object
     #
-    # @param [Object] val the new value
+    # @param [Object] value the new value
     def value=(value)
       mutex.synchronize{ @value = value }
     end

--- a/lib/concurrent/dereferenceable.rb
+++ b/lib/concurrent/dereferenceable.rb
@@ -39,12 +39,8 @@ module Concurrent
     #
     # @return [Object] the current value of the object
     def value
-      mutex.lock
-      apply_deref_options(@value)
-    ensure
-      mutex.unlock
+      mutex.synchronize { apply_deref_options(@value) }
     end
-
     alias_method :deref, :value
 
     protected
@@ -52,11 +48,8 @@ module Concurrent
     # Set the internal value of this object
     #
     # @param [Object] val the new value
-    def value=(val)
-      mutex.lock
-      @value = val
-    ensure
-      mutex.unlock
+    def value=(value)
+      mutex.synchronize{ @value = value }
     end
 
     # A mutex lock used for synchronizing thread-safe operations. Methods defined
@@ -74,8 +67,8 @@ module Concurrent
     # @note This method *must* be called from within the constructor of the including class.
     #
     # @see #mutex
-    def init_mutex
-      @mutex = Mutex.new
+    def init_mutex(mutex = Mutex.new)
+      @mutex = mutex
     end
 
     # Set the options which define the operations #value performs before
@@ -91,14 +84,13 @@ module Concurrent
     # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing
     #   the internal value and returning the value returned from the proc
     def set_deref_options(opts = {})
-      mutex.lock
-      @dup_on_deref = opts[:dup_on_deref] || opts[:dup]
-      @freeze_on_deref = opts[:freeze_on_deref] || opts[:freeze]
-      @copy_on_deref = opts[:copy_on_deref] || opts[:copy]
-      @do_nothing_on_deref = !(@dup_on_deref || @freeze_on_deref || @copy_on_deref)
-      nil
-    ensure
-      mutex.unlock
+      mutex.synchronize do
+        @dup_on_deref = opts[:dup_on_deref] || opts[:dup]
+        @freeze_on_deref = opts[:freeze_on_deref] || opts[:freeze]
+        @copy_on_deref = opts[:copy_on_deref] || opts[:copy]
+        @do_nothing_on_deref = !(@dup_on_deref || @freeze_on_deref || @copy_on_deref)
+        nil
+      end
     end
 
     # @!visibility private

--- a/lib/concurrent/future.rb
+++ b/lib/concurrent/future.rb
@@ -88,8 +88,6 @@ module Concurrent
       execute
     end
 
-    protected :complete
-
     private
 
     # @!visibility private

--- a/lib/concurrent/future.rb
+++ b/lib/concurrent/future.rb
@@ -76,7 +76,19 @@ module Concurrent
       Future.new(opts, &block).execute
     end
 
-    protected :set, :fail, :complete
+    def set(value = IVar::NO_VALUE, &block)
+      check_for_block_or_value!(block_given?, value)
+      mutex.synchronize do
+        if @state != :unscheduled
+          raise MultipleAssignmentError
+        else
+          @task = block || Proc.new { value }
+        end
+      end
+      execute
+    end
+
+    protected :complete
 
     private
 

--- a/lib/concurrent/future.rb
+++ b/lib/concurrent/future.rb
@@ -76,6 +76,7 @@ module Concurrent
       Future.new(opts, &block).execute
     end
 
+    # @!macro ivar_set_method
     def set(value = IVar::NO_VALUE, &block)
       check_for_block_or_value!(block_given?, value)
       mutex.synchronize do

--- a/lib/concurrent/ivar.rb
+++ b/lib/concurrent/ivar.rb
@@ -100,9 +100,13 @@ module Concurrent
 
     # Set the `IVar` to a value and wake or notify all threads waiting on it.
     #
-    # @param [Object] value the value to store in the `IVar`
-    # @raise [Concurrent::MultipleAssignmentError] if the `IVar` has already
-    #   been set or otherwise completed
+    # @!macro [attach] ivar_set_parameters_and_exceptions
+    #   @param [Object] value the value to store in the `IVar`
+    #   @yield A block operation to use for setting the value
+    #   @raise [ArgumentError] if both a value and a block are given
+    #   @raise [Concurrent::MultipleAssignmentError] if the `IVar` has already
+    #     been set or otherwise completed
+    #
     # @return [IVar] self
     def set(value = NO_VALUE)
       check_for_block_or_value!(block_given?, value)
@@ -123,9 +127,15 @@ module Concurrent
     #   been set or otherwise completed
     # @return [IVar] self
     def fail(reason = StandardError.new)
-      set { raise reason }
+      complete(false, nil, reason)
     end
 
+    # Attempt to set the `IVar` with the given value or block. Return a
+    # boolean indicating the success or failure of the set operation.
+    #
+    # @!macro ivar_set_parameters_and_exceptions
+    #
+    # @return [Boolean] true if the value was set else false
     def set?(value = NO_VALUE, &block)
       set(value, &block)
       true

--- a/lib/concurrent/ivar.rb
+++ b/lib/concurrent/ivar.rb
@@ -98,16 +98,17 @@ module Concurrent
       observer
     end
 
-    # Set the `IVar` to a value and wake or notify all threads waiting on it.
-    #
-    # @!macro [attach] ivar_set_parameters_and_exceptions
-    #   @param [Object] value the value to store in the `IVar`
-    #   @yield A block operation to use for setting the value
-    #   @raise [ArgumentError] if both a value and a block are given
-    #   @raise [Concurrent::MultipleAssignmentError] if the `IVar` has already
-    #     been set or otherwise completed
-    #
-    # @return [IVar] self
+    # @!macro [attach] ivar_set_method
+    #   Set the `IVar` to a value and wake or notify all threads waiting on it.
+    #  
+    #   @!macro [attach] ivar_set_parameters_and_exceptions
+    #     @param [Object] value the value to store in the `IVar`
+    #     @yield A block operation to use for setting the value
+    #     @raise [ArgumentError] if both a value and a block are given
+    #     @raise [Concurrent::MultipleAssignmentError] if the `IVar` has already
+    #       been set or otherwise completed
+    #  
+    #   @return [IVar] self
     def set(value = NO_VALUE)
       check_for_block_or_value!(block_given?, value)
       raise MultipleAssignmentError unless compare_and_set_state(:processing, :pending)
@@ -120,12 +121,13 @@ module Concurrent
       end
     end
 
-    # Set the `IVar` to failed due to some error and wake or notify all threads waiting on it.
-    #
-    # @param [Object] reason for the failure
-    # @raise [Concurrent::MultipleAssignmentError] if the `IVar` has already
-    #   been set or otherwise completed
-    # @return [IVar] self
+    # @!macro [attach] ivar_fail_method
+    #   Set the `IVar` to failed due to some error and wake or notify all threads waiting on it.
+    #  
+    #   @param [Object] reason for the failure
+    #   @raise [Concurrent::MultipleAssignmentError] if the `IVar` has already
+    #     been set or otherwise completed
+    #   @return [IVar] self
     def fail(reason = StandardError.new)
       complete(false, nil, reason)
     end
@@ -136,7 +138,7 @@ module Concurrent
     # @!macro ivar_set_parameters_and_exceptions
     #
     # @return [Boolean] true if the value was set else false
-    def set?(value = NO_VALUE, &block)
+    def try_set(value = NO_VALUE, &block)
       set(value, &block)
       true
     rescue MultipleAssignmentError

--- a/lib/concurrent/ivar.rb
+++ b/lib/concurrent/ivar.rb
@@ -103,11 +103,8 @@ module Concurrent
     #   been set or otherwise completed
     # @return [IVar] self
     def set(value = NO_VALUE)
-      if (block_given? && value != NO_VALUE) || (!block_given? && value == NO_VALUE)
-        raise ArgumentError.new('must set with either a value or a block')
-      elsif ! compare_and_set_state(:processing, :pending)
-        raise MultipleAssignmentError
-      end
+      check_for_block_or_value!(block_given?, value)
+      raise MultipleAssignmentError unless compare_and_set_state(:processing, :pending)
 
       begin
         value = yield if block_given?

--- a/lib/concurrent/ivar.rb
+++ b/lib/concurrent/ivar.rb
@@ -127,6 +127,13 @@ module Concurrent
       set { raise reason }
     end
 
+    def set?(value = NO_VALUE, &block)
+      set(value, &block)
+      true
+    rescue MultipleAssignmentError
+      false
+    end
+
     protected
 
     # @!visibility private

--- a/lib/concurrent/ivar.rb
+++ b/lib/concurrent/ivar.rb
@@ -102,6 +102,7 @@ module Concurrent
     # @param [Object] value the value to store in the `IVar`
     # @raise [Concurrent::MultipleAssignmentError] if the `IVar` has already
     #   been set or otherwise completed
+    # @return [IVar] self
     def set(value = NO_VALUE)
       if (block_given? && value != NO_VALUE) || (!block_given? && value == NO_VALUE)
         raise ArgumentError.new('must set with either a value or a block')
@@ -122,6 +123,7 @@ module Concurrent
     # @param [Object] reason for the failure
     # @raise [Concurrent::MultipleAssignmentError] if the `IVar` has already
     #   been set or otherwise completed
+    # @return [IVar] self
     def fail(reason = StandardError.new)
       set { raise reason }
     end

--- a/lib/concurrent/ivar.rb
+++ b/lib/concurrent/ivar.rb
@@ -105,8 +105,17 @@ module Concurrent
     # @param [Object] value the value to store in the `IVar`
     # @raise [Concurrent::MultipleAssignmentError] if the `IVar` has already
     #   been set or otherwise completed
-    def set(value)
-      complete(true, value, nil)
+    def set(value = NO_VALUE)
+      if (block_given? && value != NO_VALUE) || (!block_given? && value == NO_VALUE)
+        raise ArgumentError.new('must set with either a value or a block')
+      end
+
+      begin
+        value = yield if block_given?
+        complete(true, value, nil)
+      rescue => ex
+        complete(false, nil, ex)
+      end
     end
 
     # Set the `IVar` to failed due to some error and wake or notify all threads waiting on it.

--- a/lib/concurrent/ivar.rb
+++ b/lib/concurrent/ivar.rb
@@ -39,7 +39,6 @@ module Concurrent
   #   ivar.get #=> 14
   #   ivar.set 2 # would now be an error
   class IVar
-
     include Obligation
     include Observable
 

--- a/lib/concurrent/ivar.rb
+++ b/lib/concurrent/ivar.rb
@@ -3,6 +3,7 @@ require 'thread'
 require 'concurrent/errors'
 require 'concurrent/obligation'
 require 'concurrent/observable'
+require 'concurrent/synchronization'
 
 module Concurrent
 
@@ -38,7 +39,7 @@ module Concurrent
   #   ivar.set 14
   #   ivar.get #=> 14
   #   ivar.set 2 # would now be an error
-  class IVar
+  class IVar < Synchronization::Object
     include Obligation
     include Observable
 
@@ -56,7 +57,8 @@ module Concurrent
     # @option opts [String] :copy_on_deref (nil) call the given `Proc` passing
     #   the internal value and returning the value returned from the proc
     def initialize(value = NO_VALUE, opts = {})
-      init_obligation
+      super(&nil)
+      init_obligation(self)
       self.observers = CopyOnWriteObserverSet.new
       set_deref_options(opts)
       @state = :pending

--- a/lib/concurrent/obligation.rb
+++ b/lib/concurrent/obligation.rb
@@ -59,7 +59,7 @@ module Concurrent
     #
     # @return [Boolean]
     def incomplete?
-      [:unscheduled, :pending].include? state
+      ! complete?
     end
 
     # The current value of the obligation. Will be `nil` while the state is

--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -385,13 +385,13 @@ module Concurrent
       aggregate(:any?, *promises)
     end
 
-    def set(value)
-      raise PromiseExecutionError.new('supported only on root promises') unless root?
+    def set(value = IVar::NO_VALUE)
+      raise PromiseExecutionError.new('supported only on root promise') unless root?
       super
     end
 
     def fail(reason = StandardError.new)
-      raise PromiseExecutionError.new('supported only on root promises') unless root?
+      raise PromiseExecutionError.new('supported only on root promise') unless root?
       super
     end
 

--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -242,22 +242,15 @@ module Concurrent
 
     def set(value = IVar::NO_VALUE, &block)
       raise PromiseExecutionError.new('supported only on root promise') unless root?
-      if (block_given? && value != NO_VALUE) || (!block_given? && value == NO_VALUE)
-        raise ArgumentError.new('must set with either a value or a block')
-      end
+      check_for_block_or_value!(block_given?, value)
       mutex.synchronize do
         if @state != :unscheduled
-          raise PromiseExecutionError.new('execution has already begun')
+          raise MultipleAssignmentError
         else
           @promise_body = block || Proc.new { |result| value }
         end
       end
       execute
-    end
-
-    def fail(reason = StandardError.new)
-      raise PromiseExecutionError.new('supported only on root promise') unless root?
-      super
     end
 
     # Create a new `Promise` object with the given block, execute it, and return the

--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -253,6 +253,10 @@ module Concurrent
       execute
     end
 
+    def fail(reason = StandardError.new)
+      set { raise reason }
+    end
+
     # Create a new `Promise` object with the given block, execute it, and return the
     # `:pending` object.
     #

--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -398,8 +398,6 @@ module Concurrent
       aggregate(:any?, *promises)
     end
 
-    protected :complete
-
     protected
 
     # Aggregate a collection of zero or more promises under a composite promise,
@@ -464,6 +462,7 @@ module Concurrent
       end
 
       children_to_notify.each { |child| notify_child(child) }
+      observers.notify_and_delete_observers{ [Time.now, self.value, reason] }
     end
 
     # @!visibility private

--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -481,10 +481,7 @@ module Concurrent
 
     # @!visibility private
     def synchronized_set_state!(success, value, reason)
-      mutex.lock
-      set_state!(success, value, reason)
-    ensure
-      mutex.unlock
+      mutex.synchronize { set_state!(success, value, reason) }
     end
   end
 end

--- a/lib/concurrent/synchronization/abstract_object.rb
+++ b/lib/concurrent/synchronization/abstract_object.rb
@@ -7,7 +7,9 @@ module Concurrent
     # Provides a single layer which can improve its implementation over time without changes needed to
     # the classes using it. Use {Synchronization::Object} not this abstract class.
     #
-    # @note this object does not support usage together with {Thread#wakeup} and {Thread#raise}.
+    # @note this object does not support usage together with
+    #   [Thread#wakeup](http://ruby-doc.org/core-2.2.0/Thread.html#method-i-wakeup)
+    #   and [Thread#raise](http://ruby-doc.org/core-2.2.0/Thread.html#method-i-raise).
     #   `Thread#sleep` and `Thread#wakeup` will work as expected but mixing `Synchronization::Object#wait` and
     #   `Thread#wakeup` will not work on all platforms.
     #

--- a/spec/concurrent/channel/buffered_channel_spec.rb
+++ b/spec/concurrent/channel/buffered_channel_spec.rb
@@ -47,7 +47,7 @@ module Concurrent
         it 'should assign value to a probe if probe set is not empty' do
           channel.select(probe)
           Thread.new { sleep(0.1); channel.push 3 }
-          expect(probe.value).to eq 3
+          expect(probe.value.first).to eq 3
         end
       end
 
@@ -62,14 +62,14 @@ module Concurrent
           channel.push 1
           result = channel.pop
 
-          expect(result).to eq 1
+          expect(result.first).to eq 1
         end
 
         it 'removes the first value from the buffer' do
           channel.push 'a'
           channel.push 'b'
 
-          expect(channel.pop).to eq 'a'
+          expect(channel.pop.first).to eq 'a'
           expect(channel.buffer_queue_size).to eq 1
         end
       end
@@ -91,7 +91,7 @@ module Concurrent
 
         Thread.new { channel.push 82 }
 
-        expect(probe.value).to eq 82
+        expect(probe.value.first).to eq 82
       end
 
     end
@@ -120,7 +120,7 @@ module Concurrent
 
           expect(channel.buffer_queue_size).to eq 1
 
-          expect(channel.pop).to eq 82
+          expect(channel.pop.first).to eq 82
 
         end
       end

--- a/spec/concurrent/channel/probe_spec.rb
+++ b/spec/concurrent/channel/probe_spec.rb
@@ -20,20 +20,20 @@ module Concurrent
       it_should_behave_like :observable
     end
 
-    describe '#set?' do
+    describe '#try_set' do
       context 'empty probe' do
         it 'assigns the value' do
-          probe.set?([32, channel])
+          probe.try_set([32, channel])
           expect(probe.value.first).to eq 32
         end
 
         it 'assign the channel' do
-          probe.set?([32, channel])
+          probe.try_set([32, channel])
           expect(probe.value.last).to be channel
         end
 
         it 'returns true' do
-          expect(probe.set?(['hi', channel])).to eq true
+          expect(probe.try_set(['hi', channel])).to eq true
         end
       end
 
@@ -41,12 +41,12 @@ module Concurrent
         before(:each) { probe.set([27, nil]) }
 
         it 'does not assign the value' do
-          probe.set?([88, channel])
+          probe.try_set([88, channel])
           expect(probe.value.first).to eq 27
         end
 
         it 'returns false' do
-          expect(probe.set?(['hello', channel])).to eq false
+          expect(probe.try_set(['hello', channel])).to eq false
         end
       end
 
@@ -54,7 +54,7 @@ module Concurrent
         before(:each) { probe.fail }
 
         it 'does not assign the value' do
-          probe.set?([88, channel])
+          probe.try_set([88, channel])
           expect(probe).to be_rejected
         end
 
@@ -63,7 +63,7 @@ module Concurrent
         end
 
         it 'returns false' do
-          expect(probe.set?(['hello', channel])).to eq false
+          expect(probe.try_set(['hello', channel])).to eq false
         end
       end
     end

--- a/spec/concurrent/channel/probe_spec.rb
+++ b/spec/concurrent/channel/probe_spec.rb
@@ -20,20 +20,20 @@ module Concurrent
       it_should_behave_like :observable
     end
 
-    describe '#set_unless_assigned' do
+    describe '#set?' do
       context 'empty probe' do
         it 'assigns the value' do
-          probe.set_unless_assigned(32, channel)
-          expect(probe.value).to eq 32
+          probe.set?([32, channel])
+          expect(probe.value.first).to eq 32
         end
 
         it 'assign the channel' do
-          probe.set_unless_assigned(32, channel)
-          expect(probe.channel).to be channel
+          probe.set?([32, channel])
+          expect(probe.value.last).to be channel
         end
 
         it 'returns true' do
-          expect(probe.set_unless_assigned('hi', channel)).to eq true
+          expect(probe.set?(['hi', channel])).to eq true
         end
       end
 
@@ -41,12 +41,12 @@ module Concurrent
         before(:each) { probe.set([27, nil]) }
 
         it 'does not assign the value' do
-          probe.set_unless_assigned(88, channel)
-          expect(probe.value).to eq 27
+          probe.set?([88, channel])
+          expect(probe.value.first).to eq 27
         end
 
         it 'returns false' do
-          expect(probe.set_unless_assigned('hello', channel)).to eq false
+          expect(probe.set?(['hello', channel])).to eq false
         end
       end
 
@@ -54,7 +54,7 @@ module Concurrent
         before(:each) { probe.fail }
 
         it 'does not assign the value' do
-          probe.set_unless_assigned(88, channel)
+          probe.set?([88, channel])
           expect(probe).to be_rejected
         end
 
@@ -62,15 +62,10 @@ module Concurrent
           expect(probe.value).to be_nil
         end
 
-        it 'has a nil channel' do
-          expect(probe.channel).to be_nil
-        end
-
         it 'returns false' do
-          expect(probe.set_unless_assigned('hello', channel)).to eq false
+          expect(probe.set?(['hello', channel])).to eq false
         end
       end
     end
-
   end
 end

--- a/spec/concurrent/channel/unbuffered_channel_spec.rb
+++ b/spec/concurrent/channel/unbuffered_channel_spec.rb
@@ -39,7 +39,7 @@ module Concurrent
 
         sleep(0.1)
 
-        expect(result).to eq 42
+        expect(result.first).to eq 42
       end
 
       it 'passes the pushed value to only one thread' do
@@ -62,7 +62,7 @@ module Concurrent
 
         sleep(0.1)
 
-        expect(result).to eq 57
+        expect(result.first).to eq 57
       end
     end
 
@@ -81,7 +81,7 @@ module Concurrent
 
         Thread.new { channel.push 82 }
 
-        expect(probe.value).to eq 82
+        expect(probe.value.first).to eq 82
       end
 
       it 'ignores already set probes and waits for a new one' do
@@ -101,7 +101,7 @@ module Concurrent
 
         sleep(0.05)
 
-        expect(new_probe.value).to eq 72
+        expect(new_probe.value.first).to eq 72
       end
 
     end

--- a/spec/concurrent/future_spec.rb
+++ b/spec/concurrent/future_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'dereferenceable_shared'
+require_relative 'ivar_shared'
 require_relative 'obligation_shared'
 require_relative 'observable_shared'
 require_relative 'thread_arguments_shared'
@@ -14,6 +15,11 @@ module Concurrent
       Future.new(executor: executor){
         value
       }.execute.tap{ sleep(0.1) }
+    end
+
+    context 'manual completion' do
+      subject { Future.new(executor: :immediate){ nil } }
+      it_should_behave_like :ivar
     end
 
     context 'behavior' do
@@ -78,23 +84,6 @@ module Concurrent
       end
 
       it_should_behave_like :observable
-    end
-
-    context 'subclassing' do
-
-      subject{ Future.execute(executor: executor){ 42 } }
-
-      it 'protects #set' do
-        expect{ subject.set(100) }.to raise_error
-      end
-
-      it 'protects #fail' do
-        expect{ subject.fail }.to raise_error
-      end
-
-      it 'protects #complete' do
-        expect{ subject.complete(true, 100, nil) }.to raise_error
-      end
     end
 
     context '#initialize' do

--- a/spec/concurrent/future_spec.rb
+++ b/spec/concurrent/future_spec.rb
@@ -1,4 +1,3 @@
-require_relative 'dereferenceable_shared'
 require_relative 'ivar_shared'
 require_relative 'observable_shared'
 require_relative 'thread_arguments_shared'
@@ -32,21 +31,7 @@ module Concurrent
     end
 
     it_should_behave_like :ivar do
-      subject { Future.new(executor: :immediate){ nil } }
-    end
-
-    it_should_behave_like :thread_arguments do
-
-      def get_ivar_from_no_args
-        Concurrent::Future.execute{|*args| args }
-      end
-
-      def get_ivar_from_args(opts)
-        Concurrent::Future.execute(opts){|*args| args }
-      end
-    end
-
-    it_should_behave_like :dereferenceable do
+      subject { Future.new(executor: :immediate){ value } }
 
       def dereferenceable_subject(value, opts = {})
         opts = opts.merge(executor: executor)
@@ -61,6 +46,17 @@ module Concurrent
       def execute_dereferenceable(subject)
         subject.execute
         sleep(0.1)
+      end
+    end
+
+    it_should_behave_like :thread_arguments do
+
+      def get_ivar_from_no_args
+        Concurrent::Future.execute{|*args| args }
+      end
+
+      def get_ivar_from_args(opts)
+        Concurrent::Future.execute(opts){|*args| args }
       end
     end
 

--- a/spec/concurrent/future_spec.rb
+++ b/spec/concurrent/future_spec.rb
@@ -1,5 +1,4 @@
 require_relative 'ivar_shared'
-require_relative 'observable_shared'
 require_relative 'thread_arguments_shared'
 
 module Concurrent
@@ -47,6 +46,11 @@ module Concurrent
         subject.execute
         sleep(0.1)
       end
+
+      def trigger_observable(observable)
+        observable.execute
+        sleep(0.1)
+      end
     end
 
     it_should_behave_like :thread_arguments do
@@ -57,16 +61,6 @@ module Concurrent
 
       def get_ivar_from_args(opts)
         Concurrent::Future.execute(opts){|*args| args }
-      end
-    end
-
-    it_should_behave_like :observable do
-
-      subject{ Future.new{ nil } }
-
-      def trigger_observable(observable)
-        observable.execute
-        sleep(0.1)
       end
     end
 

--- a/spec/concurrent/ivar_shared.rb
+++ b/spec/concurrent/ivar_shared.rb
@@ -93,4 +93,66 @@ shared_examples :ivar do
       expect(subject.fail).to eq subject
     end
   end
+
+  describe '#set?' do
+
+    context 'when unset' do
+
+      it 'assigns the value' do
+        subject.set?(32)
+        expect(subject.value).to eq 32
+      end
+
+      it 'assigns the block result' do
+        subject.set?{ 32 }
+        expect(subject.value).to eq 32
+      end
+
+      it 'returns true' do
+        expect(subject.set?('hi')).to eq true
+      end
+    end
+
+    context 'when fulfilled' do
+
+      before(:each) { subject.set(27) }
+
+      it 'does not assign the value' do
+        subject.set?(88)
+        expect(subject.value).to eq 27
+      end
+
+      it 'does not assign the block result' do
+        subject.set?{ 88 }
+        expect(subject.value).to eq 27
+      end
+
+      it 'returns false' do
+        expect(subject.set?('hello')).to eq false
+      end
+    end
+
+    context 'when rejected' do
+
+      before(:each) { subject.fail }
+
+      it 'does not assign the value' do
+        subject.set?(88)
+        expect(subject).to be_rejected
+      end
+
+      it 'does not assign the block result' do
+        subject.set?{ 88 }
+        expect(subject).to be_rejected
+      end
+
+      it 'has a nil value' do
+        expect(subject.value).to be_nil
+      end
+
+      it 'returns false' do
+        expect(subject.set?('hello')).to eq false
+      end
+    end
+  end
 end

--- a/spec/concurrent/ivar_shared.rb
+++ b/spec/concurrent/ivar_shared.rb
@@ -1,8 +1,10 @@
+require_relative 'dereferenceable_shared'
 require_relative 'obligation_shared'
 
 shared_examples :ivar do
 
   it_should_behave_like :obligation
+  it_should_behave_like :dereferenceable
 
   context 'initialization' do
 

--- a/spec/concurrent/ivar_shared.rb
+++ b/spec/concurrent/ivar_shared.rb
@@ -1,4 +1,8 @@
+require_relative 'obligation_shared'
+
 shared_examples :ivar do
+
+  it_should_behave_like :obligation
 
   context 'initialization' do
 

--- a/spec/concurrent/ivar_shared.rb
+++ b/spec/concurrent/ivar_shared.rb
@@ -1,10 +1,12 @@
 require_relative 'dereferenceable_shared'
 require_relative 'obligation_shared'
+require_relative 'observable_shared'
 
 shared_examples :ivar do
 
   it_should_behave_like :obligation
   it_should_behave_like :dereferenceable
+  it_should_behave_like :observable
 
   context 'initialization' do
 

--- a/spec/concurrent/ivar_shared.rb
+++ b/spec/concurrent/ivar_shared.rb
@@ -94,22 +94,22 @@ shared_examples :ivar do
     end
   end
 
-  describe '#set?' do
+  describe '#try_set' do
 
     context 'when unset' do
 
       it 'assigns the value' do
-        subject.set?(32)
+        subject.try_set(32)
         expect(subject.value).to eq 32
       end
 
       it 'assigns the block result' do
-        subject.set?{ 32 }
+        subject.try_set{ 32 }
         expect(subject.value).to eq 32
       end
 
       it 'returns true' do
-        expect(subject.set?('hi')).to eq true
+        expect(subject.try_set('hi')).to eq true
       end
     end
 
@@ -118,17 +118,17 @@ shared_examples :ivar do
       before(:each) { subject.set(27) }
 
       it 'does not assign the value' do
-        subject.set?(88)
+        subject.try_set(88)
         expect(subject.value).to eq 27
       end
 
       it 'does not assign the block result' do
-        subject.set?{ 88 }
+        subject.try_set{ 88 }
         expect(subject.value).to eq 27
       end
 
       it 'returns false' do
-        expect(subject.set?('hello')).to eq false
+        expect(subject.try_set('hello')).to eq false
       end
     end
 
@@ -137,12 +137,12 @@ shared_examples :ivar do
       before(:each) { subject.fail }
 
       it 'does not assign the value' do
-        subject.set?(88)
+        subject.try_set(88)
         expect(subject).to be_rejected
       end
 
       it 'does not assign the block result' do
-        subject.set?{ 88 }
+        subject.try_set{ 88 }
         expect(subject).to be_rejected
       end
 
@@ -151,7 +151,7 @@ shared_examples :ivar do
       end
 
       it 'returns false' do
-        expect(subject.set?('hello')).to eq false
+        expect(subject.try_set('hello')).to eq false
       end
     end
   end

--- a/spec/concurrent/ivar_shared.rb
+++ b/spec/concurrent/ivar_shared.rb
@@ -1,0 +1,88 @@
+shared_examples :ivar do
+
+  context 'initialization' do
+
+    it 'sets the state to incomplete' do
+      expect(subject).to be_incomplete
+    end
+  end
+
+  context '#set' do
+
+    it 'sets the state to be fulfilled' do
+      subject.set(14)
+      expect(subject).to be_fulfilled
+    end
+
+    it 'sets the value' do
+      subject.set(14)
+      expect(subject.value).to eq 14
+    end
+
+    it 'raises an exception if set more than once' do
+      subject.set(14)
+      expect {subject.set(2)}.to raise_error(Concurrent::MultipleAssignmentError)
+      expect(subject.value).to eq 14
+    end
+
+    it 'returns self' do
+      expect(subject.set(42)).to eq subject
+    end
+    it 'fulfils when given a block which executes successfully' do
+      subject.set{ 42 }
+      expect(subject.value).to eq 42
+    end
+
+    it 'rejects when given a block which raises an exception' do
+      expected = ArgumentError.new
+      subject.set{ raise expected }
+      expect(subject.reason).to eq expected
+    end
+
+    it 'raises an exception when given a value and a block' do
+      expect {
+        subject.set(42){ :guide }
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an exception when given neither a value nor a block' do
+      expect {
+        subject.set
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  context '#fail' do
+
+    it 'sets the state to be rejected' do
+      subject.fail
+      expect(subject).to be_rejected
+    end
+
+    it 'sets the value to be nil' do
+      subject.fail
+      expect(subject.value).to be_nil
+    end
+
+    it 'sets the reason to the given exception' do
+      expected = ArgumentError.new
+      subject.fail(expected)
+      expect(subject.reason).to eq expected
+    end
+
+    it 'raises an exception if set more than once' do
+      subject.fail
+      expect {subject.fail}.to raise_error(Concurrent::MultipleAssignmentError)
+      expect(subject.value).to be_nil
+    end
+
+    it 'defaults the reason to a StandardError' do
+      subject.fail
+      expect(subject.reason).to be_a StandardError
+    end
+
+    it 'returns self' do
+      expect(subject.fail).to eq subject
+    end
+  end
+end

--- a/spec/concurrent/ivar_spec.rb
+++ b/spec/concurrent/ivar_spec.rb
@@ -115,6 +115,33 @@ module Concurrent
         i = IVar.new
         expect(i.set(42)).to eq i
       end
+
+      it 'fulfils when given a block which executes successfully' do
+        i = IVar.new
+        i.set{ 42 }
+        expect(i.value).to eq 42
+      end
+
+      it 'rejects when given a block which raises an exception' do
+        i = IVar.new
+        expected = ArgumentError.new
+        i.set{ raise expected }
+        expect(i.reason).to eq expected
+      end
+
+      it 'raises an exception when given a value and a block' do
+        i = IVar.new
+        expect {
+          i.set(42){ :guide }
+        }.to raise_error(ArgumentError)
+      end
+
+      it 'raises an exception when given neither a value nor a block' do
+        i = IVar.new
+        expect {
+          i.set
+        }.to raise_error(ArgumentError)
+      end
     end
 
     context '#fail' do
@@ -129,6 +156,13 @@ module Concurrent
         i = IVar.new
         i.fail
         expect(i.value).to be_nil
+      end
+
+      it 'sets the reason to the given exception' do
+        i = IVar.new
+        expected = ArgumentError.new
+        i.fail(expected)
+        expect(i.reason).to eq expected
       end
 
       it 'raises an exception if set more than once' do

--- a/spec/concurrent/ivar_spec.rb
+++ b/spec/concurrent/ivar_spec.rb
@@ -1,4 +1,3 @@
-require_relative 'dereferenceable_shared'
 require_relative 'ivar_shared'
 require_relative 'observable_shared'
 
@@ -32,9 +31,6 @@ module Concurrent
 
     it_should_behave_like :ivar do
       subject{ IVar.new }
-    end
-
-    it_should_behave_like :dereferenceable do
 
       def dereferenceable_subject(value, opts = {})
         IVar.new(value, opts)

--- a/spec/concurrent/ivar_spec.rb
+++ b/spec/concurrent/ivar_spec.rb
@@ -1,5 +1,4 @@
 require_relative 'ivar_shared'
-require_relative 'observable_shared'
 
 module Concurrent
 
@@ -43,11 +42,6 @@ module Concurrent
       def execute_dereferenceable(subject)
         subject.set('value')
       end
-    end
-
-    it_should_behave_like :observable do
-
-      subject{ IVar.new }
 
       def trigger_observable(observable)
         observable.set('value')

--- a/spec/concurrent/ivar_spec.rb
+++ b/spec/concurrent/ivar_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'dereferenceable_shared'
+require_relative 'ivar_shared'
 require_relative 'obligation_shared'
 require_relative 'observable_shared'
 
@@ -12,6 +13,11 @@ module Concurrent
       i = IVar.new
       i.set(14)
       i
+    end
+
+    context 'manual completion' do
+      subject{ IVar.new }
+      it_should_behave_like :ivar
     end
 
     context 'behavior' do
@@ -85,103 +91,9 @@ module Concurrent
 
       it 'can set an initial value' do
         i = IVar.new(14)
-        expect(i).to be_completed
+        expect(i).to be_complete
       end
 
-    end
-
-    context '#set' do
-
-      it 'sets the state to be fulfilled' do
-        i = IVar.new
-        i.set(14)
-        expect(i).to be_fulfilled
-      end
-
-      it 'sets the value' do
-        i = IVar.new
-        i.set(14)
-        expect(i.value).to eq 14
-      end
-
-      it 'raises an exception if set more than once' do
-        i = IVar.new
-        i.set(14)
-        expect {i.set(2)}.to raise_error(Concurrent::MultipleAssignmentError)
-        expect(i.value).to eq 14
-      end
-
-      it 'returns self' do
-        i = IVar.new
-        expect(i.set(42)).to eq i
-      end
-
-      it 'fulfils when given a block which executes successfully' do
-        i = IVar.new
-        i.set{ 42 }
-        expect(i.value).to eq 42
-      end
-
-      it 'rejects when given a block which raises an exception' do
-        i = IVar.new
-        expected = ArgumentError.new
-        i.set{ raise expected }
-        expect(i.reason).to eq expected
-      end
-
-      it 'raises an exception when given a value and a block' do
-        i = IVar.new
-        expect {
-          i.set(42){ :guide }
-        }.to raise_error(ArgumentError)
-      end
-
-      it 'raises an exception when given neither a value nor a block' do
-        i = IVar.new
-        expect {
-          i.set
-        }.to raise_error(ArgumentError)
-      end
-    end
-
-    context '#fail' do
-
-      it 'sets the state to be rejected' do
-        i = IVar.new
-        i.fail
-        expect(i).to be_rejected
-      end
-
-      it 'sets the value to be nil' do
-        i = IVar.new
-        i.fail
-        expect(i.value).to be_nil
-      end
-
-      it 'sets the reason to the given exception' do
-        i = IVar.new
-        expected = ArgumentError.new
-        i.fail(expected)
-        expect(i.reason).to eq expected
-      end
-
-      it 'raises an exception if set more than once' do
-        i = IVar.new
-        i.fail
-        expect {i.fail}.to raise_error(Concurrent::MultipleAssignmentError)
-        expect(i.value).to be_nil
-      end
-
-      it 'defaults the reason to a StandardError' do
-        i = IVar.new
-        i.fail
-        expect(i.reason).to be_a StandardError
-      end
-
-      it 'returns self' do
-        i = IVar.new
-        expect(i.fail).to eq i
-      end
     end
 
     context 'observation' do

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -1,5 +1,4 @@
 require_relative 'ivar_shared'
-require_relative 'obligation_shared'
 require_relative 'thread_arguments_shared'
 
 module Concurrent
@@ -13,7 +12,7 @@ module Concurrent
     let!(:rejected_reason) { StandardError.new('mojo jojo') }
 
     let(:pending_subject) do
-      Promise.new(executor: executor){ sleep(0.3); fulfilled_value }.execute
+      Promise.new(executor: executor){ sleep(0.1); fulfilled_value }.execute
     end
 
     let(:fulfilled_subject) do
@@ -24,14 +23,11 @@ module Concurrent
       Promise.reject(rejected_reason, executor: executor)
     end
 
-    context 'manual completion' do
+    it_should_behave_like :ivar do
       subject{ Promise.new(executor: :immediate) }
-      it_should_behave_like :ivar
     end
 
-    context 'behavior' do
-
-      # thread_arguments
+    it_should_behave_like :thread_arguments do
 
       def get_ivar_from_no_args
         Concurrent::Promise.execute{|*args| args }
@@ -40,12 +36,6 @@ module Concurrent
       def get_ivar_from_args(opts)
         Concurrent::Promise.execute(opts){|*args| args }
       end
-
-      it_should_behave_like :thread_arguments
-
-      # obligation
-
-      it_should_behave_like :obligation
     end
 
     it 'includes Dereferenceable' do

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -5,6 +5,7 @@ module Concurrent
 
   describe Promise do
 
+    let!(:value) { 10 }
     let(:executor) { PerThreadExecutor.new }
 
     let(:empty_root) { Promise.new(executor: executor){ nil } }
@@ -24,7 +25,22 @@ module Concurrent
     end
 
     it_should_behave_like :ivar do
-      subject{ Promise.new(executor: :immediate) }
+      subject{ Promise.new(executor: :immediate){ value } }
+
+      def dereferenceable_subject(value, opts = {})
+        opts = opts.merge(executor: executor)
+        Promise.new(opts){ value }.execute.tap{ sleep(0.1) }
+      end
+
+      def dereferenceable_observable(opts = {})
+        opts = opts.merge(executor: executor)
+        Promise.new(opts){ 'value' }
+      end
+
+      def execute_dereferenceable(subject)
+        subject.execute
+        sleep(0.1)
+      end
     end
 
     it_should_behave_like :thread_arguments do
@@ -36,11 +52,6 @@ module Concurrent
       def get_ivar_from_args(opts)
         Concurrent::Promise.execute(opts){|*args| args }
       end
-    end
-
-    it 'includes Dereferenceable' do
-      promise = Promise.new{ nil }
-      expect(promise).to be_a(Dereferenceable)
     end
 
     context 'initializers' do

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -41,6 +41,11 @@ module Concurrent
         subject.execute
         sleep(0.1)
       end
+
+      def trigger_observable(observable)
+        observable.execute
+        sleep(0.1)
+      end
     end
 
     it_should_behave_like :thread_arguments do

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -486,6 +486,18 @@ module Concurrent
           root.set(20)
           expect(expected).to eq 20
         end
+
+        it 'can be called with a block' do
+          p = Promise.new(executor: executor)
+          ch = p.then(&:to_s)
+          p.set { :value }
+
+          expect(p.value).to eq :value
+          expect(p.state).to eq :fulfilled
+
+          expect(ch.value).to eq 'value'
+          expect(ch.state).to eq :fulfilled
+        end
       end
 
       context '#fail' do

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -1,3 +1,4 @@
+require_relative 'ivar_shared'
 require_relative 'obligation_shared'
 require_relative 'thread_arguments_shared'
 
@@ -21,6 +22,11 @@ module Concurrent
 
     let(:rejected_subject) do
       Promise.reject(rejected_reason, executor: executor)
+    end
+
+    context 'manual completion' do
+      subject{ Promise.new(executor: :immediate) }
+      it_should_behave_like :ivar
     end
 
     context 'behavior' do


### PR DESCRIPTION
## Promise extends IVar

`Promise` extends `IVar` the way `Future` does. This allows a Promise to be manually (and safely) be set from any thread. It also begins the process of consolidating Promise, Future, and IVar.

See #257, #139, and #269

## IVar is a Synchronization::Object

`IVar` is now a `Synchronization::Object`.

* `Dereferenceable` supports injection of a mutex
* `Obligation` supports injection of a mutex
* `IVar` extends `Synchronization::Object`
* `IVar` passes `self` to `Obligation` as injected mutex
* `IVar`, `Promise`, and `Future` no longer call `mutex#lock`

See #273 and #275

## Moved mutex unlocking into ensure clauses.

See #244 