### PR TITLE
Fix deadlock of Future when the handler raises Exception

### DIFF
--- a/lib/concurrent/future.rb
+++ b/lib/concurrent/future.rb
@@ -82,7 +82,7 @@ module Concurrent
 
     # @!visibility private
     def work # :nodoc:
-      success, val, reason = SafeTaskExecutor.new(@task).execute(*@args)
+      success, val, reason = SafeTaskExecutor.new(@task, rescue_exception: true).execute(*@args)
       complete(success, val, reason)
     end
   end

--- a/spec/concurrent/future_spec.rb
+++ b/spec/concurrent/future_spec.rb
@@ -209,6 +209,11 @@ module Concurrent
         expect(future.value).to be_nil
       end
 
+      it 'sets the reason to the Exception instance when the handler raises Exception' do
+        future = Future.new(executor: executor){ raise Exception }.execute
+        expect(future.reason).to be_a(Exception)
+      end
+
       it 'sets the state to :rejected when the handler raises an exception' do
         future = Future.new(executor: executor){ raise StandardError }.execute
         expect(future).to be_rejected

--- a/spec/concurrent/future_spec.rb
+++ b/spec/concurrent/future_spec.rb
@@ -204,6 +204,11 @@ module Concurrent
         expect(future.value).to be_nil
       end
 
+      it 'sets the value to nil when the handler raises Exception' do
+        future = Future.new(executor: executor){ raise Exception }.execute
+        expect(future.value).to be_nil
+      end
+
       it 'sets the state to :rejected when the handler raises an exception' do
         future = Future.new(executor: executor){ raise StandardError }.execute
         expect(future).to be_rejected


### PR DESCRIPTION
I found deadlock situation in using `Future` when the handler raises `Exception` (not `StandardError`).

```ruby
require 'concurrent'

future = Concurrent::Future.new do
  raise Exception
end
future.execute
future.value #=> deadlock
```

```
/Users/shohei-yasutake/work/concurrent-ruby/lib/concurrent/atomic/condition.rb:50:in `sleep': No live threads left. Deadlock? (fatal)
	from /Users/shohei-yasutake/work/concurrent-ruby/lib/concurrent/atomic/condition.rb:50:in `wait'
	from /Users/shohei-yasutake/work/concurrent-ruby/lib/concurrent/atomic/condition.rb:50:in `wait'
	from /Users/shohei-yasutake/work/concurrent-ruby/lib/concurrent/atomic/event.rb:89:in `wait'
	from /Users/shohei-yasutake/work/concurrent-ruby/lib/concurrent/obligation.rb:80:in `wait'
	from /Users/shohei-yasutake/work/concurrent-ruby/lib/concurrent/obligation.rb:71:in `value'
	from example.rb:7:in `<main>'
```

It is because the exception raised in `SafeTaskExecutor.new(@task).execute(*@args)` is not caught and `complete(success, val, reason)` is not called.

https://github.com/ruby-concurrency/concurrent-ruby/blob/master/lib/concurrent/future.rb#L85-L86

So I fixed to catch `Exception` in `SafeTaskExecutor`.