### PR TITLE
MutexAtomicBoolean is now a Synchronization::Object

### DIFF
--- a/examples/benchmark_atomic_boolean.rb
+++ b/examples/benchmark_atomic_boolean.rb
@@ -6,6 +6,9 @@ require 'concurrent/atomics'
 require 'benchmark'
 require 'rbconfig'
 
+THREADS = 10
+TESTS = 1_000_000
+
 def atomic_test(clazz, opts = {})
   threads = opts.fetch(:threads, 5)
   tests = opts.fetch(:tests, 100)
@@ -29,10 +32,10 @@ end
 
 puts "Testing with #{RbConfig::CONFIG['ruby_install_name']} #{RUBY_VERSION}"
 
-atomic_test(Concurrent::MutexAtomicBoolean, threads: 10, tests: 1_000_000)
+atomic_test(Concurrent::MutexAtomicBoolean, threads: THREADS, tests: TESTS)
 
 if defined? Concurrent::CAtomicBoolean
-  atomic_test(Concurrent::CAtomicBoolean, threads: 10, tests: 1_000_000)
+  atomic_test(Concurrent::CAtomicBoolean, threads: THREADS, tests: TESTS)
 elsif RUBY_PLATFORM == 'java'
-  atomic_test(Concurrent::JavaAtomicBoolean, threads: 10, tests: 1_000_000)
+  atomic_test(Concurrent::JavaAtomicBoolean, threads: THREADS, tests: TESTS)
 end

--- a/lib/concurrent/atomic/atomic_boolean.rb
+++ b/lib/concurrent/atomic/atomic_boolean.rb
@@ -1,4 +1,5 @@
 require 'concurrent/native_extensions'
+require 'concurrent/synchronization'
 
 module Concurrent
 
@@ -21,7 +22,7 @@ module Concurrent
   #         3.340000   0.010000   3.350000 (  0.855000)
   #
   #   @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/atomic/AtomicBoolean.html java.util.concurrent.atomic.AtomicBoolean
-  class MutexAtomicBoolean
+  class MutexAtomicBoolean < Synchronization::Object
 
     # @!macro [attach] atomic_boolean_method_initialize
     #
@@ -29,8 +30,7 @@ module Concurrent
     #
     #   @param [Boolean] initial the initial value
     def initialize(initial = false)
-      @value = !!initial
-      @mutex = Mutex.new
+      super(initial)
     end
 
     # @!macro [attach] atomic_boolean_method_value_get
@@ -39,10 +39,7 @@ module Concurrent
     #
     #   @return [Boolean] the current value
     def value
-      @mutex.lock
-      @value
-    ensure
-      @mutex.unlock
+      synchronize { @value }
     end
 
     # @!macro [attach] atomic_boolean_method_value_set
@@ -53,11 +50,7 @@ module Concurrent
     #
     #   @return [Boolean] the current value
     def value=(value)
-      @mutex.lock
-      @value = !!value
-      @value
-    ensure
-      @mutex.unlock
+      synchronize { @value = !!value }
     end
 
     # @!macro [attach] atomic_boolean_method_true_question
@@ -66,10 +59,7 @@ module Concurrent
     #
     #   @return [Boolean] true if the current value is `true`, else false
     def true?
-      @mutex.lock
-      @value
-    ensure
-      @mutex.unlock
+      synchronize { @value }
     end
 
     # @!macro atomic_boolean_method_false_question
@@ -78,10 +68,7 @@ module Concurrent
     #
     #   @return [Boolean] true if the current value is `false`, else false
     def false?
-      @mutex.lock
-      !@value
-    ensure
-      @mutex.unlock
+      synchronize { !@value }
     end
 
     # @!macro [attach] atomic_boolean_method_make_true
@@ -90,12 +77,7 @@ module Concurrent
     #
     #   @return [Boolean] true is value has changed, otherwise false
     def make_true
-      @mutex.lock
-      old = @value
-      @value = true
-      !old
-    ensure
-      @mutex.unlock
+      synchronize { ns_make_value(true) }
     end
 
     # @!macro [attach] atomic_boolean_method_make_false
@@ -104,12 +86,19 @@ module Concurrent
     #
     #   @return [Boolean] true is value has changed, otherwise false
     def make_false
-      @mutex.lock
+      synchronize { ns_make_value(false) }
+    end
+
+    protected
+
+    def ns_initialize(initial)
+      @value = !!initial
+    end
+
+    def ns_make_value(value)
       old = @value
-      @value = false
-      old
-    ensure
-      @mutex.unlock
+      @value = value
+      old != @value
     end
   end
 

--- a/spec/concurrent/atomic/atomic_boolean_spec.rb
+++ b/spec/concurrent/atomic/atomic_boolean_spec.rb
@@ -108,45 +108,45 @@ module Concurrent
 
     it_should_behave_like :atomic_boolean
 
-    specify 'construction is synchronized' do
-      mutex = double('mutex')
-      expect(Mutex).to receive(:new).once.with(no_args).and_return(mutex)
-      described_class.new
-    end
+    #specify 'construction is synchronized' do
+      #mutex = double('mutex')
+      #expect(Mutex).to receive(:new).once.with(no_args).and_return(mutex)
+      #described_class.new
+    #end
 
-    context 'instance methods' do
+    #context 'instance methods' do
 
-      before(:each) do
-        mutex = double('mutex')
-        allow(Mutex).to receive(:new).with(no_args).and_return(mutex)
-        expect(mutex).to receive(:lock)
-        expect(mutex).to receive(:unlock)
-      end
+      #before(:each) do
+        #mutex = double('mutex')
+        #allow(Mutex).to receive(:new).with(no_args).and_return(mutex)
+        #expect(mutex).to receive(:lock)
+        #expect(mutex).to receive(:unlock)
+      #end
 
-      specify 'value is synchronized' do
-        described_class.new.value
-      end
+      #specify 'value is synchronized' do
+        #described_class.new.value
+      #end
 
-      specify 'value= is synchronized' do
-        described_class.new.value = 10
-      end
+      #specify 'value= is synchronized' do
+        #described_class.new.value = 10
+      #end
 
-      specify 'true? is synchronized' do
-        described_class.new.true?
-      end
+      #specify 'true? is synchronized' do
+        #described_class.new.true?
+      #end
 
-      specify 'false? is synchronized' do
-        described_class.new.false?
-      end
+      #specify 'false? is synchronized' do
+        #described_class.new.false?
+      #end
 
-      specify 'make_true is synchronized' do
-        described_class.new.make_true
-      end
+      #specify 'make_true is synchronized' do
+        #described_class.new.make_true
+      #end
 
-      specify 'make_false is synchronized' do
-        described_class.new.make_false
-      end
-    end
+      #specify 'make_false is synchronized' do
+        #described_class.new.make_false
+      #end
+    #end
   end
 
   if defined? Concurrent::CAtomicBoolean


### PR DESCRIPTION
## Do Not Merge

Before:

```
Testing with ruby 2.2.1
Testing with Concurrent::MutexAtomicBoolean...
Rehearsal ------------------------------------
   4.930000   0.010000   4.940000 (  4.967906)
--------------------------- total: 4.940000sec

       user     system      total        real
   0.000000   0.000000   0.000000 (  1.021545)
Testing with Concurrent::CAtomicBoolean...
Rehearsal ------------------------------------
   4.330000   0.010000   4.340000 (  4.354824)
--------------------------- total: 4.340000sec

       user     system      total        real
   0.000000   0.000000   0.000000 (  0.000272)
```

After:

```
Testing with ruby 2.2.1
Testing with Concurrent::MutexAtomicBoolean...
Rehearsal ------------------------------------
  20.630000  51.690000  72.320000 ( 54.480074)
-------------------------- total: 72.320000sec

       user     system      total        real
   0.100000   0.000000   0.100000 (  0.100887)
Testing with Concurrent::CAtomicBoolean...
Rehearsal ------------------------------------
   1.260000   0.000000   1.260000 (  1.287014)
--------------------------- total: 1.260000sec

       user     system      total        real
   0.000000   0.000000   0.000000 (  0.000239)
```