### PR TITLE
More Synchronization

### DIFF
--- a/examples/benchmark_atomic_boolean.rb
+++ b/examples/benchmark_atomic_boolean.rb
@@ -6,6 +6,9 @@ require 'concurrent/atomics'
 require 'benchmark'
 require 'rbconfig'
 
+THREADS = 1
+TESTS = 10_000_000
+
 def atomic_test(clazz, opts = {})
   threads = opts.fetch(:threads, 5)
   tests = opts.fetch(:tests, 100)
@@ -29,10 +32,10 @@ end
 
 puts "Testing with #{RbConfig::CONFIG['ruby_install_name']} #{RUBY_VERSION}"
 
-atomic_test(Concurrent::MutexAtomicBoolean, threads: 10, tests: 1_000_000)
+atomic_test(Concurrent::MutexAtomicBoolean, threads: THREADS, tests: TESTS)
 
 if defined? Concurrent::CAtomicBoolean
-  atomic_test(Concurrent::CAtomicBoolean, threads: 10, tests: 1_000_000)
+  atomic_test(Concurrent::CAtomicBoolean, threads: THREADS, tests: TESTS)
 elsif RUBY_PLATFORM == 'java'
-  atomic_test(Concurrent::JavaAtomicBoolean, threads: 10, tests: 1_000_000)
+  atomic_test(Concurrent::JavaAtomicBoolean, threads: THREADS, tests: TESTS)
 end

--- a/examples/benchmark_atomic_fixnum.rb
+++ b/examples/benchmark_atomic_fixnum.rb
@@ -6,6 +6,9 @@ require 'concurrent/atomics'
 require 'benchmark'
 require 'rbconfig'
 
+THREADS = 1
+TESTS = 10_000_000
+
 def atomic_test(clazz, opts = {})
   threads = opts.fetch(:threads, 5)
   tests = opts.fetch(:tests, 100)
@@ -29,10 +32,10 @@ end
 
 puts "Testing with #{RbConfig::CONFIG['ruby_install_name']} #{RUBY_VERSION}"
 
-atomic_test(Concurrent::MutexAtomicFixnum, threads: 10, tests: 1_000_000)
+atomic_test(Concurrent::MutexAtomicFixnum, threads: THREADS, tests: TESTS)
 
 if defined? Concurrent::CAtomicFixnum
-  atomic_test(Concurrent::CAtomicFixnum, threads: 10, tests: 1_000_000)
+  atomic_test(Concurrent::CAtomicFixnum, threads: THREADS, tests: TESTS)
 elsif RUBY_PLATFORM == 'java'
-  atomic_test(Concurrent::JavaAtomicFixnum, threads: 10, tests: 1_000_000)
+  atomic_test(Concurrent::JavaAtomicFixnum, threads: THREADS, tests: TESTS)
 end

--- a/lib/concurrent/atomic/atomic_boolean.rb
+++ b/lib/concurrent/atomic/atomic_boolean.rb
@@ -1,4 +1,5 @@
 require 'concurrent/native_extensions'
+require 'concurrent/synchronization'
 
 module Concurrent
 
@@ -21,7 +22,7 @@ module Concurrent
   #         3.340000   0.010000   3.350000 (  0.855000)
   #
   #   @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/atomic/AtomicBoolean.html java.util.concurrent.atomic.AtomicBoolean
-  class MutexAtomicBoolean
+  class MutexAtomicBoolean < Synchronization::Object
 
     # @!macro [attach] atomic_boolean_method_initialize
     #
@@ -29,8 +30,7 @@ module Concurrent
     #
     #   @param [Boolean] initial the initial value
     def initialize(initial = false)
-      @value = !!initial
-      @mutex = Mutex.new
+      super(initial)
     end
 
     # @!macro [attach] atomic_boolean_method_value_get
@@ -39,10 +39,7 @@ module Concurrent
     #
     #   @return [Boolean] the current value
     def value
-      @mutex.lock
-      @value
-    ensure
-      @mutex.unlock
+      synchronize { @value }
     end
 
     # @!macro [attach] atomic_boolean_method_value_set
@@ -53,11 +50,7 @@ module Concurrent
     #
     #   @return [Boolean] the current value
     def value=(value)
-      @mutex.lock
-      @value = !!value
-      @value
-    ensure
-      @mutex.unlock
+      synchronize { @value = !!value }
     end
 
     # @!macro [attach] atomic_boolean_method_true_question
@@ -66,10 +59,7 @@ module Concurrent
     #
     #   @return [Boolean] true if the current value is `true`, else false
     def true?
-      @mutex.lock
-      @value
-    ensure
-      @mutex.unlock
+      synchronize { @value }
     end
 
     # @!macro atomic_boolean_method_false_question
@@ -78,10 +68,7 @@ module Concurrent
     #
     #   @return [Boolean] true if the current value is `false`, else false
     def false?
-      @mutex.lock
-      !@value
-    ensure
-      @mutex.unlock
+      synchronize { !@value }
     end
 
     # @!macro [attach] atomic_boolean_method_make_true
@@ -90,12 +77,7 @@ module Concurrent
     #
     #   @return [Boolean] true is value has changed, otherwise false
     def make_true
-      @mutex.lock
-      old = @value
-      @value = true
-      !old
-    ensure
-      @mutex.unlock
+      synchronize { ns_make_value(true) }
     end
 
     # @!macro [attach] atomic_boolean_method_make_false
@@ -104,12 +86,19 @@ module Concurrent
     #
     #   @return [Boolean] true is value has changed, otherwise false
     def make_false
-      @mutex.lock
+      synchronize { ns_make_value(false) }
+    end
+
+    protected
+
+    def ns_initialize(initial)
+      @value = !!initial
+    end
+
+    def ns_make_value(value)
       old = @value
-      @value = false
-      old
-    ensure
-      @mutex.unlock
+      @value = value
+      old != @value
     end
   end
 

--- a/lib/concurrent/atomic/semaphore.rb
+++ b/lib/concurrent/atomic/semaphore.rb
@@ -146,12 +146,6 @@ module Concurrent
 
     def try_acquire_timed(permits, timeout)
       ns_wait_until(timeout) { try_acquire_now(permits) }
-      #remaining = Condition::Result.new(timeout)
-      #while !try_acquire_now(permits) && remaining.can_wait?
-        #@condition.signal
-        #remaining = @condition.wait(@mutex, remaining.remaining_time)
-      #end
-      #remaining.can_wait? ? true : false
     end
   end
 

--- a/lib/concurrent/atomic/semaphore.rb
+++ b/lib/concurrent/atomic/semaphore.rb
@@ -1,7 +1,7 @@
-require 'concurrent/atomic/condition'
+require 'concurrent/synchronization'
 
 module Concurrent
-  class MutexSemaphore
+  class MutexSemaphore < Synchronization::Object
     # @!macro [attach] semaphore_method_initialize
     #
     #   Create a new `Semaphore` with the initial `count`.
@@ -13,9 +13,7 @@ module Concurrent
       unless count.is_a?(Fixnum) && count >= 0
         fail ArgumentError, 'count must be an non-negative integer'
       end
-      @mutex = Mutex.new
-      @condition = Condition.new
-      @free = count
+      super(count)
     end
 
     # @!macro [attach] semaphore_method_acquire
@@ -33,7 +31,7 @@ module Concurrent
       unless permits.is_a?(Fixnum) && permits > 0
         fail ArgumentError, 'permits must be an integer greater than zero'
       end
-      @mutex.synchronize do
+      synchronize do
         try_acquire_timed(permits, nil)
         nil
       end
@@ -45,7 +43,7 @@ module Concurrent
     #
     #   @return [Integer]
     def available_permits
-      @mutex.synchronize { @free }
+      synchronize { @free }
     end
 
     # @!macro [attach] semaphore_method_drain_permits
@@ -54,7 +52,7 @@ module Concurrent
     #
     #   @return [Integer]
     def drain_permits
-      @mutex.synchronize do
+      synchronize do
         @free.tap { |_| @free = 0 }
       end
     end
@@ -79,7 +77,7 @@ module Concurrent
       unless permits.is_a?(Fixnum) && permits > 0
         fail ArgumentError, 'permits must be an integer greater than zero'
       end
-      @mutex.synchronize do
+      synchronize do
         if timeout.nil?
           try_acquire_now(permits)
         else
@@ -101,9 +99,9 @@ module Concurrent
       unless permits.is_a?(Fixnum) && permits > 0
         fail ArgumentError, 'permits must be an integer greater than zero'
       end
-      @mutex.synchronize do
+      synchronize do
         @free += permits
-        permits.times { @condition.signal }
+        permits.times { ns_signal }
       end
       nil
     end
@@ -125,8 +123,14 @@ module Concurrent
       unless reduction.is_a?(Fixnum) && reduction >= 0
         fail ArgumentError, 'reduction must be an non-negative integer'
       end
-      @mutex.synchronize { @free -= reduction }
+      synchronize { @free -= reduction }
       nil
+    end
+
+    protected
+
+    def ns_initialize(count)
+      @free = count
     end
 
     private
@@ -141,12 +145,13 @@ module Concurrent
     end
 
     def try_acquire_timed(permits, timeout)
-      remaining = Condition::Result.new(timeout)
-      while !try_acquire_now(permits) && remaining.can_wait?
-        @condition.signal
-        remaining = @condition.wait(@mutex, remaining.remaining_time)
-      end
-      remaining.can_wait? ? true : false
+      ns_wait_until(timeout) { try_acquire_now(permits) }
+      #remaining = Condition::Result.new(timeout)
+      #while !try_acquire_now(permits) && remaining.can_wait?
+        #@condition.signal
+        #remaining = @condition.wait(@mutex, remaining.remaining_time)
+      #end
+      #remaining.can_wait? ? true : false
     end
   end
 

--- a/lib/concurrent/channel/blocking_ring_buffer.rb
+++ b/lib/concurrent/channel/blocking_ring_buffer.rb
@@ -1,43 +1,39 @@
-require 'concurrent/atomic/condition'
+require 'concurrent/synchronization'
 
 module Concurrent
-  class BlockingRingBuffer
+  class BlockingRingBuffer < Synchronization::Object
 
     def initialize(capacity)
-      @buffer = RingBuffer.new(capacity)
-      @first = @last = 0
-      @count = 0
-      @mutex = Mutex.new
-      @condition = Condition.new
+      super(capacity)
     end
 
     # @return [Integer] the capacity of the buffer
     def capacity
-      @mutex.synchronize { @buffer.capacity }
+      synchronize { @buffer.capacity }
     end
 
     # @return [Integer] the number of elements currently in the buffer
     def count
-      @mutex.synchronize { @buffer.count }
+      synchronize { @buffer.count }
     end
 
     # @return [Boolean] true if buffer is empty, false otherwise
     def empty?
-      @mutex.synchronize { @buffer.empty? }
+      synchronize { @buffer.empty? }
     end
 
     # @return [Boolean] true if buffer is full, false otherwise
     def full?
-      @mutex.synchronize { @buffer.full? }
+      synchronize { @buffer.full? }
     end
 
     # @param [Object] value the value to be inserted
     # @return [Boolean] true if value has been inserted, false otherwise
     def put(value)
-      @mutex.synchronize do
+      synchronize do
         wait_while_full
         @buffer.offer(value)
-        @condition.signal
+        ns_signal
         true
       end
     end
@@ -45,10 +41,10 @@ module Concurrent
     # @return [Object] the first available value and removes it from the buffer.
     #   If buffer is empty it blocks until an element is available
     def take
-      @mutex.synchronize do
+      synchronize do
         wait_while_empty
         result = @buffer.poll
-        @condition.signal
+        ns_signal
         result
       end
     end
@@ -56,18 +52,25 @@ module Concurrent
     # @return [Object] the first available value and without removing it from
     #   the buffer. If buffer is empty returns nil
     def peek
-      @mutex.synchronize { @buffer.peek }
+      synchronize { @buffer.peek }
+    end
+
+    protected
+
+    def ns_initialize(capacity)
+      @buffer = RingBuffer.new(capacity)
+      @first = @last = 0
+      @count = 0
     end
 
     private
 
     def wait_while_full
-      @condition.wait(@mutex) while @buffer.full?
+      ns_wait_until { !@buffer.full? }
     end
 
     def wait_while_empty
-      @condition.wait(@mutex) while @buffer.empty?
+      ns_wait_until { !@buffer.empty? }
     end
-
   end
 end

--- a/lib/concurrent/channel/buffered_channel.rb
+++ b/lib/concurrent/channel/buffered_channel.rb
@@ -1,4 +1,3 @@
-require 'concurrent/atomic/condition'
 require 'concurrent/channel/waitable_list'
 
 module Concurrent
@@ -6,8 +5,8 @@ module Concurrent
 
     def initialize(size)
       @mutex = Mutex.new
-      @condition = Condition.new
-      @buffer_condition = Condition.new
+      @condition = ConditionVariable.new
+      @buffer_condition = ConditionVariable.new
 
       @probe_set = WaitableList.new
       @buffer = RingBuffer.new(size)

--- a/lib/concurrent/channel/buffered_channel.rb
+++ b/lib/concurrent/channel/buffered_channel.rb
@@ -1,6 +1,5 @@
 require 'concurrent/atomic/condition'
-
-require_relative 'waitable_list'
+require 'concurrent/channel/waitable_list'
 
 module Concurrent
   class BufferedChannel

--- a/lib/concurrent/channel/waitable_list.rb
+++ b/lib/concurrent/channel/waitable_list.rb
@@ -1,40 +1,38 @@
-require 'concurrent/atomic/condition'
+require 'concurrent/synchronization'
 
 module Concurrent
-  class WaitableList
-
-    def initialize
-      @mutex = Mutex.new
-      @condition = Condition.new
-
-      @list = []
-    end
+  class WaitableList < Synchronization::Object
 
     def size
-      @mutex.synchronize { @list.size }
+      synchronize { @list.size }
     end
 
     def empty?
-      @mutex.synchronize { @list.empty? }
+      synchronize { @list.empty? }
     end
 
     def put(value)
-      @mutex.synchronize do
+      synchronize do
         @list << value
-        @condition.signal
+        ns_signal
       end
     end
 
     def delete(value)
-      @mutex.synchronize { @list.delete(value) }
+      synchronize { @list.delete(value) }
     end
 
     def take
-      @mutex.synchronize do
-        @condition.wait(@mutex) while @list.empty?
+      synchronize do
+        ns_wait_until { !@list.empty? }
         @list.shift
       end
     end
 
+    protected
+
+    def ns_initialize
+      @list = []
+    end
   end
 end

--- a/lib/concurrent/executor/safe_task_executor.rb
+++ b/lib/concurrent/executor/safe_task_executor.rb
@@ -1,4 +1,4 @@
-require 'thread'
+require 'concurrent/synchronization'
 
 module Concurrent
 
@@ -6,17 +6,15 @@ module Concurrent
   # success - indicating if the callable has been executed without errors
   # value - filled by the callable result if it has been executed without errors, nil otherwise
   # reason - the error risen by the callable if it has been executed with errors, nil otherwise
-  class SafeTaskExecutor
+  class SafeTaskExecutor < Synchronization::Object
 
     def initialize(task, opts = {})
-      @task = task
-      @mutex = Mutex.new
-      @exception_class = opts.fetch(:rescue_exception, false) ? Exception : StandardError
+      super(task, opts)
     end
 
     # @return [Array]
     def execute(*args)
-      @mutex.synchronize do
+      synchronize do
         success = false
         value = reason = nil
 
@@ -30,6 +28,13 @@ module Concurrent
 
         [success, value, reason]
       end
+    end
+
+    protected
+
+    def ns_initialize(task, opts)
+      @task = task
+      @exception_class = opts.fetch(:rescue_exception, false) ? Exception : StandardError
     end
   end
 end

--- a/lib/concurrent/executor/safe_task_executor.rb
+++ b/lib/concurrent/executor/safe_task_executor.rb
@@ -9,7 +9,10 @@ module Concurrent
   class SafeTaskExecutor < Synchronization::Object
 
     def initialize(task, opts = {})
-      super(task, opts)
+      super()
+      @task = task
+      @exception_class = opts.fetch(:rescue_exception, false) ? Exception : StandardError
+      ensure_ivar_visibility!
     end
 
     # @return [Array]
@@ -28,13 +31,6 @@ module Concurrent
 
         [success, value, reason]
       end
-    end
-
-    protected
-
-    def ns_initialize(task, opts)
-      @task = task
-      @exception_class = opts.fetch(:rescue_exception, false) ? Exception : StandardError
     end
   end
 end

--- a/lib/concurrent/synchronization/abstract_object.rb
+++ b/lib/concurrent/synchronization/abstract_object.rb
@@ -58,7 +58,7 @@ module Concurrent
       #     synchronize { ns_wait_until(timeout, &condition) }
       #   end
       #   ```
-      def ns_wait_until(timeout, &condition)
+      def ns_wait_until(timeout = nil, &condition)
         if timeout
           wait_until = Concurrent.monotonic_time + timeout
           loop do

--- a/spec/concurrent/atomic/atomic_boolean_spec.rb
+++ b/spec/concurrent/atomic/atomic_boolean_spec.rb
@@ -108,43 +108,34 @@ module Concurrent
 
     it_should_behave_like :atomic_boolean
 
-    specify 'construction is synchronized' do
-      mutex = double('mutex')
-      expect(Mutex).to receive(:new).once.with(no_args).and_return(mutex)
-      described_class.new
-    end
-
     context 'instance methods' do
 
       before(:each) do
-        mutex = double('mutex')
-        allow(Mutex).to receive(:new).with(no_args).and_return(mutex)
-        expect(mutex).to receive(:lock)
-        expect(mutex).to receive(:unlock)
+        expect(subject).to receive(:synchronize).with(no_args).and_return(true)
       end
 
       specify 'value is synchronized' do
-        described_class.new.value
+        subject.value
       end
 
       specify 'value= is synchronized' do
-        described_class.new.value = 10
+        subject.value = 10
       end
 
       specify 'true? is synchronized' do
-        described_class.new.true?
+        subject.true?
       end
 
       specify 'false? is synchronized' do
-        described_class.new.false?
+        subject.false?
       end
 
       specify 'make_true is synchronized' do
-        described_class.new.make_true
+        subject.make_true
       end
 
       specify 'make_false is synchronized' do
-        described_class.new.make_false
+        subject.make_false
       end
     end
   end

--- a/spec/concurrent/atomic/atomic_fixnum_spec.rb
+++ b/spec/concurrent/atomic/atomic_fixnum_spec.rb
@@ -116,50 +116,31 @@ module Concurrent
 
     it_should_behave_like :atomic_fixnum
 
-    specify 'construction is synchronized' do
-      mutex = double('mutex')
-      expect(Mutex).to receive(:new).once.with(no_args).and_return(mutex)
-      described_class.new
-    end
+    context 'instance methods' do
 
-    specify 'value is synchronized' do
-      mutex = double('mutex')
-      allow(Mutex).to receive(:new).with(no_args).and_return(mutex)
-      expect(mutex).to receive(:lock)
-      expect(mutex).to receive(:unlock)
-      described_class.new.value
-    end
+      before(:each) do
+        expect(subject).to receive(:synchronize).with(no_args).and_return(10)
+      end
 
-    specify 'value= is synchronized' do
-      mutex = double('mutex')
-      allow(Mutex).to receive(:new).with(no_args).and_return(mutex)
-      expect(mutex).to receive(:lock)
-      expect(mutex).to receive(:unlock)
-      described_class.new.value = 10
-    end
+      specify 'value is synchronized' do
+        subject.value
+      end
 
-    specify 'increment is synchronized' do
-      mutex = double('mutex')
-      allow(Mutex).to receive(:new).with(no_args).and_return(mutex)
-      expect(mutex).to receive(:lock)
-      expect(mutex).to receive(:unlock)
-      described_class.new.increment
-    end
+      specify 'value= is synchronized' do
+        subject.value = 10
+      end
 
-    specify 'decrement is synchronized' do
-      mutex = double('mutex')
-      allow(Mutex).to receive(:new).with(no_args).and_return(mutex)
-      expect(mutex).to receive(:lock)
-      expect(mutex).to receive(:unlock)
-      described_class.new.decrement
-    end
+      specify 'increment is synchronized' do
+        subject.increment
+      end
 
-    specify 'compare_and_set is synchronized' do
-      mutex = double('mutex')
-      allow(Mutex).to receive(:new).with(no_args).and_return(mutex)
-      expect(mutex).to receive(:lock)
-      expect(mutex).to receive(:unlock)
-      described_class.new(14).compare_and_set(14, 2)
+      specify 'decrement is synchronized' do
+        subject.decrement
+      end
+
+      specify 'compare_and_set is synchronized' do
+        subject.compare_and_set(14, 2)
+      end
     end
   end
 

--- a/spec/concurrent/atomic/atomic_fixnum_spec.rb
+++ b/spec/concurrent/atomic/atomic_fixnum_spec.rb
@@ -115,11 +115,26 @@ module Concurrent
   describe MutexAtomicFixnum do
 
     it_should_behave_like :atomic_fixnum
+    
+    context 'construction' do
+
+      it 'raises en exception if the initial value is too big' do
+        expect {
+          described_class.new(described_class::MAX_VALUE + 1)
+        }.to raise_error
+      end
+
+      it 'raises en exception if the initial value is too small' do
+        expect {
+          described_class.new(described_class::MIN_VALUE - 1)
+        }.to raise_error
+      end
+    end
 
     context 'instance methods' do
 
       before(:each) do
-        expect(subject).to receive(:synchronize).with(no_args).and_return(10)
+        expect(subject).to receive(:synchronize).with(no_args).and_call_original
       end
 
       specify 'value is synchronized' do

--- a/spec/concurrent/executor/safe_task_executor_spec.rb
+++ b/spec/concurrent/executor/safe_task_executor_spec.rb
@@ -32,9 +32,7 @@ module Concurrent
         end
 
         it 'protectes #execute with a mutex' do
-          mutex = double(:mutex)
-          expect(Mutex).to receive(:new).with(no_args).and_return(mutex)
-          expect(mutex).to receive(:synchronize).with(no_args)
+          expect(subject).to receive(:synchronize).with(no_args)
           subject.execute
         end
       end


### PR DESCRIPTION
Updated most classes using `Mutex` to be `Synchronization::Object` subclasses. A few classes have not been updated because they do not align neatly with the implementation of `Synchronization::Object`. Specifically:

* `ReadWriteLock` uses two mutexes and two condition variables
* `MutexAtomicReference` is a fallback class only used on runtimes without synchronization primitives
* `BufferedChannel` uses two condition variables with a single mutex
* `MVar` uses two condition variables with a single mutex
* `TVar` uses `#lock` and `#unlock` methods which are not available on `Synchronization::Object`