### PR TITLE
Future, TimerSet, ScheduleTask cancel, reset, and reschedule

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
 --require spec_helper
 --color
---backtrace
 --format documentation

--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,3 @@
---protected
 --no-private
 --embed-mixins
 --output-dir ./yardoc

--- a/lib/concurrent/collection/priority_queue.rb
+++ b/lib/concurrent/collection/priority_queue.rb
@@ -21,7 +21,7 @@ module Concurrent
   #   When running under JRuby the class `PriorityQueue` extends `JavaPriorityQueue`.
   #   When running under all other interpreters it extends `MutexPriorityQueue`.
   #
-  #   @note This implementation is *not* thread safe and performs no blocking.
+  #   @note This implementation is *not* thread safe.
   #
   #   @see http://en.wikipedia.org/wiki/Priority_queue
   #   @see http://ruby-doc.org/stdlib-2.0.0/libdoc/thread/rdoc/Queue.html
@@ -305,6 +305,16 @@ module Concurrent
   # @!macro priority_queue
   class PriorityQueue < PriorityQueueImplementation
 
+    alias_method :has_priority?, :include?
+
+    alias_method :size, :length
+
+    alias_method :deq, :pop
+    alias_method :shift, :pop
+
+    alias_method :<<, :push
+    alias_method :enq, :push
+
     # @!method initialize(opts = {})
     #   @!macro priority_queue_method_initialize
 
@@ -334,6 +344,5 @@ module Concurrent
 
     # @!method self.from_list(list, opts = {})
     #   @!macro priority_queue_method_from_list
-
   end
 end

--- a/lib/concurrent/collection/priority_queue.rb
+++ b/lib/concurrent/collection/priority_queue.rb
@@ -292,14 +292,48 @@ module Concurrent
         queue
       end
     end
+  end
 
-    # @!macro priority_queue
-    class PriorityQueue < JavaPriorityQueue
-    end
-  else
+  PriorityQueueImplementation = case
+                                when Concurrent.on_jruby?
+                                  JavaPriorityQueue
+                                else
+                                  MutexPriorityQueue
+                                end
+  private_constant :PriorityQueueImplementation
 
-    # @!macro priority_queue
-    class PriorityQueue < MutexPriorityQueue
-    end
+  # @!macro priority_queue
+  class PriorityQueue < PriorityQueueImplementation
+
+    # @!method initialize(opts = {})
+    #   @!macro priority_queue_method_initialize
+
+    # @!method clear
+    #   @!macro priority_queue_method_clear
+
+    # @!method delete(item)
+    #   @!macro priority_queue_method_delete
+
+    # @!method empty?
+    #   @!macro priority_queue_method_empty
+
+    # @!method include?(item)
+    #   @!macro priority_queue_method_include
+
+    # @!method length
+    #   @!macro priority_queue_method_length
+
+    # @!method peek
+    #   @!macro priority_queue_method_peek
+
+    # @!method pop
+    #   @!macro priority_queue_method_pop
+
+    # @!method push(item)
+    #   @!macro priority_queue_method_push
+
+    # @!method self.from_list(list, opts = {})
+    #   @!macro priority_queue_method_from_list
+
   end
 end

--- a/lib/concurrent/errors.rb
+++ b/lib/concurrent/errors.rb
@@ -3,6 +3,9 @@ module Concurrent
   # Raised when errors occur during configuration.
   ConfigurationError = Class.new(StandardError)
 
+  # Raised when an asynchronous operation is cancelled before execution.
+  CancelledOperationError = Class.new(StandardError)
+
   # Raised when a lifecycle method (such as `stop`) is called in an improper
   # sequence or when the object is in an inappropriate state.
   LifecycleError = Class.new(StandardError)

--- a/lib/concurrent/executor/timer_set.rb
+++ b/lib/concurrent/executor/timer_set.rb
@@ -35,6 +35,7 @@ module Concurrent
         end
       end
 
+      # @!visibility private
       def time
         synchronize { @time }
       end
@@ -107,7 +108,9 @@ module Concurrent
           @task_executor.post{ task.execute }
         else
           @queue.push(task)
-          @timer_executor.post(&method(:process_tasks))
+          # `process_tasks` method will run until queue is empty
+          # only post the process method when the queue is empty
+          @timer_executor.post(&method(:process_tasks)) if @queue.size == 1
         end
 
         @condition.set

--- a/lib/concurrent/ivar.rb
+++ b/lib/concurrent/ivar.rb
@@ -148,6 +148,7 @@ module Concurrent
 
     protected
 
+    # @!visibility private
     def ns_initialize(value, opts)
       init_obligation(self)
       self.observers = CopyOnWriteObserverSet.new
@@ -160,21 +161,34 @@ module Concurrent
       end
     end
 
+    # @!visibility private
+    def safe_execute(task, args = [])
+      if compare_and_set_state(:processing, :pending)
+        success, val, reason = SafeTaskExecutor.new(task, rescue_exception: true).execute(*@args)
+        complete(success, val, reason)
+        yield(success, val, reason) if block_given?
+      end
+    end
+
+    # @!visibility private
     def complete(success, value, reason)
       complete_without_notification(success, value, reason)
       notify_observers(self.value, reason)
       self
     end
 
+    # @!visibility private
     def complete_without_notification(success, value, reason)
       synchronize { ns_complete_without_notification(success, value, reason) }
       self
     end
 
+    # @!visibility private
     def notify_observers(value, reason)
       observers.notify_and_delete_observers{ [Time.now, value, reason] }
     end
 
+    # @!visibility private
     def ns_complete_without_notification(success, value, reason)
       raise MultipleAssignmentError if [:fulfilled, :rejected].include? @state
       set_state(success, value, reason)

--- a/lib/concurrent/obligation.rb
+++ b/lib/concurrent/obligation.rb
@@ -164,7 +164,7 @@ module Concurrent
 
     # @!visibility private
     def state=(value)
-      mutex.synchronize { @state = value }
+      mutex.synchronize { ns_set_state(value) }
     end
 
     # Atomic compare and set operation
@@ -176,9 +176,9 @@ module Concurrent
     # @return [Boolean] true is state is changed, false otherwise
     #
     # @!visibility private
-    def compare_and_set_state(next_state, expected_current)
+    def compare_and_set_state(next_state, *expected_current)
       mutex.synchronize do
-        if @state == expected_current
+        if expected_current.include? @state
           @state = next_state
           true
         else
@@ -214,6 +214,11 @@ module Concurrent
     # @!visibility private
     def ns_check_state?(expected)
       @state == expected
+    end
+
+    # @!visibility private
+    def ns_set_state(value)
+      @state = value
     end
   end
 end

--- a/lib/concurrent/obligation.rb
+++ b/lib/concurrent/obligation.rb
@@ -187,7 +187,7 @@ module Concurrent
       end
     end
 
-    # executes the block within mutex if current state is included in expected_states
+    # Executes the block within mutex if current state is included in expected_states
     #
     # @return block value if executed, false otherwise
     #
@@ -202,6 +202,18 @@ module Concurrent
           false
         end
       end
+    end
+
+    protected
+
+    # Am I in the current state?
+    #
+    # @param [Symbol] expected The state to check against
+    # @return [Boolean] true if in the expected state else false
+    #
+    # @!visibility private
+    def ns_check_state?(expected)
+      @state == expected
     end
   end
 end

--- a/lib/concurrent/obligation.rb
+++ b/lib/concurrent/obligation.rb
@@ -136,23 +136,23 @@ module Concurrent
     protected
 
     # @!visibility private
-    def get_arguments_from(opts = {}) # :nodoc:
+    def get_arguments_from(opts = {})
       [*opts.fetch(:args, [])]
     end
 
     # @!visibility private
-    def init_obligation(*args) # :nodoc:
+    def init_obligation(*args)
       init_mutex(*args)
       @event = Event.new
     end
 
     # @!visibility private
-    def event # :nodoc:
+    def event
       @event
     end
 
     # @!visibility private
-    def set_state(success, value, reason) # :nodoc:
+    def set_state(success, value, reason)
       if success
         @value = value
         @state = :fulfilled
@@ -163,7 +163,7 @@ module Concurrent
     end
 
     # @!visibility private
-    def state=(value) # :nodoc:
+    def state=(value)
       mutex.synchronize { @state = value }
     end
 
@@ -176,7 +176,7 @@ module Concurrent
     # @return [Boolean] true is state is changed, false otherwise
     #
     # @!visibility private
-    def compare_and_set_state(next_state, expected_current) # :nodoc:
+    def compare_and_set_state(next_state, expected_current)
       mutex.synchronize do
         if @state == expected_current
           @state = next_state
@@ -192,7 +192,7 @@ module Concurrent
     # @return block value if executed, false otherwise
     #
     # @!visibility private
-    def if_state(*expected_states) # :nodoc:
+    def if_state(*expected_states)
       mutex.synchronize do
         raise ArgumentError.new('no block given') unless block_given?
 

--- a/lib/concurrent/scheduled_task.rb
+++ b/lib/concurrent/scheduled_task.rb
@@ -149,7 +149,9 @@ module Concurrent
     #     but will not be supported in the 1.0 release.
     def initialize(delay, opts = {}, &block)
       raise ArgumentError.new('no block given') unless block_given?
-      super(Concurrent.global_timer_set, delay, [], block, &nil)
+      timer_set = opts.fetch(:timer_set, Concurrent.global_timer_set)
+      args = get_arguments_from(opts)
+      super(timer_set, delay, args, block, opts, &nil)
       synchronize do
         ns_set_state(:unscheduled)
         @__original_delay__ = delay
@@ -182,7 +184,7 @@ module Concurrent
     #
     # @!macro deprecated_scheduling_by_clock_time
     def self.execute(delay, opts = {}, &block)
-      new(delay, &block).execute
+      new(delay, opts, &block).execute
     end
 
     # In the task execution in progress?

--- a/lib/concurrent/utility/timer.rb
+++ b/lib/concurrent/utility/timer.rb
@@ -15,9 +15,7 @@ module Concurrent
   def timer(seconds, *args, &block)
     raise ArgumentError.new('no block given') unless block_given?
     raise ArgumentError.new('interval must be greater than or equal to zero') if seconds < 0
-
     Concurrent.configuration.global_timer_set.post(seconds, *args, &block)
-    true
   end
   module_function :timer
 end

--- a/lib/concurrent/utility/timer.rb
+++ b/lib/concurrent/utility/timer.rb
@@ -9,7 +9,7 @@ module Concurrent
   #
   # @yield the task to execute
   #
-  # @return [Boolean] true
+  # @return [Concurrent::TimerSet::Task] IVar representing the task
   #
   # @!macro monotonic_clock_warning
   def timer(seconds, *args, &block)

--- a/lib/concurrent/utility/timer.rb
+++ b/lib/concurrent/utility/timer.rb
@@ -5,11 +5,18 @@ module Concurrent
 
   # Perform the given operation asynchronously after the given number of seconds.
   #
+  # This is a convenience method for posting tasks to the global timer set.
+  # It is intended to be simple and easy to use. For greater control use
+  # either `TimerSet` or `ScheduledTask` directly.
+  #
   # @param [Fixnum] seconds the interval in seconds to wait before executing the task
   #
   # @yield the task to execute
   #
-  # @return [Concurrent::TimerSet::Task] IVar representing the task
+  # @return [Concurrent::ScheduledTask] IVar representing the task
+  #
+  # @see Concurrent::ScheduledTask
+  # @see Concurrent::TimerSet
   #
   # @!macro monotonic_clock_warning
   def timer(seconds, *args, &block)

--- a/spec/concurrent/executor/timer_set_spec.rb
+++ b/spec/concurrent/executor/timer_set_spec.rb
@@ -252,14 +252,14 @@ module Concurrent
       end
 
       it 'reschdules a pending and unpost task when given a valid time' do
-        original_delay = 10
+        initial_delay = 10
         rescheduled_delay = 20
         expect(queue).to receive(:push).twice.with(any_args).and_call_original
-        task = subject.post(original_delay){ nil }
+        task = subject.post(initial_delay){ nil }
         original_schedule = task.schedule_time
         success = task.reschedule(rescheduled_delay)
         expect(success).to be true
-        expect(task.original_delay).to be_within(0.01).of(rescheduled_delay)
+        expect(task.initial_delay).to be_within(0.01).of(rescheduled_delay)
         expect(task.schedule_time).to be > original_schedule
       end
 
@@ -323,9 +323,9 @@ module Concurrent
     context 'task resetting' do
 
       it 'calls #reschedule with the original delay' do
-        original_delay = 10
-        task = subject.post(original_delay){ nil }
-        expect(task).to receive(:ns_reschedule).with(original_delay)
+        initial_delay = 10
+        task = subject.post(initial_delay){ nil }
+        expect(task).to receive(:ns_reschedule).with(initial_delay)
         task.reset
       end
     end

--- a/spec/concurrent/executor/timer_set_spec.rb
+++ b/spec/concurrent/executor/timer_set_spec.rb
@@ -131,6 +131,14 @@ module Concurrent
           expect(delta).to be_within(0.1).of((i * interval) + 0.05)
         end
       end
+
+      it 'continues to execute new tasks even after the queue is emptied' do
+        10.times do |i|
+          task = subject.post(0.1){ i }
+          expect(task.value).to eq i
+          sleep(0.1)
+        end
+      end
     end
 
     context 'resolution' do

--- a/spec/concurrent/executor/timer_set_spec.rb
+++ b/spec/concurrent/executor/timer_set_spec.rb
@@ -320,6 +320,16 @@ module Concurrent
       end
     end
 
+    context 'task resetting' do
+
+      it 'calls #reschedule with the original delay' do
+        original_delay = 10
+        task = subject.post(original_delay){ nil }
+        expect(task).to receive(:ns_reschedule).with(original_delay)
+        task.reset
+      end
+    end
+
     context 'termination' do
 
       it 'cancels all pending tasks on #shutdown' do

--- a/spec/concurrent/executor/timer_set_spec.rb
+++ b/spec/concurrent/executor/timer_set_spec.rb
@@ -1,3 +1,5 @@
+require 'timecop'
+
 module Concurrent
 
   describe TimerSet do
@@ -6,209 +8,304 @@ module Concurrent
 
     after(:each){ subject.kill }
 
-    it 'uses the executor given at construction' do
-      executor = Concurrent.global_immediate_executor
-      expect(executor).to receive(:post).with(no_args)
-      subject = TimerSet.new(executor: executor)
-      subject.post(0){ nil }
-      sleep(0.1)
-    end
+    context 'construction' do
 
-    it 'uses the global io executor be default' do
-      expect(Concurrent.global_io_executor).to receive(:post).with(no_args)
-      subject = TimerSet.new
-      subject.post(0){ nil }
-      sleep(0.1)
-    end
-
-    it 'executes a given task when given a Time' do
-      warn 'deprecated syntax'
-      latch = CountDownLatch.new(1)
-      subject.post(Time.now + 0.1){ latch.count_down }
-      expect(latch.wait(0.2)).to be_truthy
-    end
-
-    it 'executes a given task when given an interval in seconds' do
-      latch = CountDownLatch.new(1)
-      subject.post(0.1){ latch.count_down }
-      expect(latch.wait(0.2)).to be_truthy
-    end
-
-    it 'returns true when posting a task' do
-      expect(subject.post(0.1) { nil }).to be true
-    end
-
-    it 'executes a given task when given an interval in seconds, even if longer tasks have been scheduled' do
-      latch = CountDownLatch.new(1)
-      subject.post(0.5){ nil }
-      sleep 0.1
-      subject.post(0.1){ latch.count_down }
-      expect(latch.wait(0.2)).to be_truthy
-    end
-
-    it 'passes all arguments to the task on execution' do
-      expected = nil
-      latch = CountDownLatch.new(1)
-      subject.post(0.1, 1, 2, 3) do |*args|
-        expected = args
-        latch.count_down
-      end
-      expect(latch.wait(0.2)).to be_truthy
-      expect(expected).to eq [1, 2, 3]
-    end
-
-    it 'immediately posts a task when the delay is zero' do
-      expect(Thread).not_to receive(:new).with(any_args)
-      subject.post(0){ true }
-    end
-
-    it 'does not execute tasks early' do
-      latch = Concurrent::CountDownLatch.new(1)
-      start = Time.now.to_f
-      subject.post(0.2){ latch.count_down }
-      expect(latch.wait(1)).to be true
-      expect(Time.now.to_f - start).to be_within(0.1).of(0.2)
-    end
-
-    it 'raises an exception when given a task with a past Time value' do
-      warn 'deprecated syntax'
-      expect {
-        subject.post(Time.now - 10){ nil }
-      }.to raise_error(ArgumentError)
-    end
-
-    it 'raises an exception when given a task with a delay less than zero' do
-      expect {
-        subject.post(-10){ nil }
-      }.to raise_error(ArgumentError)
-    end
-
-    it 'raises an exception when no block given' do
-      expect {
-        subject.post(10)
-      }.to raise_error(ArgumentError)
-    end
-
-    it 'executes all tasks scheduled for the same time' do
-      latch = CountDownLatch.new(5)
-      5.times{ subject.post(0.1){ latch.count_down } }
-      expect(latch.wait(0.2)).to be_truthy
-    end
-
-    it 'executes tasks with different times in schedule order' do
-      latch = CountDownLatch.new(3)
-      expected = []
-      3.times{|i| subject.post(i/10){ expected << i; latch.count_down } }
-      latch.wait(1)
-      expect(expected).to eq [0, 1, 2]
-    end
-
-    it 'executes tasks with different times in schedule time' do
-      tests = 3
-      interval = 0.1
-      latch = CountDownLatch.new(tests)
-      expected = Queue.new
-      start = Time.now
-
-      (1..tests).each do |i|
-        subject.post(interval * i) { expected << Time.now - start; latch.count_down }
+      it 'uses the executor given at construction' do
+        executor = Concurrent.global_immediate_executor
+        expect(executor).to receive(:post).with(no_args)
+        subject = TimerSet.new(executor: executor)
+        subject.post(0){ nil }
+        sleep(0.1)
       end
 
-      expect(latch.wait((tests * interval) + 1)).to be true
-
-      (1..tests).each do |i|
-        delta = expected.pop
-        expect(delta).to be_within(0.1).of((i * interval) + 0.05)
+      it 'uses the global io executor be default' do
+        expect(Concurrent.global_io_executor).to receive(:post).with(no_args)
+        subject = TimerSet.new
+        subject.post(0){ nil }
+        sleep(0.1)
       end
     end
 
-    it 'cancels all pending tasks on #shutdown' do
-      expected = AtomicFixnum.new(0)
-      10.times{ subject.post(0.2){ expected.increment } }
-      sleep(0.1)
-      subject.shutdown
-      sleep(0.2)
-      expect(expected.value).to eq 0
+    context '#post' do
+
+      it 'raises an exception when given a task with a past Time value' do
+        warn 'deprecated syntax'
+        expect {
+          subject.post(Time.now - 10){ nil }
+        }.to raise_error(ArgumentError)
+      end
+
+      it 'raises an exception when given a task with a delay less than zero' do
+        expect {
+          subject.post(-10){ nil }
+        }.to raise_error(ArgumentError)
+      end
+
+      it 'raises an exception when no block given' do
+        expect {
+          subject.post(10)
+        }.to raise_error(ArgumentError)
+      end
+
+      it 'immediately posts a task when the delay is zero' do
+        expect(Thread).not_to receive(:new).with(any_args)
+        subject.post(0){ true }
+      end
     end
 
-    it 'cancels all pending tasks on #kill' do
-      expected = AtomicFixnum.new(0)
-      10.times{ subject.post(0.2){ expected.increment } }
-      sleep(0.1)
-      subject.kill
-      sleep(0.2)
-      expect(expected.value).to eq 0
+    context 'execution' do
+
+      it 'executes a given task when given a Time' do
+        warn 'deprecated syntax'
+        latch = CountDownLatch.new(1)
+        subject.post(Time.now + 0.1){ latch.count_down }
+        expect(latch.wait(0.2)).to be_truthy
+      end
+
+      it 'executes a given task when given an interval in seconds' do
+        latch = CountDownLatch.new(1)
+        subject.post(0.1){ latch.count_down }
+        expect(latch.wait(0.2)).to be_truthy
+      end
+
+      it 'returns an IVar when posting a task' do
+        expect(subject.post(0.1) { nil }).to be_a Concurrent::IVar
+      end
+
+      it 'executes a given task when given an interval in seconds, even if longer tasks have been scheduled' do
+        latch = CountDownLatch.new(1)
+        subject.post(0.5){ nil }
+        sleep 0.1
+        subject.post(0.1){ latch.count_down }
+        expect(latch.wait(0.2)).to be_truthy
+      end
+
+      it 'passes all arguments to the task on execution' do
+        expected = nil
+        latch = CountDownLatch.new(1)
+        subject.post(0.1, 1, 2, 3) do |*args|
+          expected = args
+          latch.count_down
+        end
+        expect(latch.wait(0.2)).to be_truthy
+        expect(expected).to eq [1, 2, 3]
+      end
+
+      it 'does not execute tasks early' do
+        latch = Concurrent::CountDownLatch.new(1)
+        start = Time.now.to_f
+        subject.post(0.2){ latch.count_down }
+        expect(latch.wait(1)).to be true
+        expect(Time.now.to_f - start).to be_within(0.1).of(0.2)
+      end
+
+      it 'executes all tasks scheduled for the same time' do
+        latch = CountDownLatch.new(5)
+        5.times{ subject.post(0.1){ latch.count_down } }
+        expect(latch.wait(0.2)).to be_truthy
+      end
+
+      it 'executes tasks with different times in schedule order' do
+        latch = CountDownLatch.new(3)
+        expected = []
+        3.times{|i| subject.post(i/10){ expected << i; latch.count_down } }
+        latch.wait(1)
+        expect(expected).to eq [0, 1, 2]
+      end
+
+      it 'executes tasks with different times in schedule time' do
+        tests = 3
+        interval = 0.1
+        latch = CountDownLatch.new(tests)
+        expected = Queue.new
+        start = Time.now
+
+        (1..tests).each do |i|
+          subject.post(interval * i) { expected << Time.now - start; latch.count_down }
+        end
+
+        expect(latch.wait((tests * interval) + 1)).to be true
+
+        (1..tests).each do |i|
+          delta = expected.pop
+          expect(delta).to be_within(0.1).of((i * interval) + 0.05)
+        end
+      end
     end
 
-    it 'stops the monitor thread on #shutdown' do
-      timer_executor = subject.instance_variable_get(:@timer_executor)
-      subject.shutdown
-      sleep(0.1)
-      expect(timer_executor).not_to be_running
+    context 'resolution' do
+
+      it 'sets the IVar value on success when delay is zero' do
+        job = subject.post(0){ 42 }
+        expect(job.value).to eq 42
+        expect(job.reason).to be_nil
+        expect(job).to be_fulfilled
+      end
+
+      it 'sets the IVar value on success when given a delay' do
+        job = subject.post(0.1){ 42 }
+        expect(job.value).to eq 42
+        expect(job.reason).to be_nil
+        expect(job).to be_fulfilled
+      end
+
+      it 'sets the IVar reason on failure when delay is zero' do
+        error = ArgumentError.new('expected error')
+        job = subject.post(0){ raise error }
+        expect(job.value).to be_nil
+        expect(job.reason).to eq error
+        expect(job).to be_rejected
+      end
+
+      it 'sets the IVar reason on failure when given a delay' do
+        error = ArgumentError.new('expected error')
+        job = subject.post(0.1){ raise error }
+        expect(job.value).to be_nil
+        expect(job.reason).to eq error
+        expect(job).to be_rejected
+      end
     end
 
-    it 'kills the monitor thread on #kill' do
-      timer_executor = subject.instance_variable_get(:@timer_executor)
-      subject.kill
-      sleep(0.1)
-      expect(timer_executor).not_to be_running
+    context 'task cancellation' do
+
+      after(:each) do
+        Timecop.return
+      end
+
+      it 'fails to cancel the task once processing has begun' do
+        start_latch = Concurrent::CountDownLatch.new
+        continue_latch = Concurrent::CountDownLatch.new
+        job = subject.post(0.1) do
+          start_latch.count_down
+          continue_latch.wait(2)
+          42
+        end
+
+        start_latch.wait(2)
+        success = job.cancel
+        continue_latch.count_down
+        
+        expect(success).to be false
+        expect(job.value).to eq 42
+        expect(job.reason).to be_nil
+      end
+
+      it 'fails to cancel the task once processing is complete' do
+        job = subject.post(0.1){ 42 }
+
+        job.wait(2)
+        success = job.cancel
+        
+        expect(success).to be false
+        expect(job.value).to eq 42
+        expect(job.reason).to be_nil
+      end
+
+      it 'cancels a pending task' do
+        actual = AtomicBoolean.new(false)
+        Timecop.freeze
+        job = subject.post(0.1){ actual.make_true }
+        success = job.cancel
+        Timecop.travel(1)
+        expect(success).to be true
+        expect(job.value(0)).to be_nil
+        expect(job.reason).to be_a CancelledOperationError
+      end
     end
 
-    it 'rejects tasks once shutdown' do
-      expected = AtomicFixnum.new(0)
-      subject.shutdown
-      sleep(0.1)
-      expect(subject.post(0){ expected.increment }).to be_falsey
-      sleep(0.1)
-      expect(expected.value).to eq 0
+    context 'termination' do
+
+      it 'cancels all pending tasks on #shutdown' do
+        expected = AtomicFixnum.new(0)
+        10.times{ subject.post(0.2){ expected.increment } }
+        sleep(0.1)
+        subject.shutdown
+        sleep(0.2)
+        expect(expected.value).to eq 0
+      end
+
+      it 'cancels all pending tasks on #kill' do
+        expected = AtomicFixnum.new(0)
+        10.times{ subject.post(0.2){ expected.increment } }
+        sleep(0.1)
+        subject.kill
+        sleep(0.2)
+        expect(expected.value).to eq 0
+      end
+
+      it 'stops the monitor thread on #shutdown' do
+        timer_executor = subject.instance_variable_get(:@timer_executor)
+        subject.shutdown
+        sleep(0.1)
+        expect(timer_executor).not_to be_running
+      end
+
+      it 'kills the monitor thread on #kill' do
+        timer_executor = subject.instance_variable_get(:@timer_executor)
+        subject.kill
+        sleep(0.1)
+        expect(timer_executor).not_to be_running
+      end
+
+      it 'rejects tasks once shutdown' do
+        expected = AtomicFixnum.new(0)
+        subject.shutdown
+        sleep(0.1)
+        expect(subject.post(0){ expected.increment }).to be_falsey
+        sleep(0.1)
+        expect(expected.value).to eq 0
+      end
+
+      it 'rejects tasks once killed' do
+        expected = AtomicFixnum.new(0)
+        subject.kill
+        sleep(0.1)
+        expect(subject.post(0){ expected.increment }).to be_falsey
+        sleep(0.1)
+        expect(expected.value).to eq 0
+      end
+
+      specify '#wait_for_termination returns true if shutdown completes before timeout' do
+        subject.post(0.1){ nil }
+        sleep(0.1)
+        subject.shutdown
+        expect(subject.wait_for_termination(0.1)).to be_truthy
+      end
+
+      specify '#wait_for_termination returns false on timeout' do
+        subject.post(0.1){ nil }
+        sleep(0.1)
+        # do not call shutdown -- force timeout
+        expect(subject.wait_for_termination(0.1)).to be_falsey
+      end
     end
 
-    it 'rejects tasks once killed' do
-      expected = AtomicFixnum.new(0)
-      subject.kill
-      sleep(0.1)
-      expect(subject.post(0){ expected.increment }).to be_falsey
-      sleep(0.1)
-      expect(expected.value).to eq 0
-    end
+    context 'state' do
 
-    it 'is running? when first created' do
-      expect(subject).to be_running
-      expect(subject).not_to be_shutdown
-    end
+      it 'is running? when first created' do
+        expect(subject).to be_running
+        expect(subject).not_to be_shutdown
+      end
 
-    it 'is running? after tasks have been post' do
-      subject.post(0.1){ nil }
-      expect(subject).to be_running
-      expect(subject).not_to be_shutdown
-    end
+      it 'is running? after tasks have been post' do
+        subject.post(0.1){ nil }
+        expect(subject).to be_running
+        expect(subject).not_to be_shutdown
+      end
 
-    it 'is shutdown? after shutdown completes' do
-      subject.shutdown
-      sleep(0.1)
-      expect(subject).not_to be_running
-      expect(subject).to be_shutdown
-    end
+      it 'is shutdown? after shutdown completes' do
+        subject.shutdown
+        sleep(0.1)
+        expect(subject).not_to be_running
+        expect(subject).to be_shutdown
+      end
 
-    it 'is shutdown? after being killed' do
-      subject.kill
-      sleep(0.1)
-      expect(subject).not_to be_running
-      expect(subject).to be_shutdown
-    end
-
-    specify '#wait_for_termination returns true if shutdown completes before timeout' do
-      subject.post(0.1){ nil }
-      sleep(0.1)
-      subject.shutdown
-      expect(subject.wait_for_termination(0.1)).to be_truthy
-    end
-
-    specify '#wait_for_termination returns false on timeout' do
-      subject.post(0.1){ nil }
-      sleep(0.1)
-      # do not call shutdown -- force timeout
-      expect(subject.wait_for_termination(0.1)).to be_falsey
+      it 'is shutdown? after being killed' do
+        subject.kill
+        sleep(0.1)
+        expect(subject).not_to be_running
+        expect(subject).to be_shutdown
+      end
     end
   end
 end

--- a/spec/concurrent/scheduled_task_spec.rb
+++ b/spec/concurrent/scheduled_task_spec.rb
@@ -5,6 +5,7 @@ require_relative 'observable_shared'
 module Concurrent
 
   describe ScheduledTask do
+
     context 'behavior' do
 
       # obligation
@@ -57,7 +58,7 @@ module Concurrent
         Timecop.freeze do
           now = Time.now
           task = ScheduledTask.new(expected){ nil }.execute
-          expect(task.delay).to be_within(0.1).of(expected)
+          expect(task.original_delay).to be_within(0.1).of(expected)
         end
       end
 
@@ -66,7 +67,7 @@ module Concurrent
         expected = 60 * 10
         schedule = Time.now + expected
         task = ScheduledTask.new(schedule){ nil }.execute
-        expect(task.delay).to be_within(0.1).of(expected)
+        expect(task.original_delay).to be_within(0.1).of(expected)
       end
 
       it 'raises an exception when seconds is less than zero' do
@@ -185,11 +186,12 @@ module Concurrent
         expect(task.cancel).to be_truthy
       end
 
-      it 'sets the state to :cancelled when cancelled' do
+      it 'sets the reason to CancelledOperationError when cancelled' do
         task = ScheduledTask.new(10){ 42 }.execute
         sleep(0.1)
         task.cancel
-        expect(task).to be_cancelled
+        expect(task).to be_rejected
+        expect(task.reason).to be_a CancelledOperationError
       end
     end
 

--- a/spec/concurrent/scheduled_task_spec.rb
+++ b/spec/concurrent/scheduled_task_spec.rb
@@ -66,7 +66,7 @@ module Concurrent
         Timecop.freeze do
           now = Time.now
           task = ScheduledTask.new(expected){ nil }.execute
-          expect(task.original_delay).to be_within(0.1).of(expected)
+          expect(task.initial_delay).to be_within(0.1).of(expected)
         end
       end
 
@@ -75,7 +75,7 @@ module Concurrent
         expected = 60 * 10
         schedule = Time.now + expected
         task = ScheduledTask.new(schedule){ nil }.execute
-        expect(task.original_delay).to be_within(0.1).of(expected)
+        expect(task.initial_delay).to be_within(0.1).of(expected)
       end
 
       it 'raises an exception when seconds is less than zero' do
@@ -165,7 +165,7 @@ module Concurrent
 
       it 'uses the :executor from the options' do
         latch = Concurrent::CountDownLatch.new
-        executor = Concurrent::ImmediateExecutor.new
+        executor = Concurrent::SingleThreadExecutor.new
         expect(executor).to receive(:post).once.with(any_args).and_call_original
         task = ScheduledTask.execute(0.1, executor: executor) do
           latch.count_down


### PR DESCRIPTION
## Future

A `Future` may now be cancelled before the task has begun processing. Once processing has begun, however, it cannot be cancelled and will be allowed to run to completion. Three new methods have been added:

* `Future#cancel` attempts to cancel the operation before it has begin processing
* `Future#cancelled?` is a predicate method for checking if the operation has been cancelled
* `Future#wait_or_cancel` will wait the given number of seconds for the operation to complete and will attempt to cancel it if the timeout is reached 

## ScheduledTask

A `ScheduledTask` is now an `IVar` that can be cancelled, reset, or rescheduled. Once processing of a has begun, however, it cannot be modified and will be allowed to run to completion. Several new methods have been added:

* `ScheduledTask#cancel` attempts to cancel the operation before it has begin processing
* `ScheduledTask#cancelled?` is a predicate method for checking if the operation has been cancelled
* `ScheduledTask#reset` will reset the schedule using the original delay value
* `ScheduledTask#reschedule` will reschedule using a new delay value

Additionally, the construction methods of `ScheduleTask` now support the `:executor`, `:args`, and `:timer_set` options.

## TimerSet

Rather than returning a simple true/false value when posting a task, `TimerSet` returns a `ScheduledTask` when posting. This gives the user significantly greater capabilities than before. Additionally, the `#post` nows support the `:executor` and `:args` options.

## Concurrent.timer

The `Concurrent.timer` method is still just a convenience method for posting a task to the global timer set. It now returns the `ScheduledTask` created when post.