### PR TITLE
Marked private API abstractions.

### DIFF
--- a/lib/concurrent.rb
+++ b/lib/concurrent.rb
@@ -26,6 +26,11 @@ require 'concurrent/settable_struct'
 require 'concurrent/timer_task'
 require 'concurrent/tvar'
 
+# @!macro [new] internal_implementation_note
+#
+#   @note **Private Implementation:** This abstraction is a private, internal
+#     implementation detail. It should never be used directly.
+
 # @!macro [new] monotonic_clock_warning
 #
 #   @note Time calculations one all platforms and languages are sensitive to

--- a/lib/concurrent/actor.rb
+++ b/lib/concurrent/actor.rb
@@ -11,6 +11,8 @@ module Concurrent
   # TODO more effective executor
 
   # {include:file:doc/actor/main.md}
+  # @api Actor
+  # @!macro edge_warning
   module Actor
 
     require 'concurrent/actor/type_check'

--- a/lib/concurrent/agent.rb
+++ b/lib/concurrent/agent.rb
@@ -91,7 +91,15 @@ module Concurrent
     #
     # @param [Object] initial the initial value
     #
-    # @!macro executor_and_deref_options
+    # @!macro [attach] executor_and_deref_options
+    #  
+    #   @param [Hash] opts the options used to define the behavior at update and deref
+    #     and to specify the executor on which to perform actions
+    #   @option opts [Executor] :executor when set use the given `Executor` instance.
+    #     Three special values are also supported: `:task` returns the global task pool,
+    #     `:operation` returns the global operation pool, and `:immediate` returns a new
+    #     `ImmediateExecutor` object.
+    #   @!macro deref_options
     def initialize(initial, opts = {})
       @value                = initial
       @rescuers             = []

--- a/lib/concurrent/agent.rb
+++ b/lib/concurrent/agent.rb
@@ -79,6 +79,8 @@ module Concurrent
   #
   # @!attribute [r] timeout
   #   @return [Fixnum] the maximum number of seconds before an update is cancelled
+  #
+  # @!macro edge_warning
   class Agent
     include Concern::Dereferenceable
     include Concern::Observable

--- a/lib/concurrent/atomic/atomic_boolean.rb
+++ b/lib/concurrent/atomic/atomic_boolean.rb
@@ -23,7 +23,9 @@ module Concurrent
   #
   #   @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/atomic/AtomicBoolean.html java.util.concurrent.atomic.AtomicBoolean
   #
-  # @api private
+  # @!visibility private
+  #
+  # @!macro internal_implementation_note
   class MutexAtomicBoolean < Synchronization::Object
 
     # @!macro [attach] atomic_boolean_method_initialize
@@ -107,7 +109,8 @@ module Concurrent
     end
   end
 
-  # @api private
+  # @!visibility private
+  # @!macro internal_implementation_note
   AtomicBooleanImplementation = case
                                 when Concurrent.on_jruby?
                                   JavaAtomicBoolean

--- a/lib/concurrent/atomic/atomic_boolean.rb
+++ b/lib/concurrent/atomic/atomic_boolean.rb
@@ -22,6 +22,8 @@ module Concurrent
   #         3.340000   0.010000   3.350000 (  0.855000)
   #
   #   @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/atomic/AtomicBoolean.html java.util.concurrent.atomic.AtomicBoolean
+  #
+  # @api private
   class MutexAtomicBoolean < Synchronization::Object
 
     # @!macro [attach] atomic_boolean_method_initialize
@@ -105,6 +107,7 @@ module Concurrent
     end
   end
 
+  # @api private
   AtomicBooleanImplementation = case
                                 when Concurrent.on_jruby?
                                   JavaAtomicBoolean

--- a/lib/concurrent/atomic/atomic_fixnum.rb
+++ b/lib/concurrent/atomic/atomic_fixnum.rb
@@ -23,7 +23,8 @@ module Concurrent
   #
   #   @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/atomic/AtomicLong.html java.util.concurrent.atomic.AtomicLong
   #
-  # @api private
+  # @!visibility private
+  # @!macro internal_implementation_note
   class MutexAtomicFixnum < Synchronization::Object
 
     # http://stackoverflow.com/questions/535721/ruby-max-integer
@@ -134,7 +135,8 @@ module Concurrent
     end
   end
 
-  # @api private
+  # @!visibility private
+  # @!macro internal_implementation_note
   AtomicFixnumImplementation = case
                                when Concurrent.on_jruby?
                                  JavaAtomicFixnum

--- a/lib/concurrent/atomic/atomic_fixnum.rb
+++ b/lib/concurrent/atomic/atomic_fixnum.rb
@@ -22,6 +22,8 @@ module Concurrent
   #         4.520000   0.030000   4.550000 (  1.187000)
   #
   #   @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/atomic/AtomicLong.html java.util.concurrent.atomic.AtomicLong
+  #
+  # @api private
   class MutexAtomicFixnum < Synchronization::Object
 
     # http://stackoverflow.com/questions/535721/ruby-max-integer
@@ -132,6 +134,7 @@ module Concurrent
     end
   end
 
+  # @api private
   AtomicFixnumImplementation = case
                                when Concurrent.on_jruby?
                                  JavaAtomicFixnum

--- a/lib/concurrent/atomic/count_down_latch.rb
+++ b/lib/concurrent/atomic/count_down_latch.rb
@@ -12,7 +12,8 @@ module Concurrent
   #   When the latch counter reaches zero the waiting thread is unblocked and continues
   #   with its work. A `CountDownLatch` can be used only once. Its value cannot be reset.
   #
-  # @api private
+  # @!visibility private
+  # @!macro internal_implementation_note
   class PureCountDownLatch < Synchronization::Object
 
     # @!macro [attach] count_down_latch_method_initialize
@@ -71,7 +72,8 @@ module Concurrent
   if Concurrent.on_jruby?
 
     # @!macro count_down_latch
-    # @api private
+    # @!visibility private
+    # @!macro internal_implementation_note
     class JavaCountDownLatch
 
       # @!macro count_down_latch_method_initialize

--- a/lib/concurrent/atomic/count_down_latch.rb
+++ b/lib/concurrent/atomic/count_down_latch.rb
@@ -11,6 +11,8 @@ module Concurrent
   #   method. Each of the other threads calls `#count_down` when done with its work.
   #   When the latch counter reaches zero the waiting thread is unblocked and continues
   #   with its work. A `CountDownLatch` can be used only once. Its value cannot be reset.
+  #
+  # @api private
   class PureCountDownLatch < Synchronization::Object
 
     # @!macro [attach] count_down_latch_method_initialize
@@ -69,6 +71,7 @@ module Concurrent
   if Concurrent.on_jruby?
 
     # @!macro count_down_latch
+    # @api private
     class JavaCountDownLatch
 
       # @!macro count_down_latch_method_initialize

--- a/lib/concurrent/atomic/cyclic_barrier.rb
+++ b/lib/concurrent/atomic/cyclic_barrier.rb
@@ -4,6 +4,7 @@ module Concurrent
 
   class CyclicBarrier < Synchronization::Object
 
+    # @api private
     Generation = Struct.new(:status)
     private_constant :Generation
 

--- a/lib/concurrent/atomic/cyclic_barrier.rb
+++ b/lib/concurrent/atomic/cyclic_barrier.rb
@@ -4,7 +4,7 @@ module Concurrent
 
   class CyclicBarrier < Synchronization::Object
 
-    # @api private
+    # @!visibility private
     Generation = Struct.new(:status)
     private_constant :Generation
 

--- a/lib/concurrent/atomic/semaphore.rb
+++ b/lib/concurrent/atomic/semaphore.rb
@@ -10,6 +10,10 @@ module Concurrent
   #   releasing a blocking acquirer.
   #   However, no actual permit objects are used; the Semaphore just keeps a
   #   count of the number available and acts accordingly.
+  #
+  # @!visibility private
+  #
+  # @!macro internal_implementation_note
   class MutexSemaphore < Synchronization::Object
 
     # @!macro [attach] semaphore_method_initialize
@@ -163,6 +167,8 @@ module Concurrent
     end
   end
 
+  # @!visibility private
+  # @!macro internal_implementation_note
   SemaphoreImplementation = case
                             when Concurrent.on_jruby?
                               JavaSemaphore

--- a/lib/concurrent/atomic/thread_local_var.rb
+++ b/lib/concurrent/atomic/thread_local_var.rb
@@ -32,6 +32,8 @@ module Concurrent
   #     v.value #=> 14
   #
   #   @see https://docs.oracle.com/javase/7/docs/api/java/lang/ThreadLocal.html Java ThreadLocal
+  #
+  # @!visibility private
   class AbstractThreadLocalVar
 
     # @api private
@@ -113,6 +115,8 @@ module Concurrent
     end
   end
 
+  # @!visibility private
+  # @!macro internal_implementation_note
   class RubyThreadLocalVar < AbstractThreadLocalVar
 
     protected
@@ -145,6 +149,8 @@ module Concurrent
 
   if Concurrent.on_jruby?
 
+    # @!visibility private
+    # @!macro internal_implementation_note
     class JavaThreadLocalVar < AbstractThreadLocalVar
 
       protected
@@ -166,6 +172,8 @@ module Concurrent
     end
   end
 
+  # @!visibility private
+  # @!macro internal_implementation_note
   ThreadLocalVarImplementation = case
                                  when Concurrent.on_jruby?
                                    JavaThreadLocalVar
@@ -175,9 +183,6 @@ module Concurrent
   private_constant :ThreadLocalVarImplementation
 
   # @!macro thread_local_var
-  #
-  # @see Concurrent::AbstractThreadLocalVar
-  # @see Concurrent::RubyThreadLocalVar
   class ThreadLocalVar < ThreadLocalVarImplementation
 
     # @!method initialize(default = nil)

--- a/lib/concurrent/atomic/thread_local_var.rb
+++ b/lib/concurrent/atomic/thread_local_var.rb
@@ -34,6 +34,7 @@ module Concurrent
   #   @see https://docs.oracle.com/javase/7/docs/api/java/lang/ThreadLocal.html Java ThreadLocal
   class AbstractThreadLocalVar
 
+    # @api private
     NIL_SENTINEL = Object.new
     private_constant :NIL_SENTINEL
 

--- a/lib/concurrent/atomic/thread_local_var.rb
+++ b/lib/concurrent/atomic/thread_local_var.rb
@@ -36,7 +36,7 @@ module Concurrent
   # @!visibility private
   class AbstractThreadLocalVar
 
-    # @api private
+    # @!visibility private
     NIL_SENTINEL = Object.new
     private_constant :NIL_SENTINEL
 

--- a/lib/concurrent/atomic/thread_local_var/weak_key_map.rb
+++ b/lib/concurrent/atomic/thread_local_var/weak_key_map.rb
@@ -21,7 +21,7 @@
 
 module Concurrent
 
-  # @api private
+  # @!visibility private
   class AbstractThreadLocalVar
 
     begin

--- a/lib/concurrent/atomic/thread_local_var/weak_key_map.rb
+++ b/lib/concurrent/atomic/thread_local_var/weak_key_map.rb
@@ -21,6 +21,7 @@
 
 module Concurrent
 
+  # @api private
   class AbstractThreadLocalVar
 
     begin

--- a/lib/concurrent/atomic_reference/direct_update.rb
+++ b/lib/concurrent/atomic_reference/direct_update.rb
@@ -3,6 +3,7 @@ require 'concurrent/atomic_reference/concurrent_update_error'
 module Concurrent
 
   # Define update methods that use direct paths
+  # @api private
   module AtomicDirectUpdate
 
     # @!macro [attach] atomic_reference_method_update

--- a/lib/concurrent/atomic_reference/direct_update.rb
+++ b/lib/concurrent/atomic_reference/direct_update.rb
@@ -3,7 +3,9 @@ require 'concurrent/atomic_reference/concurrent_update_error'
 module Concurrent
 
   # Define update methods that use direct paths
-  # @api private
+  #
+  # @!visibility private
+  # @!macro internal_implementation_note
   module AtomicDirectUpdate
 
     # @!macro [attach] atomic_reference_method_update

--- a/lib/concurrent/atomic_reference/jruby.rb
+++ b/lib/concurrent/atomic_reference/jruby.rb
@@ -6,6 +6,7 @@ if defined?(Concurrent::JavaAtomicReference)
   module Concurrent
 
     # @!macro atomic_reference
+    # @api private
     class JavaAtomicReference
       include Concurrent::AtomicDirectUpdate
     end

--- a/lib/concurrent/atomic_reference/jruby.rb
+++ b/lib/concurrent/atomic_reference/jruby.rb
@@ -6,7 +6,9 @@ if defined?(Concurrent::JavaAtomicReference)
   module Concurrent
 
     # @!macro atomic_reference
-    # @api private
+    #
+    # @!visibility private
+    # @!macro internal_implementation_note
     class JavaAtomicReference
       include Concurrent::AtomicDirectUpdate
     end

--- a/lib/concurrent/atomic_reference/mutex_atomic.rb
+++ b/lib/concurrent/atomic_reference/mutex_atomic.rb
@@ -5,46 +5,32 @@ require 'concurrent/atomic_reference/numeric_cas_wrapper'
 module Concurrent
 
   # @!macro atomic_reference
-  # @api private
+  #
+  # @!visibility private
+  # @!macro internal_implementation_note
   class MutexAtomicReference
     include Concurrent::AtomicDirectUpdate
     include Concurrent::AtomicNumericCompareAndSetWrapper
 
-    # @!macro [attach] atomic_reference_method_initialize
+    # @!macro atomic_reference_method_initialize
     def initialize(value = nil)
       @mutex = Mutex.new
       @value = value
     end
 
-    # @!macro [attach] atomic_reference_method_get
-    #
-    #   Gets the current value.
-    #
-    #   @return [Object] the current value
+    # @!macro atomic_reference_method_get
     def get
       @mutex.synchronize { @value }
     end
     alias_method :value, :get
 
-    # @!macro [attach] atomic_reference_method_set
-    #
-    #   Sets to the given value.
-    #
-    #   @param [Object] new_value the new value
-    #
-    #   @return [Object] the new value
+    # @!macro atomic_reference_method_set
     def set(new_value)
       @mutex.synchronize { @value = new_value }
     end
     alias_method :value=, :set
 
-    # @!macro [attach] atomic_reference_method_get_and_set
-    #
-    #   Atomically sets to the given value and returns the old value.
-    #
-    #   @param [Object] new_value the new value
-    #
-    #   @return [Object] the old value
+    # @!macro atomic_reference_method_get_and_set
     def get_and_set(new_value)
       @mutex.synchronize do
         old_value = @value
@@ -54,17 +40,8 @@ module Concurrent
     end
     alias_method :swap, :get_and_set
 
-    # @!macro [attach] atomic_reference_method_compare_and_set
-    #
-    #   Atomically sets the value to the given updated value if
-    #   the current value == the expected value.
-    #
-    #   @param [Object] old_value the expected value
-    #   @param [Object] new_value the new value
-    #
-    #   @return [Boolean] `true` if successful. A `false` return indicates
-    #   that the actual value was not equal to the expected value.
-    def _compare_and_set(old_value, new_value) #:nodoc:
+    # @!macro atomic_reference_method_compare_and_set
+    def _compare_and_set(old_value, new_value)
       return false unless @mutex.try_lock
       begin
         return false unless @value.equal? old_value

--- a/lib/concurrent/atomic_reference/mutex_atomic.rb
+++ b/lib/concurrent/atomic_reference/mutex_atomic.rb
@@ -5,6 +5,7 @@ require 'concurrent/atomic_reference/numeric_cas_wrapper'
 module Concurrent
 
   # @!macro atomic_reference
+  # @api private
   class MutexAtomicReference
     include Concurrent::AtomicDirectUpdate
     include Concurrent::AtomicNumericCompareAndSetWrapper

--- a/lib/concurrent/atomic_reference/numeric_cas_wrapper.rb
+++ b/lib/concurrent/atomic_reference/numeric_cas_wrapper.rb
@@ -1,6 +1,7 @@
 module Concurrent
 
   # Special "compare and set" handling of numeric values.
+  # @api private
   module AtomicNumericCompareAndSetWrapper
 
     # @!macro atomic_reference_method_compare_and_set

--- a/lib/concurrent/atomic_reference/numeric_cas_wrapper.rb
+++ b/lib/concurrent/atomic_reference/numeric_cas_wrapper.rb
@@ -1,7 +1,9 @@
 module Concurrent
 
   # Special "compare and set" handling of numeric values.
-  # @api private
+  #
+  # @!visibility private
+  # @!macro internal_implementation_note
   module AtomicNumericCompareAndSetWrapper
 
     # @!macro atomic_reference_method_compare_and_set

--- a/lib/concurrent/atomic_reference/rbx.rb
+++ b/lib/concurrent/atomic_reference/rbx.rb
@@ -7,6 +7,7 @@ module Concurrent
   #
   # @note Extends `Rubinius::AtomicReference` version adding aliases
   #   and numeric logic.
+  # @api private
   class RbxAtomicReference < Rubinius::AtomicReference
     alias _compare_and_set compare_and_set
     include Concurrent::AtomicDirectUpdate

--- a/lib/concurrent/atomic_reference/rbx.rb
+++ b/lib/concurrent/atomic_reference/rbx.rb
@@ -7,7 +7,9 @@ module Concurrent
   #
   # @note Extends `Rubinius::AtomicReference` version adding aliases
   #   and numeric logic.
-  # @api private
+  #
+  # @!visibility private
+  # @!macro internal_implementation_note
   class RbxAtomicReference < Rubinius::AtomicReference
     alias _compare_and_set compare_and_set
     include Concurrent::AtomicDirectUpdate

--- a/lib/concurrent/atomic_reference/ruby.rb
+++ b/lib/concurrent/atomic_reference/ruby.rb
@@ -6,7 +6,9 @@ if defined? Concurrent::CAtomicReference
   module Concurrent
 
     # @!macro atomic_reference
-    # @api private
+    #
+    # @!visibility private
+    # @!macro internal_implementation_note
     class CAtomicReference
       include Concurrent::AtomicDirectUpdate
       include Concurrent::AtomicNumericCompareAndSetWrapper

--- a/lib/concurrent/atomic_reference/ruby.rb
+++ b/lib/concurrent/atomic_reference/ruby.rb
@@ -6,6 +6,7 @@ if defined? Concurrent::CAtomicReference
   module Concurrent
 
     # @!macro atomic_reference
+    # @api private
     class CAtomicReference
       include Concurrent::AtomicDirectUpdate
       include Concurrent::AtomicNumericCompareAndSetWrapper

--- a/lib/concurrent/atomics.rb
+++ b/lib/concurrent/atomics.rb
@@ -58,7 +58,7 @@
 #       @param [Object] new_value the new value
 #       @return [Object] the old value
 #   
-#   @!method _compare_and_set
+#   @!method compare_and_set
 #     @!macro [new] atomic_reference_method_compare_and_set
 #
 #       Atomically sets the value to the given updated value if
@@ -69,8 +69,6 @@
 #
 #       @return [Boolean] `true` if successful. A `false` return indicates
 #       that the actual value was not equal to the expected value.
-#
-#       @api private
 
 require 'concurrent/atomic/atomic_reference'
 require 'concurrent/atomic/atomic_boolean'

--- a/lib/concurrent/atomics.rb
+++ b/lib/concurrent/atomics.rb
@@ -36,6 +36,41 @@
 #
 #   @see http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/AtomicReference.html
 #   @see http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/package-summary.html
+#
+#   @!method initialize
+#     @!macro [new] atomic_reference_method_initialize
+#       @param [Object] value The initial value.
+#   
+#   @!method get
+#     @!macro [new] atomic_reference_method_get
+#       Gets the current value.
+#       @return [Object] the current value
+#   
+#   @!method set
+#     @!macro [new] atomic_reference_method_set
+#       Sets to the given value.
+#       @param [Object] new_value the new value
+#       @return [Object] the new value
+#   
+#   @!method get_and_set
+#     @!macro [new] atomic_reference_method_get_and_set
+#       Atomically sets to the given value and returns the old value.
+#       @param [Object] new_value the new value
+#       @return [Object] the old value
+#   
+#   @!method _compare_and_set
+#     @!macro [new] atomic_reference_method_compare_and_set
+#
+#       Atomically sets the value to the given updated value if
+#       the current value == the expected value.
+#
+#       @param [Object] old_value the expected value
+#       @param [Object] new_value the new value
+#
+#       @return [Boolean] `true` if successful. A `false` return indicates
+#       that the actual value was not equal to the expected value.
+#
+#       @api private
 
 require 'concurrent/atomic/atomic_reference'
 require 'concurrent/atomic/atomic_boolean'

--- a/lib/concurrent/channel/blocking_ring_buffer.rb
+++ b/lib/concurrent/channel/blocking_ring_buffer.rb
@@ -3,6 +3,8 @@ require 'concurrent/synchronization'
 module Concurrent
   module Channel
 
+    # @api Channel
+    # @!macro edge_warning
     class BlockingRingBuffer < Synchronization::Object
 
       def initialize(capacity)

--- a/lib/concurrent/channel/buffered_channel.rb
+++ b/lib/concurrent/channel/buffered_channel.rb
@@ -3,6 +3,8 @@ require 'concurrent/channel/waitable_list'
 module Concurrent
   module Channel
 
+    # @api Channel
+    # @!macro edge_warning
     class BufferedChannel
 
       def initialize(size)

--- a/lib/concurrent/channel/channel.rb
+++ b/lib/concurrent/channel/channel.rb
@@ -1,6 +1,9 @@
 require 'concurrent/ivar'
 
 module Concurrent
+  
+  # @api Channel
+  # @!macro edge_warning
   module Channel
 
     Probe = IVar

--- a/lib/concurrent/channel/ring_buffer.rb
+++ b/lib/concurrent/channel/ring_buffer.rb
@@ -2,6 +2,9 @@ module Concurrent
   module Channel
 
     # non-thread safe buffer
+    #
+    # @api Channel
+    # @!macro edge_warning
     class RingBuffer
 
       def initialize(capacity)

--- a/lib/concurrent/channel/unbuffered_channel.rb
+++ b/lib/concurrent/channel/unbuffered_channel.rb
@@ -3,6 +3,8 @@ require 'concurrent/channel/waitable_list'
 module Concurrent
   module Channel
 
+    # @api Channel
+    # @!macro edge_warning
     class UnbufferedChannel
 
       def initialize

--- a/lib/concurrent/channel/waitable_list.rb
+++ b/lib/concurrent/channel/waitable_list.rb
@@ -3,6 +3,8 @@ require 'concurrent/synchronization'
 module Concurrent
   module Channel
 
+    # @api Channel
+    # @!macro edge_warning
     class WaitableList < Synchronization::Object
 
       def initialize

--- a/lib/concurrent/collection/copy_on_notify_observer_set.rb
+++ b/lib/concurrent/collection/copy_on_notify_observer_set.rb
@@ -7,6 +7,8 @@ module Concurrent
     # observers are added and removed from a thread safe collection; every time
     # a notification is required the internal data structure is copied to
     # prevent concurrency issues
+    # 
+    # @api private
     class CopyOnNotifyObserverSet < Synchronization::Object
 
       def initialize

--- a/lib/concurrent/collection/copy_on_write_observer_set.rb
+++ b/lib/concurrent/collection/copy_on_write_observer_set.rb
@@ -6,6 +6,8 @@ module Concurrent
     # A thread safe observer set implemented using copy-on-write approach:
     # every time an observer is added or removed the whole internal data structure is
     # duplicated and replaced with a new one.
+    # 
+    # @api private
     class CopyOnWriteObserverSet < Synchronization::Object
 
       def initialize

--- a/lib/concurrent/collection/priority_queue.rb
+++ b/lib/concurrent/collection/priority_queue.rb
@@ -31,6 +31,8 @@ module Concurrent
     #   @see http://algs4.cs.princeton.edu/24pq/MaxPQ.java.html
     #
     #   @see http://docs.oracle.com/javase/7/docs/api/java/util/PriorityQueue.html
+    # 
+    # @api private
     class MutexPriorityQueue
 
       # @!macro [attach] priority_queue_method_initialize
@@ -223,6 +225,8 @@ module Concurrent
     if Concurrent.on_jruby?
 
       # @!macro priority_queue
+      # 
+      # @api private
       class JavaPriorityQueue
 
         # @!macro priority_queue_method_initialize
@@ -304,6 +308,8 @@ module Concurrent
     private_constant :PriorityQueueImplementation
 
     # @!macro priority_queue
+    # 
+    # @api private
     class PriorityQueue < PriorityQueueImplementation
 
       alias_method :has_priority?, :include?

--- a/lib/concurrent/collection/priority_queue.rb
+++ b/lib/concurrent/collection/priority_queue.rb
@@ -32,7 +32,8 @@ module Concurrent
     #
     #   @see http://docs.oracle.com/javase/7/docs/api/java/util/PriorityQueue.html
     # 
-    # @api private
+    # @!visibility private
+    # @!macro internal_implementation_note
     class MutexPriorityQueue
 
       # @!macro [attach] priority_queue_method_initialize
@@ -226,7 +227,8 @@ module Concurrent
 
       # @!macro priority_queue
       # 
-      # @api private
+      # @!visibility private
+      # @!macro internal_implementation_note
       class JavaPriorityQueue
 
         # @!macro priority_queue_method_initialize
@@ -299,6 +301,8 @@ module Concurrent
       end
     end
 
+    # @!visibility private
+    # @!macro internal_implementation_note
     PriorityQueueImplementation = case
                                   when Concurrent.on_jruby?
                                     JavaPriorityQueue
@@ -309,7 +313,7 @@ module Concurrent
 
     # @!macro priority_queue
     # 
-    # @api private
+    # @!visibility private
     class PriorityQueue < PriorityQueueImplementation
 
       alias_method :has_priority?, :include?

--- a/lib/concurrent/concern/deprecation.rb
+++ b/lib/concurrent/concern/deprecation.rb
@@ -3,7 +3,8 @@ require 'concurrent/concern/logging'
 module Concurrent
   module Concern
 
-    # @api private
+    # @!visibility private
+    # @!macro internal_implementation_note
     module Deprecation
       # TODO require additional parameter: a version. Display when it'll be removed based on that. Error if not removed.
       include Concern::Logging

--- a/lib/concurrent/concern/deprecation.rb
+++ b/lib/concurrent/concern/deprecation.rb
@@ -3,6 +3,7 @@ require 'concurrent/concern/logging'
 module Concurrent
   module Concern
 
+    # @api private
     module Deprecation
       # TODO require additional parameter: a version. Display when it'll be removed based on that. Error if not removed.
       include Concern::Logging

--- a/lib/concurrent/concern/dereferenceable.rb
+++ b/lib/concurrent/concern/dereferenceable.rb
@@ -8,6 +8,8 @@ module Concurrent
     # `Dereferenceable` mixin module.
     #
     # @!macro copy_options
+    #
+    # @api private
     module Dereferenceable
 
       # Return the value this object represents after applying the options specified

--- a/lib/concurrent/concern/dereferenceable.rb
+++ b/lib/concurrent/concern/dereferenceable.rb
@@ -8,8 +8,6 @@ module Concurrent
     # `Dereferenceable` mixin module.
     #
     # @!macro copy_options
-    #
-    # @api private
     module Dereferenceable
 
       # Return the value this object represents after applying the options specified

--- a/lib/concurrent/concern/logging.rb
+++ b/lib/concurrent/concern/logging.rb
@@ -4,6 +4,8 @@ module Concurrent
   module Concern
 
     # Include where logging is needed
+    #
+    # @api private
     module Logging
       include Logger::Severity
 

--- a/lib/concurrent/concern/logging.rb
+++ b/lib/concurrent/concern/logging.rb
@@ -5,7 +5,7 @@ module Concurrent
 
     # Include where logging is needed
     #
-    # @api private
+    # @!visibility private
     module Logging
       include Logger::Severity
 

--- a/lib/concurrent/concern/obligation.rb
+++ b/lib/concurrent/concern/obligation.rb
@@ -8,7 +8,6 @@ require 'concurrent/concern/deprecation'
 module Concurrent
   module Concern
 
-    # @api private
     module Obligation
       include Concern::Dereferenceable
       include Concern::Deprecation

--- a/lib/concurrent/concern/obligation.rb
+++ b/lib/concurrent/concern/obligation.rb
@@ -8,6 +8,7 @@ require 'concurrent/concern/deprecation'
 module Concurrent
   module Concern
 
+    # @api private
     module Obligation
       include Concern::Dereferenceable
       include Concern::Deprecation

--- a/lib/concurrent/concern/observable.rb
+++ b/lib/concurrent/concern/observable.rb
@@ -47,6 +47,8 @@ module Concurrent
     # `obs` is wrong because the variable `@count` can be accessed by different
     # threads at the same time, so it should be synchronized (using either a Mutex
     # or an AtomicFixum)
+    #
+    # @api private
     module Observable
 
       # @return [Object] the added observer

--- a/lib/concurrent/concern/observable.rb
+++ b/lib/concurrent/concern/observable.rb
@@ -47,8 +47,6 @@ module Concurrent
     # `obs` is wrong because the variable `@count` can be accessed by different
     # threads at the same time, so it should be synchronized (using either a Mutex
     # or an AtomicFixum)
-    #
-    # @api private
     module Observable
 
       # @return [Object] the added observer

--- a/lib/concurrent/delay.rb
+++ b/lib/concurrent/delay.rb
@@ -53,15 +53,7 @@ module Concurrent
 
     # Create a new `Delay` in the `:pending` state.
     #
-    # @!macro [attach] executor_and_deref_options
-    #  
-    #   @param [Hash] opts the options used to define the behavior at update and deref
-    #     and to specify the executor on which to perform actions
-    #   @option opts [Executor] :executor when set use the given `Executor` instance.
-    #     Three special values are also supported: `:task` returns the global task pool,
-    #     `:operation` returns the global operation pool, and `:immediate` returns a new
-    #     `ImmediateExecutor` object.
-    #   @!macro deref_options
+    # @!macro executor_and_deref_options
     #
     # @yield the delayed operation to perform
     #

--- a/lib/concurrent/edge.rb
+++ b/lib/concurrent/edge.rb
@@ -18,6 +18,12 @@ module Concurrent
   # This file should *never* be used as a global `require` for all files within
   # the edge gem. Because these features are experimental users should always
   # explicitly require only what they need.
+  #
+  # @!macro [attach] edge_warning
+  #   @api Edge
+  #   @note **Edge Feature:** Edge features are under active development and may
+  #     change frequently. They are not expected to keep backward compatibility.
+  #     They may also lack tests and documentation. Use with caution.
   module Edge
 
   end

--- a/lib/concurrent/edge/atomic_markable_reference.rb
+++ b/lib/concurrent/edge/atomic_markable_reference.rb
@@ -1,7 +1,16 @@
 module Concurrent
   module Edge
-    # @!macro atomic_markable_reference
+
+    # @!macro [attach] atomic_markable_reference
+    #
+    #   An atomic reference which maintains an object reference along with a mark bit
+    #   that can be updated atomically.
+    #
+    #   @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/atomic/AtomicMarkableReference.html java.util.concurrent.atomic.AtomicMarkableReference
+    #
+    #   @api Edge
     class AtomicMarkableReference < ::Concurrent::Synchronization::Object
+
       # @!macro [attach] atomic_markable_reference_method_initialize
       def initialize(value = nil, mark = false)
         super()
@@ -16,9 +25,9 @@ module Concurrent
       #     - the current value == the expected value &&
       #     - the current mark == the expected mark
       #
-      #   @param [Object] old_val the expected value
+      #   @param [Object] expected_val the expected value
       #   @param [Object] new_val the new value
-      #   @param [Boolean] old_mark the expected mark
+      #   @param [Boolean] expected_mark the expected mark
       #   @param [Boolean] new_mark the new mark
       #
       #   @return [Boolean] `true` if successful. A `false` return indicates

--- a/lib/concurrent/edge/future.rb
+++ b/lib/concurrent/edge/future.rb
@@ -4,19 +4,20 @@ require 'concurrent/edge/lock_free_stack'
 
 # @note different name just not to collide for now
 module Concurrent
-
-  # Provides edge features, which will be added to or replace features in main gem.
-  #
-  # Contains new unified implementation of Futures and Promises which combines Features of previous `Future`,
-  # `Promise`, `IVar`, `Event`, `Probe`, `dataflow`, `Delay`, `TimerTask` into single framework. It uses extensively
-  # new synchronization layer to make all the paths lock-free with exception of blocking threads on `#wait`.
-  # It offers better performance and does not block threads (exception being `#wait` and similar methods where it's
-  # intended).
-  #
-  # ## Examples
-  # {include:file:examples/edge_futures.out.rb}.
   module Edge
 
+    # Provides edge features, which will be added to or replace features in main gem.
+    #
+    # Contains new unified implementation of Futures and Promises which combines Features of previous `Future`,
+    # `Promise`, `IVar`, `Event`, `Probe`, `dataflow`, `Delay`, `TimerTask` into single framework. It uses extensively
+    # new synchronization layer to make all the paths lock-free with exception of blocking threads on `#wait`.
+    # It offers better performance and does not block threads (exception being #wait and similar methods where it's
+    # intended).
+    #
+    # ## Examples
+    # {include:file:examples/edge_futures.out.rb}
+    #
+    # @!macro edge_warning
     module FutureShortcuts
       # User is responsible for completing the event once by {Edge::CompletableEvent#complete}
       # @return [CompletableEvent]

--- a/lib/concurrent/exchanger.rb
+++ b/lib/concurrent/exchanger.rb
@@ -12,6 +12,8 @@ module Concurrent
   # @see Concurrent::MVar
   # @see Concurrent::Concern::Dereferenceable
   # @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Exchanger.html java.util.concurrent.Exchanger
+  #
+  # @!macro edge_warning
   class Exchanger
 
     EMPTY = Object.new

--- a/lib/concurrent/executor/cached_thread_pool.rb
+++ b/lib/concurrent/executor/cached_thread_pool.rb
@@ -39,6 +39,22 @@ module Concurrent
   #   @see Concurrent::JavaCachedThreadPool
   #
   # @!macro thread_pool_options
+  #
+  # @!macro thread_pool_executor_public_api
   class CachedThreadPool < CachedThreadPoolImplementation
+
+    # @!macro [new] cached_thread_pool_method_initialize
+    #
+    #   Create a new thread pool.
+    #
+    #   @param [Hash] opts the options defining pool behavior.
+    #   @option opts [Symbol] :fallback_policy (`:abort`) the fallback policy
+    #
+    #   @raise [ArgumentError] if `fallback_policy` is not a known policy
+    #
+    #   @see http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html#newCachedThreadPool--
+
+    # @!method initialize(opts = {})
+    #   @!macro cached_thread_pool_method_initialize
   end
 end

--- a/lib/concurrent/executor/cached_thread_pool.rb
+++ b/lib/concurrent/executor/cached_thread_pool.rb
@@ -15,6 +15,7 @@ module Concurrent
   private_constant :CachedThreadPoolImplementation
 
   # @!macro [attach] cached_thread_pool
+  #
   #   A thread pool that dynamically grows and shrinks to fit the current workload.
   #   New threads are created as needed, existing threads are reused, and threads
   #   that remain idle for too long are killed and removed from the pool. These
@@ -35,11 +36,7 @@ module Concurrent
   #
   #   The API and behavior of this class are based on Java's `CachedThreadPool`
   #
-  #   @see Concurrent::RubyCachedThreadPool
-  #   @see Concurrent::JavaCachedThreadPool
-  #
   # @!macro thread_pool_options
-  #
   # @!macro thread_pool_executor_public_api
   class CachedThreadPool < CachedThreadPoolImplementation
 

--- a/lib/concurrent/executor/executor.rb
+++ b/lib/concurrent/executor/executor.rb
@@ -3,6 +3,7 @@ require 'concurrent/concern/deprecation'
 
 module Concurrent
 
+  # @api private
   module Executor
     extend Concern::Deprecation
 

--- a/lib/concurrent/executor/executor.rb
+++ b/lib/concurrent/executor/executor.rb
@@ -3,7 +3,7 @@ require 'concurrent/concern/deprecation'
 
 module Concurrent
 
-  # @api private
+  # @!visibility private
   module Executor
     extend Concern::Deprecation
 

--- a/lib/concurrent/executor/executor_service.rb
+++ b/lib/concurrent/executor/executor_service.rb
@@ -7,57 +7,88 @@ require 'concurrent/utility/at_exit'
 
 module Concurrent
 
-  # @api private
+  # @!macro [new] executor_service_method_post
+  #
+  #   Submit a task to the executor for asynchronous processing.
+  #
+  #   @param [Array] args zero or more arguments to be passed to the task
+  #
+  #   @yield the asynchronous task to perform
+  #
+  #   @return [Boolean] `true` if the task is queued, `false` if the executor
+  #     is not running
+  #
+  #   @raise [ArgumentError] if no task is given
+
+  # @!macro [new] executor_service_method_left_shift
+  #
+  #   Submit a task to the executor for asynchronous processing.
+  #
+  #   @param [Proc] task the asynchronous task to perform
+  #
+  #   @return [self] returns itself
+
+  # @!macro [new] executor_service_method_can_overflow_question
+  #
+  #   Does the task queue have a maximum size?
+  #
+  #   @return [Boolean] True if the task queue has a maximum size else false.
+
+  # @!macro [new] executor_service_method_serialized_question
+  #
+  #   Does this executor guarantee serialization of its operations?
+  #
+  #   @return [Boolean] True if the executor guarantees that all operations
+  #     will be post in the order they are received and no two operations may
+  #     occur simultaneously. Else false.
+
+
+
+
+
+  # @!macro [new] executor_service_public_api
+  #
+  #   @!method post(*args, &task)
+  #     @!macro executor_service_method_post
+  #
+  #   @!method <<(task)
+  #     @!macro executor_service_method_left_shift
+  #
+  #   @!method can_overflow?
+  #     @!macro executor_service_method_can_overflow_question
+  #
+  #   @!method serialized?
+  #     @!macro executor_service_method_serialized_question
+
+
+
+
+
+  # @!macro executor_service_public_api
+  # @!visibility private
   module ExecutorService
     include Concern::Logging
     include Concern::Deprecation
 
-    # @!macro [attach] executor_service_method_post
-    #
-    #   Submit a task to the executor for asynchronous processing.
-    #
-    #   @param [Array] args zero or more arguments to be passed to the task
-    #
-    #   @yield the asynchronous task to perform
-    #
-    #   @return [Boolean] `true` if the task is queued, `false` if the executor
-    #     is not running
-    #
-    #   @raise [ArgumentError] if no task is given
+    # @!macro executor_service_method_post
     def post(*args, &task)
       raise NotImplementedError
     end
 
-    # @!macro [attach] executor_service_method_left_shift
-    #
-    #   Submit a task to the executor for asynchronous processing.
-    #
-    #   @param [Proc] task the asynchronous task to perform
-    #
-    #   @return [self] returns itself
+    # @!macro executor_service_method_left_shift
     def <<(task)
       post(&task)
       self
     end
 
-    # @!macro [attach] executor_service_method_can_overflow_question
-    #
-    #   Does the task queue have a maximum size?
-    #
-    #   @return [Boolean] True if the task queue has a maximum size else false.
+    # @!macro executor_service_method_can_overflow_question
     #
     # @note Always returns `false`
     def can_overflow?
       false
     end
 
-    # @!macro [attach] executor_service_method_serialized_question
-    #
-    #   Does this executor guarantee serialization of its operations?
-    #
-    #   @return [Boolean] True if the executor guarantees that all operations
-    #     will be post in the order they are received and no two operations may
-    #     occur simultaneously. Else false.
+    # @!macro executor_service_method_serialized_question
     #
     # @note Always returns `false`
     def serialized?
@@ -83,7 +114,7 @@ module Concurrent
   #   foo.is_a? Concurrent::SerialExecutor  #=> true
   #   foo.serialized?                       #=> true
   #
-  # @api private
+  # @!visibility private
   module SerialExecutorService
     include ExecutorService
 
@@ -95,6 +126,110 @@ module Concurrent
     end
   end
 
+
+
+
+
+  # @!macro [new] executor_service_attr_reader_fallback_policy
+  #   @return [Symbol] The fallback policy in effect. Either `:abort`, `:discard`, or `:caller_runs`.
+
+  # @!macro [new] executor_service_method_shutdown
+  #
+  #   Begin an orderly shutdown. Tasks already in the queue will be executed,
+  #   but no new tasks will be accepted. Has no additional effect if the
+  #   thread pool is not running.
+
+  # @!macro [new] executor_service_method_kill
+  #
+  #   Begin an immediate shutdown. In-progress tasks will be allowed to
+  #   complete but enqueued tasks will be dismissed and no new tasks
+  #   will be accepted. Has no additional effect if the thread pool is
+  #   not running.
+
+  # @!macro [new] executor_service_method_wait_for_termination
+  #
+  #   Block until executor shutdown is complete or until `timeout` seconds have
+  #   passed.
+  #
+  #   @note Does not initiate shutdown or termination. Either `shutdown` or `kill`
+  #     must be called before this method (or on another thread).
+  #
+  #   @param [Integer] timeout the maximum number of seconds to wait for shutdown to complete
+  #
+  #   @return [Boolean] `true` if shutdown complete or false on `timeout`
+
+  # @!macro [new] executor_service_method_running_question
+  #
+  #   Is the executor running?
+  #
+  #   @return [Boolean] `true` when running, `false` when shutting down or shutdown
+
+  # @!macro [new] executor_service_method_shuttingdown_question
+  #
+  #   Is the executor shuttingdown?
+  #
+  #   @return [Boolean] `true` when not running and not shutdown, else `false`
+
+  # @!macro [new] executor_service_method_shutdown_question
+  #
+  #   Is the executor shutdown?
+  #
+  #   @return [Boolean] `true` when shutdown, `false` when shutting down or running
+
+  # @!macro [new] executor_service_method_auto_terminate_question
+  #
+  #   Is the executor auto-terminate when the application exits?
+  #
+  #   @return [Boolean] `true` when auto-termination is enabled else `false`.
+
+  # @!macro [new] executor_service_method_auto_terminate_setter
+  #
+  #   Set the auto-terminate behavior for this executor.
+  #
+  #   @param [Boolean] value The new auto-terminate value to set for this executor.
+  #
+  #   @return [Boolean] `true` when auto-termination is enabled else `false`.
+
+
+
+
+
+  # @!macro [new] abstract_executor_service_public_api
+  #
+  #   @!macro executor_service_public_api
+  #
+  #   @!attribute [r] fallback_policy
+  #     @!macro executor_service_attr_reader_fallback_policy
+  #
+  #   @!method shutdown
+  #     @!macro executor_service_method_shutdown
+  #
+  #   @!method kill
+  #     @!macro executor_service_method_kill
+  #
+  #   @!method wait_for_termination(timeout = nil)
+  #     @!macro executor_service_method_wait_for_termination
+  #
+  #   @!method running?
+  #     @!macro executor_service_method_running_question
+  #
+  #   @!method shuttingdown?
+  #     @!macro executor_service_method_shuttingdown_question
+  #
+  #   @!method shutdown?
+  #     @!macro executor_service_method_shutdown_question
+  #
+  #   @!method auto_terminate?
+  #     @!macro executor_service_method_auto_terminate_question
+  #
+  #   @!method auto_terminate=(value)
+  #     @!macro executor_service_method_auto_terminate_setter
+
+
+
+
+
+  # @!macro abstract_executor_service_public_api
   # @!visibility private
   class AbstractExecutorService < Synchronization::Object
     include ExecutorService
@@ -103,7 +238,6 @@ module Concurrent
     FALLBACK_POLICIES = [:abort, :discard, :caller_runs].freeze
 
     # @!macro [attach] executor_service_attr_reader_fallback_policy
-    #   @return [Symbol] The fallback policy in effect. Either `:abort`, `:discard`, or `:caller_runs`.
     attr_reader :fallback_policy
 
     # Create a new thread pool.
@@ -113,82 +247,41 @@ module Concurrent
     end
 
     # @!macro [attach] executor_service_method_shutdown
-    #
-    #   Begin an orderly shutdown. Tasks already in the queue will be executed,
-    #   but no new tasks will be accepted. Has no additional effect if the
-    #   thread pool is not running.
     def shutdown
       raise NotImplementedError
     end
 
     # @!macro [attach] executor_service_method_kill
-    #
-    #   Begin an immediate shutdown. In-progress tasks will be allowed to
-    #   complete but enqueued tasks will be dismissed and no new tasks
-    #   will be accepted. Has no additional effect if the thread pool is
-    #   not running.
     def kill
       raise NotImplementedError
     end
 
     # @!macro [attach] executor_service_method_wait_for_termination
-    #
-    #   Block until executor shutdown is complete or until `timeout` seconds have
-    #   passed.
-    #
-    #   @note Does not initiate shutdown or termination. Either `shutdown` or `kill`
-    #     must be called before this method (or on another thread).
-    #
-    #   @param [Integer] timeout the maximum number of seconds to wait for shutdown to complete
-    #
-    #   @return [Boolean] `true` if shutdown complete or false on `timeout`
     def wait_for_termination(timeout = nil)
       raise NotImplementedError
     end
 
     # @!macro [attach] executor_service_method_running_question
-    #
-    #   Is the executor running?
-    #
-    #   @return [Boolean] `true` when running, `false` when shutting down or shutdown
     def running?
       synchronize { ns_running? }
     end
 
     # @!macro [attach] executor_service_method_shuttingdown_question
-    #
-    #   Is the executor shuttingdown?
-    #
-    #   @return [Boolean] `true` when not running and not shutdown, else `false`
     def shuttingdown?
       synchronize { ns_shuttingdown? }
     end
 
     # @!macro [attach] executor_service_method_shutdown_question
-    #
-    #   Is the executor shutdown?
-    #
-    #   @return [Boolean] `true` when shutdown, `false` when shutting down or running
     def shutdown?
       synchronize { ns_shutdown? }
     end
 
     # @!macro [attach] executor_service_method_auto_terminate_question
-    #
-    #   Is the executor auto-terminate when the application exits?
-    #
-    #   @return [Boolean] `true` when auto-termination is enabled else `false`.
     def auto_terminate?
       synchronize { ns_auto_terminate? }
     end
 
     # @!macro [attach] executor_service_method_auto_terminate_setter
-    #
-    #   Set the auto-terminate behavior for this executor.
-    #
-    #   @param [Boolean] value The new auto-terminate value to set for this executor.
-    #
-    #   @return [Boolean] `true` when auto-termination is enabled else `false`.
     def auto_terminate=(value)
       synchronize { self.ns_auto_terminate = value }
     end
@@ -265,7 +358,8 @@ module Concurrent
     end
   end
 
-  # @api private
+  # @!macro abstract_executor_service_public_api
+  # @!visibility private
   class RubyExecutorService < AbstractExecutorService
 
     def initialize(*args, &block)
@@ -333,7 +427,8 @@ module Concurrent
 
   if Concurrent.on_jruby?
 
-    # @api private
+    # @!macro abstract_executor_service_public_api
+    # @!visibility private
     class JavaExecutorService < AbstractExecutorService
       java_import 'java.lang.Runnable'
 

--- a/lib/concurrent/executor/executor_service.rb
+++ b/lib/concurrent/executor/executor_service.rb
@@ -95,15 +95,18 @@ module Concurrent
     end
   end
 
-  # @api private
+  # @!visibility private
   class AbstractExecutorService < Synchronization::Object
     include ExecutorService
 
     # The set of possible fallback policies that may be set at thread pool creation.
     FALLBACK_POLICIES = [:abort, :discard, :caller_runs].freeze
 
+    # @!macro [attach] executor_service_attr_reader_fallback_policy
+    #   @return [Symbol] The fallback policy in effect. Either `:abort`, `:discard`, or `:caller_runs`.
     attr_reader :fallback_policy
 
+    # Create a new thread pool.
     def initialize(*args, &block)
       super(&nil)
       synchronize { ns_initialize(*args, &block) }
@@ -170,10 +173,22 @@ module Concurrent
       synchronize { ns_shutdown? }
     end
 
+    # @!macro [attach] executor_service_method_auto_terminate_question
+    #
+    #   Is the executor auto-terminate when the application exits?
+    #
+    #   @return [Boolean] `true` when auto-termination is enabled else `false`.
     def auto_terminate?
       synchronize { ns_auto_terminate? }
     end
 
+    # @!macro [attach] executor_service_method_auto_terminate_setter
+    #
+    #   Set the auto-terminate behavior for this executor.
+    #
+    #   @param [Boolean] value The new auto-terminate value to set for this executor.
+    #
+    #   @return [Boolean] `true` when auto-termination is enabled else `false`.
     def auto_terminate=(value)
       synchronize { self.ns_auto_terminate = value }
     end

--- a/lib/concurrent/executor/executor_service.rb
+++ b/lib/concurrent/executor/executor_service.rb
@@ -7,6 +7,7 @@ require 'concurrent/utility/at_exit'
 
 module Concurrent
 
+  # @api private
   module ExecutorService
     include Concern::Logging
     include Concern::Deprecation
@@ -81,6 +82,8 @@ module Concurrent
   #   foo.is_a? Concurrent::ExecutorService #=> true
   #   foo.is_a? Concurrent::SerialExecutor  #=> true
   #   foo.serialized?                       #=> true
+  #
+  # @api private
   module SerialExecutorService
     include ExecutorService
 
@@ -92,6 +95,7 @@ module Concurrent
     end
   end
 
+  # @api private
   class AbstractExecutorService < Synchronization::Object
     include ExecutorService
 
@@ -246,6 +250,7 @@ module Concurrent
     end
   end
 
+  # @api private
   class RubyExecutorService < AbstractExecutorService
 
     def initialize(*args, &block)
@@ -313,6 +318,7 @@ module Concurrent
 
   if Concurrent.on_jruby?
 
+    # @api private
     class JavaExecutorService < AbstractExecutorService
       java_import 'java.lang.Runnable'
 

--- a/lib/concurrent/executor/fixed_thread_pool.rb
+++ b/lib/concurrent/executor/fixed_thread_pool.rb
@@ -14,6 +14,154 @@ module Concurrent
                                   end
   private_constant :FixedThreadPoolImplementation
 
+  # @!macro [new] thread_pool_executor_constant_default_max_pool_size
+  #   Default maximum number of threads that will be created in the pool.
+
+  # @!macro [new] thread_pool_executor_constant_default_min_pool_size
+  #   Default minimum number of threads that will be retained in the pool.
+
+  # @!macro [new] thread_pool_executor_constant_default_max_queue_size
+  #   Default maximum number of tasks that may be added to the task queue.
+
+  # @!macro [new] thread_pool_executor_constant_default_thread_timeout
+  #   Default maximum number of seconds a thread in the pool may remain idle
+  #   before being reclaimed.
+
+  # @!macro [new] thread_pool_executor_attr_reader_max_length
+  #   The maximum number of threads that may be created in the pool.
+  #   @return [Integer] The maximum number of threads that may be created in the pool.
+
+  # @!macro [new] thread_pool_executor_attr_reader_min_length
+  #   The minimum number of threads that may be retained in the pool.
+  #   @return [Integer] The minimum number of threads that may be retained in the pool.
+
+  # @!macro [new] thread_pool_executor_attr_reader_largest_length
+  #   The largest number of threads that have been created in the pool since construction.
+  #   @return [Integer] The largest number of threads that have been created in the pool since construction.
+
+  # @!macro [new] thread_pool_executor_attr_reader_scheduled_task_count
+  #   The number of tasks that have been scheduled for execution on the pool since construction.
+  #   @return [Integer] The number of tasks that have been scheduled for execution on the pool since construction.
+
+  # @!macro [new] thread_pool_executor_attr_reader_completed_task_count
+  #   The number of tasks that have been completed by the pool since construction.
+  #   @return [Integer] The number of tasks that have been completed by the pool since construction.
+
+  # @!macro [new] thread_pool_executor_attr_reader_idletime
+  #   The number of seconds that a thread may be idle before being reclaimed.
+  #   @return [Integer] The number of seconds that a thread may be idle before being reclaimed.
+
+  # @!macro [new] thread_pool_executor_attr_reader_max_queue
+  #   The maximum number of tasks that may be waiting in the work queue at any one time.
+  #   When the queue size reaches `max_queue` subsequent tasks will be rejected in
+  #   accordance with the configured `fallback_policy`.
+  #
+  #   @return [Integer] The maximum number of tasks that may be waiting in the work queue at any one time.
+  #     When the queue size reaches `max_queue` subsequent tasks will be rejected in
+  #     accordance with the configured `fallback_policy`.
+
+  # @!macro [new] thread_pool_executor_attr_reader_length
+  #   The number of threads currently in the pool.
+  #   @return [Integer] The number of threads currently in the pool.
+
+  # @!macro [new] thread_pool_executor_attr_reader_queue_length
+  #   The number of tasks in the queue awaiting execution.
+  #   @return [Integer] The number of tasks in the queue awaiting execution.
+
+  # @!macro [new] thread_pool_executor_attr_reader_remaining_capacity
+  #   Number of tasks that may be enqueued before reaching `max_queue` and rejecting
+  #   new tasks. A value of -1 indicates that the queue may grow without bound.
+  #
+  #   @return [Integer] Number of tasks that may be enqueued before reaching `max_queue` and rejecting
+  #     new tasks. A value of -1 indicates that the queue may grow without bound.
+
+
+
+
+
+  # @!macro [new] thread_pool_executor_public_api
+  #
+  #   @!attribute [r] fallback_policy
+  #     @!macro executor_service_attr_reader_fallback_policy
+  #
+  #   @!attribute [r] max_length
+  #     @!macro thread_pool_executor_attr_reader_max_length
+  #
+  #   @!attribute [r] min_length
+  #     @!macro thread_pool_executor_attr_reader_min_length
+  #
+  #   @!attribute [r] largest_length
+  #     @!macro thread_pool_executor_attr_reader_largest_length
+  #
+  #   @!attribute [r] scheduled_task_count
+  #     @!macro thread_pool_executor_attr_reader_scheduled_task_count
+  #
+  #   @!attribute [r] completed_task_count
+  #     @!macro thread_pool_executor_attr_reader_completed_task_count
+  #
+  #   @!attribute [r] idletime
+  #     @!macro thread_pool_executor_attr_reader_idletime
+  #
+  #   @!attribute [r] max_queue
+  #     @!macro thread_pool_executor_attr_reader_max_queue
+  #
+  #   @!attribute [r] length
+  #     @!macro thread_pool_executor_attr_reader_length
+  #
+  #   @!attribute [r] queue_length
+  #     @!macro thread_pool_executor_attr_reader_queue_length
+  #
+  #   @!attribute [r] remaining_capacity
+  #     @!macro thread_pool_executor_attr_reader_remaining_capacity
+  #
+  #   @!method can_overflow?
+  #     @!macro executor_service_method_can_overflow_question
+  #
+  #   @!method shutdown
+  #     @!macro executor_service_method_shutdown
+  #
+  #   @!method kill
+  #     @!macro executor_service_method_kill
+  #
+  #   @!method wait_for_termination(timeout = nil)
+  #     @!macro executor_service_method_wait_for_termination
+  #
+  #   @!method running?
+  #     @!macro executor_service_method_running_question
+  #
+  #   @!method shuttingdown?
+  #     @!macro executor_service_method_shuttingdown_question
+  #
+  #   @!method shutdown?
+  #     @!macro executor_service_method_shutdown_question
+  #
+  #   @!method auto_terminate?
+  #     @!macro executor_service_method_auto_terminate_question
+  #
+  #   @!method auto_terminate=(value)
+  #     @!macro executor_service_method_auto_terminate_setter
+
+
+
+
+
+  # @!macro [new] fixed_thread_pool_method_initialize
+  #
+  #   Create a new thread pool.
+  #
+  #   @param [Integer] num_threads the number of threads to allocate
+  #   @param [Hash] opts the options defining pool behavior.
+  #   @option opts [Symbol] :fallback_policy (`:abort`) the fallback policy
+  #
+  #   @raise [ArgumentError] if `num_threads` is less than or equal to zero
+  #   @raise [ArgumentError] if `fallback_policy` is not a known policy
+  #
+  #   @see http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html#newFixedThreadPool-int-
+
+
+
+
+
   # @!macro [attach] fixed_thread_pool
   #
   #   A thread pool with a set number of threads. The number of threads in the pool
@@ -25,6 +173,8 @@ module Concurrent
   #   The API and behavior of this class are based on Java's `FixedThreadPool`
   #
   # @!macro [attach] thread_pool_options
+  #
+  #   **Thread Pool Options**
   #
   #   Thread pools support several configuration options:
   #
@@ -78,6 +228,11 @@ module Concurrent
   #   @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Executors.html Java Executors class
   #   @see http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html Java ExecutorService interface
   #   @see http://ruby-doc.org//core-2.2.0/Kernel.html#method-i-at_exit Kernel#at_exit
+  #
+  # @!macro thread_pool_executor_public_api
   class FixedThreadPool < FixedThreadPoolImplementation
+
+    # @!method initialize(num_threads, opts = {})
+    #   @!macro fixed_thread_pool_method_initialize
   end
 end

--- a/lib/concurrent/executor/fixed_thread_pool.rb
+++ b/lib/concurrent/executor/fixed_thread_pool.rb
@@ -24,9 +24,6 @@ module Concurrent
   #
   #   The API and behavior of this class are based on Java's `FixedThreadPool`
   #
-  #   @see Concurrent::RubyFixedThreadPool
-  #   @see Concurrent::JavaFixedThreadPool
-  #
   # @!macro [attach] thread_pool_options
   #
   #   Thread pools support several configuration options:
@@ -76,12 +73,6 @@ module Concurrent
   #
   #   @note Failure to properly shutdown a thread pool can lead to unpredictable results.
   #     Please read *Shutting Down Thread Pools* for more information.
-  #
-  #   @note When running on the JVM (JRuby) this class will inherit from `JavaFixedThreadPool`.
-  #     On all other platforms it will inherit from `RubyFixedThreadPool`.
-  #
-  #   @see Concurrent::RubyFixedThreadPool
-  #   @see Concurrent::JavaFixedThreadPool
   #
   #   @see http://docs.oracle.com/javase/tutorial/essential/concurrency/pools.html Java Tutorials: Thread Pools
   #   @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Executors.html Java Executors class

--- a/lib/concurrent/executor/fixed_thread_pool.rb
+++ b/lib/concurrent/executor/fixed_thread_pool.rb
@@ -81,8 +81,7 @@ module Concurrent
 
   # @!macro [new] thread_pool_executor_public_api
   #
-  #   @!attribute [r] fallback_policy
-  #     @!macro executor_service_attr_reader_fallback_policy
+  #   @!macro abstract_executor_service_public_api
   #
   #   @!attribute [r] max_length
   #     @!macro thread_pool_executor_attr_reader_max_length
@@ -116,30 +115,6 @@ module Concurrent
   #
   #   @!method can_overflow?
   #     @!macro executor_service_method_can_overflow_question
-  #
-  #   @!method shutdown
-  #     @!macro executor_service_method_shutdown
-  #
-  #   @!method kill
-  #     @!macro executor_service_method_kill
-  #
-  #   @!method wait_for_termination(timeout = nil)
-  #     @!macro executor_service_method_wait_for_termination
-  #
-  #   @!method running?
-  #     @!macro executor_service_method_running_question
-  #
-  #   @!method shuttingdown?
-  #     @!macro executor_service_method_shuttingdown_question
-  #
-  #   @!method shutdown?
-  #     @!macro executor_service_method_shutdown_question
-  #
-  #   @!method auto_terminate?
-  #     @!macro executor_service_method_auto_terminate_question
-  #
-  #   @!method auto_terminate=(value)
-  #     @!macro executor_service_method_auto_terminate_setter
 
 
 

--- a/lib/concurrent/executor/java_cached_thread_pool.rb
+++ b/lib/concurrent/executor/java_cached_thread_pool.rb
@@ -6,6 +6,7 @@ if Concurrent.on_jruby?
 
     # @!macro cached_thread_pool
     # @!macro thread_pool_options
+    # @api private
     class JavaCachedThreadPool < JavaThreadPoolExecutor
 
       # Create a new thread pool.

--- a/lib/concurrent/executor/java_cached_thread_pool.rb
+++ b/lib/concurrent/executor/java_cached_thread_pool.rb
@@ -6,17 +6,11 @@ if Concurrent.on_jruby?
 
     # @!macro cached_thread_pool
     # @!macro thread_pool_options
-    # @api private
+    # @!macro thread_pool_executor_public_api
+    # @!visibility private
     class JavaCachedThreadPool < JavaThreadPoolExecutor
 
-      # Create a new thread pool.
-      #
-      # @param [Hash] opts the options defining pool behavior.
-      # @option opts [Symbol] :fallback_policy (`:abort`) the fallback policy
-      #
-      # @raise [ArgumentError] if `fallback_policy` is not a known policy
-      #
-      # @see http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html#newCachedThreadPool--
+      # @!macro cached_thread_pool_method_initialize
       def initialize(opts = {})
         defaults  = { idletime: DEFAULT_THREAD_IDLETIMEOUT }
         overrides = { min_threads:     0,

--- a/lib/concurrent/executor/java_fixed_thread_pool.rb
+++ b/lib/concurrent/executor/java_fixed_thread_pool.rb
@@ -6,6 +6,7 @@ if Concurrent.on_jruby?
 
     # @!macro fixed_thread_pool
     # @!macro thread_pool_options
+    # @api private
     class JavaFixedThreadPool < JavaThreadPoolExecutor
 
       # Create a new thread pool.

--- a/lib/concurrent/executor/java_fixed_thread_pool.rb
+++ b/lib/concurrent/executor/java_fixed_thread_pool.rb
@@ -6,18 +6,11 @@ if Concurrent.on_jruby?
 
     # @!macro fixed_thread_pool
     # @!macro thread_pool_options
-    # @api private
+    # @!macro thread_pool_executor_public_api
+    # @!visibility private
     class JavaFixedThreadPool < JavaThreadPoolExecutor
 
-      # Create a new thread pool.
-      #
-      # @param [Hash] opts the options defining pool behavior.
-      # @option opts [Symbol] :fallback_policy (`:abort`) the fallback policy
-      #
-      # @raise [ArgumentError] if `num_threads` is less than or equal to zero
-      # @raise [ArgumentError] if `fallback_policy` is not a known policy
-      #
-      # @see http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html#newFixedThreadPool-int-
+      # @!macro fixed_thread_pool_method_initialize
       def initialize(num_threads, opts = {})
         raise ArgumentError.new('number of threads must be greater than zero') if num_threads.to_i < 1
         defaults  = { max_queue:   DEFAULT_MAX_QUEUE_SIZE,

--- a/lib/concurrent/executor/java_single_thread_executor.rb
+++ b/lib/concurrent/executor/java_single_thread_executor.rb
@@ -5,6 +5,7 @@ if Concurrent.on_jruby?
 
     # @!macro single_thread_executor
     # @!macro thread_pool_options
+    # @api private
     class JavaSingleThreadExecutor < JavaExecutorService
       include SerialExecutorService
 

--- a/lib/concurrent/executor/java_single_thread_executor.rb
+++ b/lib/concurrent/executor/java_single_thread_executor.rb
@@ -1,23 +1,17 @@
 if Concurrent.on_jruby?
+
   require 'concurrent/executor/executor_service'
 
   module Concurrent
 
     # @!macro single_thread_executor
     # @!macro thread_pool_options
-    # @api private
+    # @!macro abstract_executor_service_public_api
+    # @!visibility private
     class JavaSingleThreadExecutor < JavaExecutorService
       include SerialExecutorService
 
-      # Create a new thread pool.
-      #
-      # @option opts [Symbol] :fallback_policy (:discard) the policy
-      #   for handling new tasks that are received when the queue size
-      #   has reached `max_queue` or after the executor has shut down
-      #
-      # @see http://docs.oracle.com/javase/tutorial/essential/concurrency/pools.html
-      # @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Executors.html
-      # @see http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html
+      # @!macro single_thread_executor_method_initialize
       def initialize(opts = {})
         super(opts)
       end

--- a/lib/concurrent/executor/java_thread_pool_executor.rb
+++ b/lib/concurrent/executor/java_thread_pool_executor.rb
@@ -5,6 +5,7 @@ if Concurrent.on_jruby?
 
     # @!macro thread_pool_executor
     # @!macro thread_pool_options
+    # @api private
     class JavaThreadPoolExecutor < JavaExecutorService
 
       # Default maximum number of threads that will be created in the pool.

--- a/lib/concurrent/executor/java_thread_pool_executor.rb
+++ b/lib/concurrent/executor/java_thread_pool_executor.rb
@@ -1,4 +1,5 @@
 if Concurrent.on_jruby?
+
   require 'concurrent/executor/executor_service'
 
   module Concurrent

--- a/lib/concurrent/executor/java_thread_pool_executor.rb
+++ b/lib/concurrent/executor/java_thread_pool_executor.rb
@@ -5,53 +5,28 @@ if Concurrent.on_jruby?
 
     # @!macro thread_pool_executor
     # @!macro thread_pool_options
-    # @api private
+    # @!visibility private
     class JavaThreadPoolExecutor < JavaExecutorService
 
-      # Default maximum number of threads that will be created in the pool.
+      # @!macro thread_pool_executor_constant_default_max_pool_size
       DEFAULT_MAX_POOL_SIZE = java.lang.Integer::MAX_VALUE # 2147483647
 
-      # Default minimum number of threads that will be retained in the pool.
+      # @!macro thread_pool_executor_constant_default_min_pool_size
       DEFAULT_MIN_POOL_SIZE = 0
 
-      # Default maximum number of tasks that may be added to the task queue.
+      # @!macro thread_pool_executor_constant_default_max_queue_size
       DEFAULT_MAX_QUEUE_SIZE = 0
 
-      # Default maximum number of seconds a thread in the pool may remain idle
-      # before being reclaimed.
+      # @!macro thread_pool_executor_constant_default_thread_timeout
       DEFAULT_THREAD_IDLETIMEOUT = 60
 
-      # The maximum number of threads that may be created in the pool.
+      # @!macro thread_pool_executor_attr_reader_max_length
       attr_reader :max_length
 
-      # The maximum number of tasks that may be waiting in the work queue at any one time.
-      # When the queue size reaches `max_queue` subsequent tasks will be rejected in
-      # accordance with the configured `fallback_policy`.
+      # @!macro thread_pool_executor_attr_reader_max_queue
       attr_reader :max_queue
 
-      # Create a new thread pool.
-      #
-      # @param [Hash] opts the options which configure the thread pool
-      #
-      # @option opts [Integer] :max_threads (DEFAULT_MAX_POOL_SIZE) the maximum
-      #   number of threads to be created
-      # @option opts [Integer] :min_threads (DEFAULT_MIN_POOL_SIZE) the minimum
-      #   number of threads to be retained
-      # @option opts [Integer] :idletime (DEFAULT_THREAD_IDLETIMEOUT) the maximum
-      #   number of seconds a thread may be idle before being reclaimed
-      # @option opts [Integer] :max_queue (DEFAULT_MAX_QUEUE_SIZE) the maximum
-      #   number of tasks allowed in the work queue at any one time; a value of
-      #   zero means the queue may grow without bound
-      # @option opts [Symbol] :fallback_policy (:abort) the policy for handling new
-      #   tasks that are received when the queue size has reached
-      #   `max_queue` or the executir has shut down
-      #
-      # @raise [ArgumentError] if `:max_threads` is less than one
-      # @raise [ArgumentError] if `:min_threads` is less than zero
-      # @raise [ArgumentError] if `:fallback_policy` is not one of the values specified
-      #   in `FALLBACK_POLICIES`
-      #
-      # @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ThreadPoolExecutor.html
+      # @!macro thread_pool_executor_method_initialize
       def initialize(opts = {})
         super(opts)
       end
@@ -61,73 +36,52 @@ if Concurrent.on_jruby?
         @max_queue != 0
       end
 
-      # The minimum number of threads that may be retained in the pool.
-      #
-      # @return [Integer] the min_length
+      # @!macro thread_pool_executor_attr_reader_min_length
       def min_length
         @executor.getCorePoolSize
       end
 
-      # The maximum number of threads that may be created in the pool.
-      #
-      # @return [Integer] the max_length
+      # @!macro thread_pool_executor_attr_reader_max_length
       def max_length
         @executor.getMaximumPoolSize
       end
 
-      # The number of threads currently in the pool.
-      #
-      # @return [Integer] the length
+      # @!macro thread_pool_executor_attr_reader_length
       def length
         @executor.getPoolSize
       end
 
-      # The largest number of threads that have been created in the pool since construction.
-      #
-      # @return [Integer] the largest_length
+      # @!macro thread_pool_executor_attr_reader_largest_length
       def largest_length
         @executor.getLargestPoolSize
       end
 
-      # The number of tasks that have been scheduled for execution on the pool since construction.
-      #
-      # @return [Integer] the scheduled_task_count
+      # @!macro thread_pool_executor_attr_reader_scheduled_task_count
       def scheduled_task_count
         @executor.getTaskCount
       end
 
-      # The number of tasks that have been completed by the pool since construction.
-      #
-      # @return [Integer] the completed_task_count
+      # @!macro thread_pool_executor_attr_reader_completed_task_count
       def completed_task_count
         @executor.getCompletedTaskCount
       end
 
-      # The number of seconds that a thread may be idle before being reclaimed.
-      #
-      # @return [Integer] the idletime
+      # @!macro thread_pool_executor_attr_reader_idletime
       def idletime
         @executor.getKeepAliveTime(java.util.concurrent.TimeUnit::SECONDS)
       end
 
-      # The number of tasks in the queue awaiting execution.
-      #
-      # @return [Integer] the queue_length
+      # @!macro thread_pool_executor_attr_reader_queue_length
       def queue_length
         @executor.getQueue.size
       end
 
-      # Number of tasks that may be enqueued before reaching `max_queue` and rejecting
-      # new tasks. A value of -1 indicates that the queue may grow without bound.
-      #
-      # @return [Integer] the remaining_capacity
+      # @!macro thread_pool_executor_attr_reader_remaining_capacity
       def remaining_capacity
         @max_queue == 0 ? -1 : @executor.getQueue.remainingCapacity
       end
 
-      # Is the thread pool running?
-      #
-      # @return [Boolean] `true` when running, `false` when shutting down or shutdown
+      # @!macro executor_service_method_running_question
       def running?
         super && !@executor.isTerminating
       end

--- a/lib/concurrent/executor/ruby_cached_thread_pool.rb
+++ b/lib/concurrent/executor/ruby_cached_thread_pool.rb
@@ -4,6 +4,7 @@ module Concurrent
 
   # @!macro cached_thread_pool
   # @!macro thread_pool_options
+  # @api private
   class RubyCachedThreadPool < RubyThreadPoolExecutor
 
     # Create a new thread pool.

--- a/lib/concurrent/executor/ruby_cached_thread_pool.rb
+++ b/lib/concurrent/executor/ruby_cached_thread_pool.rb
@@ -4,15 +4,11 @@ module Concurrent
 
   # @!macro cached_thread_pool
   # @!macro thread_pool_options
-  # @api private
+  # @!macro thread_pool_executor_public_api
+  # @!visibility private
   class RubyCachedThreadPool < RubyThreadPoolExecutor
 
-    # Create a new thread pool.
-    #
-    # @param [Hash] opts the options defining pool behavior.
-    # @option opts [Symbol] :fallback_policy (`:abort`) the fallback policy
-    #
-    # @raise [ArgumentError] if `fallback_policy` is not a known policy
+    # @!macro cached_thread_pool_method_initialize
     def initialize(opts = {})
       defaults  = { idletime: DEFAULT_THREAD_IDLETIMEOUT }
       overrides = { min_threads:     0,

--- a/lib/concurrent/executor/ruby_fixed_thread_pool.rb
+++ b/lib/concurrent/executor/ruby_fixed_thread_pool.rb
@@ -4,6 +4,7 @@ module Concurrent
 
   # @!macro fixed_thread_pool
   # @!macro thread_pool_options
+  # @api private
   class RubyFixedThreadPool < RubyThreadPoolExecutor
 
     # Create a new thread pool.

--- a/lib/concurrent/executor/ruby_fixed_thread_pool.rb
+++ b/lib/concurrent/executor/ruby_fixed_thread_pool.rb
@@ -4,17 +4,11 @@ module Concurrent
 
   # @!macro fixed_thread_pool
   # @!macro thread_pool_options
-  # @api private
+  # @!macro thread_pool_executor_public_api
+  # @!visibility private
   class RubyFixedThreadPool < RubyThreadPoolExecutor
 
-    # Create a new thread pool.
-    #
-    # @param [Integer] num_threads the number of threads to allocate
-    # @param [Hash] opts the options defining pool behavior.
-    # @option opts [Symbol] :fallback_policy (`:abort`) the fallback policy
-    #
-    # @raise [ArgumentError] if `num_threads` is less than or equal to zero
-    # @raise [ArgumentError] if `fallback_policy` is not a known policy
+    # @!macro fixed_thread_pool_method_initialize
     def initialize(num_threads, opts = {})
       raise ArgumentError.new('number of threads must be greater than zero') if num_threads.to_i < 1
       defaults  = { max_queue:   DEFAULT_MAX_QUEUE_SIZE,

--- a/lib/concurrent/executor/ruby_single_thread_executor.rb
+++ b/lib/concurrent/executor/ruby_single_thread_executor.rb
@@ -4,19 +4,12 @@ module Concurrent
 
   # @!macro single_thread_executor
   # @!macro thread_pool_options
-  # @api private
+  # @!macro abstract_executor_service_public_api
+  # @!visibility private
   class RubySingleThreadExecutor < RubyExecutorService
     include SerialExecutorService
 
-    # Create a new thread pool.
-    #
-    # @option opts [Symbol] :fallback_policy (:discard) the policy for
-    #   handling new tasks that are received when the queue size has
-    #   reached `max_queue` or after the executor has shut down
-    #
-    # @see http://docs.oracle.com/javase/tutorial/essential/concurrency/pools.html
-    # @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Executors.html
-    # @see http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html
+    # @!macro single_thread_executor_method_initialize
     def initialize(opts = {})
       super
     end

--- a/lib/concurrent/executor/ruby_single_thread_executor.rb
+++ b/lib/concurrent/executor/ruby_single_thread_executor.rb
@@ -4,6 +4,7 @@ module Concurrent
 
   # @!macro single_thread_executor
   # @!macro thread_pool_options
+  # @api private
   class RubySingleThreadExecutor < RubyExecutorService
     include SerialExecutorService
 

--- a/lib/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent/executor/ruby_thread_pool_executor.rb
@@ -9,68 +9,43 @@ module Concurrent
 
   # @!macro thread_pool_executor
   # @!macro thread_pool_options
-  # @api private
+  # @!visibility private
   class RubyThreadPoolExecutor < RubyExecutorService
 
-    # Default maximum number of threads that will be created in the pool.
+    # @!macro thread_pool_executor_constant_default_max_pool_size
     DEFAULT_MAX_POOL_SIZE      = 2_147_483_647 # java.lang.Integer::MAX_VALUE
 
-    # Default minimum number of threads that will be retained in the pool.
+    # @!macro thread_pool_executor_constant_default_min_pool_size
     DEFAULT_MIN_POOL_SIZE      = 0
 
-    # Default maximum number of tasks that may be added to the task queue.
+    # @!macro thread_pool_executor_constant_default_max_queue_size
     DEFAULT_MAX_QUEUE_SIZE     = 0
 
-    # Default maximum number of seconds a thread in the pool may remain idle
-    # before being reclaimed.
+    # @!macro thread_pool_executor_constant_default_thread_timeout
     DEFAULT_THREAD_IDLETIMEOUT = 60
 
-    # The maximum number of threads that may be created in the pool.
+    # @!macro thread_pool_executor_attr_reader_max_length
     attr_reader :max_length
 
-    # The minimum number of threads that may be retained in the pool.
+    # @!macro thread_pool_executor_attr_reader_min_length
     attr_reader :min_length
 
-    # The largest number of threads that have been created in the pool since construction.
+    # @!macro thread_pool_executor_attr_reader_largest_length
     attr_reader :largest_length
 
-    # The number of tasks that have been scheduled for execution on the pool since construction.
+    # @!macro thread_pool_executor_attr_reader_scheduled_task_count
     attr_reader :scheduled_task_count
 
-    # The number of tasks that have been completed by the pool since construction.
+    # @!macro thread_pool_executor_attr_reader_completed_task_count
     attr_reader :completed_task_count
 
-    # The number of seconds that a thread may be idle before being reclaimed.
+    # @!macro thread_pool_executor_attr_reader_idletime
     attr_reader :idletime
 
-    # The maximum number of tasks that may be waiting in the work queue at any one time.
-    # When the queue size reaches `max_queue` subsequent tasks will be rejected in
-    # accordance with the configured `fallback_policy`.
+    # @!macro thread_pool_executor_attr_reader_max_queue
     attr_reader :max_queue
 
-    # Create a new thread pool.
-    #
-    # @param [Hash] opts the options which configure the thread pool
-    #
-    # @option opts [Integer] :max_threads (DEFAULT_MAX_POOL_SIZE) the maximum
-    #   number of threads to be created
-    # @option opts [Integer] :min_threads (DEFAULT_MIN_POOL_SIZE) the minimum
-    #   number of threads to be retained
-    # @option opts [Integer] :idletime (DEFAULT_THREAD_IDLETIMEOUT) the maximum
-    #   number of seconds a thread may be idle before being reclaimed
-    # @option opts [Integer] :max_queue (DEFAULT_MAX_QUEUE_SIZE) the maximum
-    #   number of tasks allowed in the work queue at any one time; a value of
-    #   zero means the queue may grow without bound
-    # @option opts [Symbol] :fallback_policy (:abort) the policy for handling new
-    #   tasks that are received when the queue size has reached
-    #   `max_queue` or the executor has shut down
-    #
-    # @raise [ArgumentError] if `:max_threads` is less than one
-    # @raise [ArgumentError] if `:min_threads` is less than zero
-    # @raise [ArgumentError] if `:fallback_policy` is not one of the values specified
-    #   in `FALLBACK_POLICIES`
-    #
-    # @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ThreadPoolExecutor.html
+    # @!macro thread_pool_executor_method_initialize
     def initialize(opts = {})
       super(opts)
     end
@@ -80,24 +55,17 @@ module Concurrent
       synchronize { ns_limited_queue? }
     end
 
-    # The number of threads currently in the pool.
-    #
-    # @return [Integer] the length
+    # @!macro thread_pool_executor_attr_reader_length
     def length
       synchronize { @pool.length }
     end
 
-    # The number of tasks in the queue awaiting execution.
-    #
-    # @return [Integer] the queue_length
+    # @!macro thread_pool_executor_attr_reader_queue_length
     def queue_length
       synchronize { @queue.length }
     end
 
-    # Number of tasks that may be enqueued before reaching `max_queue` and rejecting
-    # new tasks. A value of -1 indicates that the queue may grow without bound.
-    #
-    # @return [Integer] the remaining_capacity
+    # @!macro thread_pool_executor_attr_reader_remaining_capacity
     def remaining_capacity
       synchronize do
         if ns_limited_queue?
@@ -108,22 +76,22 @@ module Concurrent
       end
     end
 
-    # @api private
+    # @!visibility private
     def remove_busy_worker(worker)
       synchronize { ns_remove_busy_worker worker }
     end
 
-    # @api private
+    # @!visibility private
     def ready_worker(worker)
       synchronize { ns_ready_worker worker }
     end
 
-    # @api private
+    # @!visibility private
     def worker_not_old_enough(worker)
       synchronize { ns_worker_not_old_enough worker }
     end
 
-    # @api private
+    # @!visibility private
     def worker_died(worker)
       synchronize { ns_worker_died worker }
     end
@@ -303,6 +271,7 @@ module Concurrent
       @next_gc_time = Concurrent.monotonic_time + @gc_interval
     end
 
+    # @!visibility private
     class Worker
       include Concern::Logging
 

--- a/lib/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent/executor/ruby_thread_pool_executor.rb
@@ -9,6 +9,7 @@ module Concurrent
 
   # @!macro thread_pool_executor
   # @!macro thread_pool_options
+  # @api private
   class RubyThreadPoolExecutor < RubyExecutorService
 
     # Default maximum number of threads that will be created in the pool.

--- a/lib/concurrent/executor/single_thread_executor.rb
+++ b/lib/concurrent/executor/single_thread_executor.rb
@@ -24,10 +24,23 @@ module Concurrent
   #
   #   The API and behavior of this class are based on Java's `SingleThreadExecutor`
   #
-  #   @see Concurrent::RubySingleThreadExecutor
-  #   @see Concurrent::JavaSingleThreadExecutor
-  #
   # @!macro thread_pool_options
+  # @!macro abstract_executor_service_public_api
   class SingleThreadExecutor < SingleThreadExecutorImplementation
+
+    # @!macro [new] single_thread_executor_method_initialize
+    #
+    #   Create a new thread pool.
+    #
+    #   @option opts [Symbol] :fallback_policy (:discard) the policy for
+    #     handling new tasks that are received when the queue size has
+    #     reached `max_queue` or after the executor has shut down
+    #
+    #   @see http://docs.oracle.com/javase/tutorial/essential/concurrency/pools.html
+    #   @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Executors.html
+    #   @see http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html
+
+    # @!method initialize(opts = {})
+    #   @!macro single_thread_executor_method_initialize
   end
 end

--- a/lib/concurrent/executor/thread_pool_executor.rb
+++ b/lib/concurrent/executor/thread_pool_executor.rb
@@ -45,5 +45,162 @@ module Concurrent
   #
   # @!macro thread_pool_options
   class ThreadPoolExecutor < ThreadPoolExecutorImplementation
+
+    # @!macro [new] thread_pool_executor_constant_default_max_pool_size
+    #   Default maximum number of threads that will be created in the pool.
+
+    # @!macro [new] thread_pool_executor_constant_default_min_pool_size
+    #   Default minimum number of threads that will be retained in the pool.
+
+    # @!macro [new] thread_pool_executor_constant_default_max_queue_size
+    #   Default maximum number of tasks that may be added to the task queue.
+
+    # @!macro [new] thread_pool_executor_constant_default_thread_timeout
+    #   Default maximum number of seconds a thread in the pool may remain idle
+    #   before being reclaimed.
+
+    # @!macro [new] thread_pool_executor_attr_reader_max_length
+    #   The maximum number of threads that may be created in the pool.
+    #   @return [Integer] The maximum number of threads that may be created in the pool.
+
+    # @!macro [new] thread_pool_executor_attr_reader_min_length
+    #   The minimum number of threads that may be retained in the pool.
+    #   @return [Integer] The minimum number of threads that may be retained in the pool.
+
+    # @!macro [new] thread_pool_executor_attr_reader_largest_length
+    #   The largest number of threads that have been created in the pool since construction.
+    #   @return [Integer] The largest number of threads that have been created in the pool since construction.
+
+    # @!macro [new] thread_pool_executor_attr_reader_scheduled_task_count
+    #   The number of tasks that have been scheduled for execution on the pool since construction.
+    #   @return [Integer] The number of tasks that have been scheduled for execution on the pool since construction.
+
+    # @!macro [new] thread_pool_executor_attr_reader_completed_task_count
+    #   The number of tasks that have been completed by the pool since construction.
+    #   @return [Integer] The number of tasks that have been completed by the pool since construction.
+
+    # @!macro [new] thread_pool_executor_attr_reader_idletime
+    #   The number of seconds that a thread may be idle before being reclaimed.
+    #   @return [Integer] The number of seconds that a thread may be idle before being reclaimed.
+
+    # @!macro [new] thread_pool_executor_attr_reader_max_queue
+    #   The maximum number of tasks that may be waiting in the work queue at any one time.
+    #   When the queue size reaches `max_queue` subsequent tasks will be rejected in
+    #   accordance with the configured `fallback_policy`.
+    #
+    #   @return [Integer] The maximum number of tasks that may be waiting in the work queue at any one time.
+    #     When the queue size reaches `max_queue` subsequent tasks will be rejected in
+    #     accordance with the configured `fallback_policy`.
+
+    # @!macro [new] thread_pool_executor_attr_reader_length
+    #   The number of threads currently in the pool.
+    #   @return [Integer] The number of threads currently in the pool.
+
+    # @!macro [new] thread_pool_executor_attr_reader_queue_length
+    #   The number of tasks in the queue awaiting execution.
+    #   @return [Integer] The number of tasks in the queue awaiting execution.
+
+    # @!macro [new] thread_pool_executor_attr_reader_remaining_capacity
+    #   Number of tasks that may be enqueued before reaching `max_queue` and rejecting
+    #   new tasks. A value of -1 indicates that the queue may grow without bound.
+    #
+    #   @return [Integer] Number of tasks that may be enqueued before reaching `max_queue` and rejecting
+    #     new tasks. A value of -1 indicates that the queue may grow without bound.
+
+    # @!macro [new] thread_pool_executor_method_initialize
+    #
+    #   Create a new thread pool.
+    #  
+    #   @param [Hash] opts the options which configure the thread pool.
+    #  
+    #   @option opts [Integer] :max_threads (DEFAULT_MAX_POOL_SIZE) the maximum
+    #     number of threads to be created
+    #   @option opts [Integer] :min_threads (DEFAULT_MIN_POOL_SIZE) the minimum
+    #     number of threads to be retained
+    #   @option opts [Integer] :idletime (DEFAULT_THREAD_IDLETIMEOUT) the maximum
+    #     number of seconds a thread may be idle before being reclaimed
+    #   @option opts [Integer] :max_queue (DEFAULT_MAX_QUEUE_SIZE) the maximum
+    #     number of tasks allowed in the work queue at any one time; a value of
+    #     zero means the queue may grow without bound
+    #   @option opts [Symbol] :fallback_policy (:abort) the policy for handling new
+    #     tasks that are received when the queue size has reached
+    #     `max_queue` or the executor has shut down
+    #  
+    #   @raise [ArgumentError] if `:max_threads` is less than one
+    #   @raise [ArgumentError] if `:min_threads` is less than zero
+    #   @raise [ArgumentError] if `:fallback_policy` is not one of the values specified
+    #     in `FALLBACK_POLICIES`
+    #  
+    #   @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ThreadPoolExecutor.html
+
+
+
+    # @!attribute [r] fallback_policy
+    #   @!macro executor_service_attr_reader_fallback_policy
+
+    # @!attribute [r] max_length
+    #   @!macro thread_pool_executor_attr_reader_max_length
+
+    # @!attribute [r] min_length
+    #   @!macro thread_pool_executor_attr_reader_min_length
+
+    # @!attribute [r] largest_length
+    #   @!macro thread_pool_executor_attr_reader_largest_length
+
+    # @!attribute [r] scheduled_task_count
+    #   @!macro thread_pool_executor_attr_reader_scheduled_task_count
+
+    # @!attribute [r] completed_task_count
+    #   @!macro thread_pool_executor_attr_reader_completed_task_count
+
+    # @!attribute [r] idletime
+    #   @!macro thread_pool_executor_attr_reader_idletime
+
+    # @!attribute [r] max_queue
+    #   @!macro thread_pool_executor_attr_reader_max_queue
+
+    # @!attribute [r] length
+    #   @!macro thread_pool_executor_attr_reader_length
+
+    # @!attribute [r] queue_length
+    #   @!macro thread_pool_executor_attr_reader_queue_length
+
+    # @!attribute [r] remaining_capacity
+    #   @!macro thread_pool_executor_attr_reader_remaining_capacity
+
+    # @!method initialize(opts = {})
+    #   @!macro thread_pool_executor_method_initialize
+
+    # @!method can_overflow?
+    #   @!macro executor_service_method_can_overflow_question
+
+
+
+
+
+    # @!method shutdown
+    #   @!macro executor_service_method_shutdown
+
+    # @!method kill
+    #   @!macro executor_service_method_kill
+
+    # @!method wait_for_termination(timeout = nil)
+    #   @!macro executor_service_method_wait_for_termination
+
+
+    # @!method running?
+    #   @!macro executor_service_method_running_question
+
+    # @!method shuttingdown?
+    #   @!macro executor_service_method_shuttingdown_question
+
+    # @!method shutdown?
+    #   @!macro executor_service_method_shutdown_question
+
+    # @!method auto_terminate?
+    #   @!macro executor_service_method_auto_terminate_question
+
+    # @!method auto_terminate=(value)
+    #   @!macro executor_service_method_auto_terminate_setter
   end
 end

--- a/lib/concurrent/executor/thread_pool_executor.rb
+++ b/lib/concurrent/executor/thread_pool_executor.rb
@@ -44,68 +44,9 @@ module Concurrent
   #   > scenarios.
   #
   # @!macro thread_pool_options
+  #
+  # @!macro thread_pool_executor_public_api
   class ThreadPoolExecutor < ThreadPoolExecutorImplementation
-
-    # @!macro [new] thread_pool_executor_constant_default_max_pool_size
-    #   Default maximum number of threads that will be created in the pool.
-
-    # @!macro [new] thread_pool_executor_constant_default_min_pool_size
-    #   Default minimum number of threads that will be retained in the pool.
-
-    # @!macro [new] thread_pool_executor_constant_default_max_queue_size
-    #   Default maximum number of tasks that may be added to the task queue.
-
-    # @!macro [new] thread_pool_executor_constant_default_thread_timeout
-    #   Default maximum number of seconds a thread in the pool may remain idle
-    #   before being reclaimed.
-
-    # @!macro [new] thread_pool_executor_attr_reader_max_length
-    #   The maximum number of threads that may be created in the pool.
-    #   @return [Integer] The maximum number of threads that may be created in the pool.
-
-    # @!macro [new] thread_pool_executor_attr_reader_min_length
-    #   The minimum number of threads that may be retained in the pool.
-    #   @return [Integer] The minimum number of threads that may be retained in the pool.
-
-    # @!macro [new] thread_pool_executor_attr_reader_largest_length
-    #   The largest number of threads that have been created in the pool since construction.
-    #   @return [Integer] The largest number of threads that have been created in the pool since construction.
-
-    # @!macro [new] thread_pool_executor_attr_reader_scheduled_task_count
-    #   The number of tasks that have been scheduled for execution on the pool since construction.
-    #   @return [Integer] The number of tasks that have been scheduled for execution on the pool since construction.
-
-    # @!macro [new] thread_pool_executor_attr_reader_completed_task_count
-    #   The number of tasks that have been completed by the pool since construction.
-    #   @return [Integer] The number of tasks that have been completed by the pool since construction.
-
-    # @!macro [new] thread_pool_executor_attr_reader_idletime
-    #   The number of seconds that a thread may be idle before being reclaimed.
-    #   @return [Integer] The number of seconds that a thread may be idle before being reclaimed.
-
-    # @!macro [new] thread_pool_executor_attr_reader_max_queue
-    #   The maximum number of tasks that may be waiting in the work queue at any one time.
-    #   When the queue size reaches `max_queue` subsequent tasks will be rejected in
-    #   accordance with the configured `fallback_policy`.
-    #
-    #   @return [Integer] The maximum number of tasks that may be waiting in the work queue at any one time.
-    #     When the queue size reaches `max_queue` subsequent tasks will be rejected in
-    #     accordance with the configured `fallback_policy`.
-
-    # @!macro [new] thread_pool_executor_attr_reader_length
-    #   The number of threads currently in the pool.
-    #   @return [Integer] The number of threads currently in the pool.
-
-    # @!macro [new] thread_pool_executor_attr_reader_queue_length
-    #   The number of tasks in the queue awaiting execution.
-    #   @return [Integer] The number of tasks in the queue awaiting execution.
-
-    # @!macro [new] thread_pool_executor_attr_reader_remaining_capacity
-    #   Number of tasks that may be enqueued before reaching `max_queue` and rejecting
-    #   new tasks. A value of -1 indicates that the queue may grow without bound.
-    #
-    #   @return [Integer] Number of tasks that may be enqueued before reaching `max_queue` and rejecting
-    #     new tasks. A value of -1 indicates that the queue may grow without bound.
 
     # @!macro [new] thread_pool_executor_method_initialize
     #
@@ -133,74 +74,7 @@ module Concurrent
     #  
     #   @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ThreadPoolExecutor.html
 
-
-
-    # @!attribute [r] fallback_policy
-    #   @!macro executor_service_attr_reader_fallback_policy
-
-    # @!attribute [r] max_length
-    #   @!macro thread_pool_executor_attr_reader_max_length
-
-    # @!attribute [r] min_length
-    #   @!macro thread_pool_executor_attr_reader_min_length
-
-    # @!attribute [r] largest_length
-    #   @!macro thread_pool_executor_attr_reader_largest_length
-
-    # @!attribute [r] scheduled_task_count
-    #   @!macro thread_pool_executor_attr_reader_scheduled_task_count
-
-    # @!attribute [r] completed_task_count
-    #   @!macro thread_pool_executor_attr_reader_completed_task_count
-
-    # @!attribute [r] idletime
-    #   @!macro thread_pool_executor_attr_reader_idletime
-
-    # @!attribute [r] max_queue
-    #   @!macro thread_pool_executor_attr_reader_max_queue
-
-    # @!attribute [r] length
-    #   @!macro thread_pool_executor_attr_reader_length
-
-    # @!attribute [r] queue_length
-    #   @!macro thread_pool_executor_attr_reader_queue_length
-
-    # @!attribute [r] remaining_capacity
-    #   @!macro thread_pool_executor_attr_reader_remaining_capacity
-
     # @!method initialize(opts = {})
     #   @!macro thread_pool_executor_method_initialize
-
-    # @!method can_overflow?
-    #   @!macro executor_service_method_can_overflow_question
-
-
-
-
-
-    # @!method shutdown
-    #   @!macro executor_service_method_shutdown
-
-    # @!method kill
-    #   @!macro executor_service_method_kill
-
-    # @!method wait_for_termination(timeout = nil)
-    #   @!macro executor_service_method_wait_for_termination
-
-
-    # @!method running?
-    #   @!macro executor_service_method_running_question
-
-    # @!method shuttingdown?
-    #   @!macro executor_service_method_shuttingdown_question
-
-    # @!method shutdown?
-    #   @!macro executor_service_method_shutdown_question
-
-    # @!method auto_terminate?
-    #   @!macro executor_service_method_auto_terminate_question
-
-    # @!method auto_terminate=(value)
-    #   @!macro executor_service_method_auto_terminate_setter
   end
 end

--- a/lib/concurrent/lazy_register.rb
+++ b/lib/concurrent/lazy_register.rb
@@ -14,6 +14,8 @@ module Concurrent
   #   #=> #<Concurrent::LazyRegister:0x007fd7ecd5e230 @data=#<Concurrent::AtomicReference:0x007fd7ecd5e1e0>>
   #   register[:key]
   #   #=> #<Concurrent::Actor::Reference /ping (Concurrent::Actor::AdHoc)>
+  #
+  # @!macro edge_warning
   class LazyRegister
 
     def initialize

--- a/lib/concurrent/synchronization/abstract_object.rb
+++ b/lib/concurrent/synchronization/abstract_object.rb
@@ -1,78 +1,62 @@
 module Concurrent
   module Synchronization
 
-    # Safe synchronization under any Ruby implementation.
-    # It provides methods like {#synchronize}, {#ns_wait}, {#ns_signal} and {#ns_broadcast}.
-    # Provides a single layer which can improve its implementation over time without changes needed to
-    # the classes using it. Use {Synchronization::Object} not this abstract class.
-    #
-    # @note this object does not support usage together with
-    #   [`Thread#wakeup`](http://ruby-doc.org/core-2.2.0/Thread.html#method-i-wakeup)
-    #   and [`Thread#raise`](http://ruby-doc.org/core-2.2.0/Thread.html#method-i-raise).
-    #   `Thread#sleep` and `Thread#wakeup` will work as expected but mixing `Synchronization::Object#wait` and
-    #   `Thread#wakeup` will not work on all platforms.
-    #
-    # @see {Event} implementation as an example of this class use
-    #
-    # @example simple
-    #   class AnClass < Synchronization::Object
-    #     def initialize
-    #       super
-    #       synchronize { @value = 'asd' }
-    #     end
-    #
-    #     def value
-    #       synchronize { @value }
-    #     end
-    #   end
-    #
-    # @api private
+    # @!macro synchronization_object
+    # @!visibility private
     class AbstractObject
 
-      # @abstract for helper ivar initialization if needed,
-      #   otherwise it can be left empty. It has to call ns_initialize.
-      def initialize
+      # @!macro [attach] synchronization_object_method_initialize
+      #  
+      #   @abstract for helper ivar initialization if needed,
+      #     otherwise it can be left empty. It has to call ns_initialize.
+      def initialize(*args, &block)
         raise NotImplementedError
       end
 
       protected
 
-      # @yield runs the block synchronized against this object,
-      #   equivalent of java's `synchronize(this) {}`
-      # @note can by made public in descendants if required by `public :synchronize`
+      # @!macro [attach] synchronization_object_method_synchronize
+      #  
+      #   @yield runs the block synchronized against this object,
+      #     equivalent of java's `synchronize(this) {}`
+      #   @note can by made public in descendants if required by `public :synchronize`
       def synchronize
         raise NotImplementedError
       end
 
-      # initialization of the object called inside synchronize block
-      # @note has to be called manually when required in children of this class
-      # @example
-      #   class Child < Concurrent::Synchornization::Object
-      #     def initialize(*args, &block)
-      #       super(&nil)
-      #       synchronize { ns_initialize(*args, &block) }
+      # @!macro [attach] synchronization_object_method_ns_initialize
+      #  
+      #   initialization of the object called inside synchronize block
+      #   @note has to be called manually when required in children of this class
+      #   @example
+      #     class Child < Concurrent::Synchornization::Object
+      #       def initialize(*args, &block)
+      #         super(&nil)
+      #         synchronize { ns_initialize(*args, &block) }
+      #       end
+      #     
+      #       def ns_initialize(*args, &block)
+      #         @args = args          
+      #       end
       #     end
-      #   
-      #     def ns_initialize(*args, &block)
-      #       @args = args          
-      #     end
-      #   end
       def ns_initialize(*args, &block)
       end
 
-      # Wait until condition is met or timeout passes,
-      # protects against spurious wake-ups.
-      # @param [Numeric, nil] timeout in seconds, `nil` means no timeout
-      # @yield condition to be met
-      # @yieldreturn [true, false]
-      # @return [true, false] if condition met
-      # @note only to be used inside synchronized block
-      # @note to provide direct access to this method in a descendant add method
-      #   ```
-      #   def wait_until(timeout = nil, &condition)
-      #     synchronize { ns_wait_until(timeout, &condition) }
-      #   end
-      #   ```
+      # @!macro [attach] synchronization_object_method_ns_wait_until
+      #  
+      #   Wait until condition is met or timeout passes,
+      #   protects against spurious wake-ups.
+      #   @param [Numeric, nil] timeout in seconds, `nil` means no timeout
+      #   @yield condition to be met
+      #   @yieldreturn [true, false]
+      #   @return [true, false] if condition met
+      #   @note only to be used inside synchronized block
+      #   @note to provide direct access to this method in a descendant add method
+      #     ```
+      #     def wait_until(timeout = nil, &condition)
+      #       synchronize { ns_wait_until(timeout, &condition) }
+      #     end
+      #     ```
       def ns_wait_until(timeout = nil, &condition)
         if timeout
           wait_until = Concurrent.monotonic_time + timeout
@@ -90,65 +74,75 @@ module Concurrent
         end
       end
 
-      # Wait until another thread calls #signal or #broadcast,
-      # spurious wake-ups can happen.
-      #
-      # @param [Numeric, nil] timeout in seconds, `nil` means no timeout
-      # @return [self]
-      # @note only to be used inside synchronized block
-      # @note to provide direct access to this method in a descendant add method
-      #   ```
-      #   def wait(timeout = nil)
-      #     synchronize { ns_wait(timeout) }
-      #   end
-      #   ```
+      # @!macro [attach] synchronization_object_method_ns_wait
+      #  
+      #   Wait until another thread calls #signal or #broadcast,
+      #   spurious wake-ups can happen.
+      #  
+      #   @param [Numeric, nil] timeout in seconds, `nil` means no timeout
+      #   @return [self]
+      #   @note only to be used inside synchronized block
+      #   @note to provide direct access to this method in a descendant add method
+      #     ```
+      #     def wait(timeout = nil)
+      #       synchronize { ns_wait(timeout) }
+      #     end
+      #     ```
       def ns_wait(timeout = nil)
         raise NotImplementedError
       end
 
-      # Signal one waiting thread.
-      # @return [self]
-      # @note only to be used inside synchronized block
-      # @note to provide direct access to this method in a descendant add method
-      #   ```
-      #   def signal
-      #     synchronize { ns_signal }
-      #   end
-      #   ```
+      # @!macro [attach] synchronization_object_method_ns_signal
+      #    
+      #   Signal one waiting thread.
+      #   @return [self]
+      #   @note only to be used inside synchronized block
+      #   @note to provide direct access to this method in a descendant add method
+      #     ```
+      #     def signal
+      #       synchronize { ns_signal }
+      #     end
+      #     ```
       def ns_signal
         raise NotImplementedError
       end
 
-      # Broadcast to all waiting threads.
-      # @return [self]
-      # @note only to be used inside synchronized block
-      # @note to provide direct access to this method in a descendant add method
-      #   ```
-      #   def broadcast
-      #     synchronize { ns_broadcast }
-      #   end
-      #   ```
+      # @!macro [attach] synchronization_object_method_ns_broadcast
+      #  
+      #   Broadcast to all waiting threads.
+      #   @return [self]
+      #   @note only to be used inside synchronized block
+      #   @note to provide direct access to this method in a descendant add method
+      #     ```
+      #     def broadcast
+      #       synchronize { ns_broadcast }
+      #     end
+      #     ```
       def ns_broadcast
         raise NotImplementedError
       end
 
-      # Allows to construct immutable objects where all fields are visible after initialization, not requiring
-      # further synchronization on access.
-      # @example
-      #   class AClass
-      #     attr_reader :val
-      #     def initialize(val)
-      #       @val = val # final value, after assignment it's not changed (just convention, not enforced)
-      #       ensure_ivar_visibility!
-      #       # now it can be shared as Java's final field
+      # @!macro [attach] synchronization_object_method_ensure_ivar_visibility
+      #  
+      #   Allows to construct immutable objects where all fields are visible after initialization, not requiring
+      #   further synchronization on access.
+      #   @example
+      #     class AClass
+      #       attr_reader :val
+      #       def initialize(val)
+      #         @val = val # final value, after assignment it's not changed (just convention, not enforced)
+      #         ensure_ivar_visibility!
+      #         # now it can be shared as Java's final field
+      #       end
       #     end
-      #   end
       def ensure_ivar_visibility!
         raise NotImplementedError
       end
 
-      # creates methods for reading and writing to a instance variable with volatile (Java semantic) instance variable
-      # return [Array<Symbol>] names of defined method names
+      # @!macro [attach] synchronization_object_method_self_attr_volatile
+      #    
+      #   creates methods for reading and writing to a instance variable with volatile (Java semantic) instance variable
+      #   return [Array<Symbol>] names of defined method names
       def self.attr_volatile(*names)
         names.each do |name|
           ivar = :"@volatile_#{name}"

--- a/lib/concurrent/synchronization/abstract_object.rb
+++ b/lib/concurrent/synchronization/abstract_object.rb
@@ -1,5 +1,6 @@
 module Concurrent
   module Synchronization
+
     # Safe synchronization under any Ruby implementation.
     # It provides methods like {#synchronize}, {#ns_wait}, {#ns_signal} and {#ns_broadcast}.
     # Provides a single layer which can improve its implementation over time without changes needed to
@@ -24,6 +25,8 @@ module Concurrent
     #       synchronize { @value }
     #     end
     #   end
+    #
+    # @api private
     class AbstractObject
 
       # @abstract for helper ivar initialization if needed,

--- a/lib/concurrent/synchronization/abstract_struct.rb
+++ b/lib/concurrent/synchronization/abstract_struct.rb
@@ -2,6 +2,7 @@ module Concurrent
   module Synchronization
 
     # @!visibility private
+    # @api private
     module AbstractStruct
 
       # @!visibility private

--- a/lib/concurrent/synchronization/abstract_struct.rb
+++ b/lib/concurrent/synchronization/abstract_struct.rb
@@ -2,7 +2,7 @@ module Concurrent
   module Synchronization
 
     # @!visibility private
-    # @api private
+    # @!macro internal_implementation_note
     module AbstractStruct
 
       # @!visibility private

--- a/lib/concurrent/synchronization/java_object.rb
+++ b/lib/concurrent/synchronization/java_object.rb
@@ -6,7 +6,8 @@ module Concurrent
     if Concurrent.on_jruby?
       require 'jruby'
 
-      # @api private
+      # @!visibility private
+      # @!macro internal_implementation_note
       class JavaObject < AbstractObject
 
         def self.attr_volatile(*names)

--- a/lib/concurrent/synchronization/java_object.rb
+++ b/lib/concurrent/synchronization/java_object.rb
@@ -6,6 +6,7 @@ module Concurrent
     if Concurrent.on_jruby?
       require 'jruby'
 
+      # @api private
       class JavaObject < AbstractObject
 
         def self.attr_volatile(*names)

--- a/lib/concurrent/synchronization/monitor_object.rb
+++ b/lib/concurrent/synchronization/monitor_object.rb
@@ -1,7 +1,8 @@
 module Concurrent
   module Synchronization
 
-    # @api private
+    # @!visibility private
+    # @!macro internal_implementation_note
     class MonitorObject < MutexObject
       def initialize
         @__lock__      = ::Monitor.new

--- a/lib/concurrent/synchronization/monitor_object.rb
+++ b/lib/concurrent/synchronization/monitor_object.rb
@@ -1,5 +1,7 @@
 module Concurrent
   module Synchronization
+
+    # @api private
     class MonitorObject < MutexObject
       def initialize
         @__lock__      = ::Monitor.new

--- a/lib/concurrent/synchronization/mutex_object.rb
+++ b/lib/concurrent/synchronization/mutex_object.rb
@@ -1,7 +1,8 @@
 module Concurrent
   module Synchronization
 
-    # @api private
+    # @!visibility private
+    # @!macro internal_implementation_note
     class MutexObject < AbstractObject
       def initialize
         @__lock__      = ::Mutex.new

--- a/lib/concurrent/synchronization/mutex_object.rb
+++ b/lib/concurrent/synchronization/mutex_object.rb
@@ -1,5 +1,7 @@
 module Concurrent
   module Synchronization
+
+    # @api private
     class MutexObject < AbstractObject
       def initialize
         @__lock__      = ::Mutex.new

--- a/lib/concurrent/synchronization/object.rb
+++ b/lib/concurrent/synchronization/object.rb
@@ -1,7 +1,8 @@
 module Concurrent
   module Synchronization
 
-    # @api private
+    # @!visibility private
+    # @!macro internal_implementation_note
     Implementation = case
                      when Concurrent.on_jruby?
                        JavaObject
@@ -17,8 +18,61 @@ module Concurrent
                      end
     private_constant :Implementation
 
-    # @see AbstractObject AbstractObject which defines interface of this class.
+    # @!macro [attach] synchronization_object
+    #  
+    #   Safe synchronization under any Ruby implementation.
+    #   It provides methods like {#synchronize}, {#wait}, {#signal} and {#broadcast}.
+    #   Provides a single layer which can improve its implementation over time without changes needed to
+    #   the classes using it. Use {Synchronization::Object} not this abstract class.
+    #  
+    #   @note this object does not support usage together with
+    #     [`Thread#wakeup`](http://ruby-doc.org/core-2.2.0/Thread.html#method-i-wakeup)
+    #     and [`Thread#raise`](http://ruby-doc.org/core-2.2.0/Thread.html#method-i-raise).
+    #     `Thread#sleep` and `Thread#wakeup` will work as expected but mixing `Synchronization::Object#wait` and
+    #     `Thread#wakeup` will not work on all platforms.
+    #  
+    #   @see {Event} implementation as an example of this class use
+    #  
+    #   @example simple
+    #     class AnClass < Synchronization::Object
+    #       def initialize
+    #         super
+    #         synchronize { @value = 'asd' }
+    #       end
+    #  
+    #       def value
+    #         synchronize { @value }
+    #       end
+    #     end
+    #
     class Object < Implementation
+
+      # @!method initialize(*args, &block)
+      #   @!macro synchronization_object_method_initialize
+
+      # @!method synchronize
+      #   @!macro synchronization_object_method_synchronize
+
+      # @!method initialize(*args, &block)
+      #   @!macro synchronization_object_method_ns_initialize
+
+      # @!method wait_until(timeout = nil, &condition)
+      #   @!macro synchronization_object_method_ns_wait_until
+
+      # @!method wait(timeout = nil)
+      #   @!macro synchronization_object_method_ns_wait
+
+      # @!method signal
+      #   @!macro synchronization_object_method_ns_signal
+
+      # @!method broadcast
+      #   @!macro synchronization_object_method_ns_broadcast
+
+      # @!method ensure_ivar_visibility!
+      #   @!macro synchronization_object_method_ensure_ivar_visibility
+
+      # @!method self.attr_volatile(*names)
+      #   @!macro synchronization_object_method_self_attr_volatile
     end
   end
 end

--- a/lib/concurrent/synchronization/object.rb
+++ b/lib/concurrent/synchronization/object.rb
@@ -1,5 +1,7 @@
 module Concurrent
   module Synchronization
+
+    # @api private
     Implementation = case
                      when Concurrent.on_jruby?
                        JavaObject

--- a/lib/concurrent/synchronization/rbx_object.rb
+++ b/lib/concurrent/synchronization/rbx_object.rb
@@ -3,7 +3,8 @@ module Concurrent
 
     if Concurrent.on_rbx?
       
-      # @api private
+      # @!visibility private
+      # @!macro internal_implementation_note
       class RbxObject < AbstractObject
         def initialize
           @Waiters = []

--- a/lib/concurrent/synchronization/rbx_object.rb
+++ b/lib/concurrent/synchronization/rbx_object.rb
@@ -1,6 +1,9 @@
 module Concurrent
   module Synchronization
+
     if Concurrent.on_rbx?
+      
+      # @api private
       class RbxObject < AbstractObject
         def initialize
           @Waiters = []

--- a/lib/concurrent/utility/at_exit.rb
+++ b/lib/concurrent/utility/at_exit.rb
@@ -6,7 +6,7 @@ module Concurrent
   # Provides ability to add and remove handlers to be run at `Kernel#at_exit`, order is undefined.
   # Each handler is executed at most once.
   #
-  # @api private
+  # @!visibility private
   class AtExitImplementation < Synchronization::Object
     include Concern::Logging
 
@@ -92,6 +92,6 @@ module Concurrent
   private_constant :AtExitImplementation
 
   # @see AtExitImplementation
-  # @api private
+  # @!visibility private
   AtExit = AtExitImplementation.new.install
 end

--- a/lib/concurrent/utility/at_exit.rb
+++ b/lib/concurrent/utility/at_exit.rb
@@ -5,6 +5,8 @@ module Concurrent
 
   # Provides ability to add and remove handlers to be run at `Kernel#at_exit`, order is undefined.
   # Each handler is executed at most once.
+  #
+  # @api private
   class AtExitImplementation < Synchronization::Object
     include Concern::Logging
 
@@ -90,5 +92,6 @@ module Concurrent
   private_constant :AtExitImplementation
 
   # @see AtExitImplementation
+  # @api private
   AtExit = AtExitImplementation.new.install
 end

--- a/lib/concurrent/utility/engine.rb
+++ b/lib/concurrent/utility/engine.rb
@@ -1,6 +1,7 @@
 module Concurrent
   module Utility
 
+    # @api private
     module EngineDetector
       def on_jruby?
         ruby_engine == 'jruby'
@@ -34,5 +35,6 @@ module Concurrent
     end
   end
 
+  # @api private
   extend Utility::EngineDetector
 end

--- a/lib/concurrent/utility/engine.rb
+++ b/lib/concurrent/utility/engine.rb
@@ -1,7 +1,7 @@
 module Concurrent
   module Utility
 
-    # @api private
+    # @!visibility private
     module EngineDetector
       def on_jruby?
         ruby_engine == 'jruby'
@@ -35,6 +35,6 @@ module Concurrent
     end
   end
 
-  # @api private
+  # @!visibility private
   extend Utility::EngineDetector
 end

--- a/lib/concurrent/utility/monotonic_time.rb
+++ b/lib/concurrent/utility/monotonic_time.rb
@@ -38,7 +38,10 @@ module Concurrent
 
   # Clock that cannot be set and represents monotonic time since
   # some unspecified starting point.
+  #
   # @!visibility private
+  #
+  # @api private
   GLOBAL_MONOTONIC_CLOCK = class_definition.new
   private_constant :GLOBAL_MONOTONIC_CLOCK
 

--- a/lib/concurrent/utility/monotonic_time.rb
+++ b/lib/concurrent/utility/monotonic_time.rb
@@ -40,8 +40,6 @@ module Concurrent
   # some unspecified starting point.
   #
   # @!visibility private
-  #
-  # @api private
   GLOBAL_MONOTONIC_CLOCK = class_definition.new
   private_constant :GLOBAL_MONOTONIC_CLOCK
 

--- a/lib/concurrent/utility/native_extension_loader.rb
+++ b/lib/concurrent/utility/native_extension_loader.rb
@@ -4,7 +4,7 @@ require 'concurrent/utility/engine'
 module Concurrent
   module Utility
 
-    # @api private
+    # @!visibility private
     module NativeExtensionLoader
 
       @c_ext_loaded    ||= false
@@ -51,6 +51,6 @@ module Concurrent
     end
   end
 
-  # @api private
+  # @!visibility private
   extend Utility::NativeExtensionLoader
 end

--- a/lib/concurrent/utility/native_extension_loader.rb
+++ b/lib/concurrent/utility/native_extension_loader.rb
@@ -4,6 +4,7 @@ require 'concurrent/utility/engine'
 module Concurrent
   module Utility
 
+    # @api private
     module NativeExtensionLoader
 
       @c_ext_loaded    ||= false
@@ -50,5 +51,6 @@ module Concurrent
     end
   end
 
+  # @api private
   extend Utility::NativeExtensionLoader
 end

--- a/lib/concurrent/utility/processor_counter.rb
+++ b/lib/concurrent/utility/processor_counter.rb
@@ -4,7 +4,7 @@ require 'concurrent/delay'
 module Concurrent
   module Utility
 
-    # @api private
+    # @!visibility private
     class ProcessorCounter
       def initialize
         @processor_count          = Delay.new { compute_processor_count }

--- a/lib/concurrent/utility/processor_counter.rb
+++ b/lib/concurrent/utility/processor_counter.rb
@@ -4,6 +4,7 @@ require 'concurrent/delay'
 module Concurrent
   module Utility
 
+    # @api private
     class ProcessorCounter
       def initialize
         @processor_count          = Delay.new { compute_processor_count }


### PR DESCRIPTION
According to [Semantic Versioning 2.0.0](http://semver.org/), major and minor version numbers must only be changed when the *public* API changes. Those version numbers do not have to change when private, internal changes are made. According to the spec, software following Semantic Versioning "MUST declare a public API." Yardoc provides an [@api](http://www.rubydoc.info/gems/yard/file/docs/Tags.md#api) tag which can be used to indicate which features are part of the public API and which are part of the private API.

The PR marks many abstractions with the `@api private` tag to clearly indicate which abstractions are being *excluded* from Semantic Versioning.