### PR TITLE
Prevent Ruby thread pools from creating too many threads.

### DIFF
--- a/examples/stress_ruby_thread_pool.rb
+++ b/examples/stress_ruby_thread_pool.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+$: << File.expand_path('../../lib', __FILE__)
+
+require 'benchmark'
+require 'concurrent/executors'
+
+COUNT = 100_000
+
+executor = Concurrent::CachedThreadPool.new
+latch = Concurrent::CountDownLatch.new
+
+COUNT.times { executor.post{ nil } }
+
+#COUNT.times do |i|
+#  executor.post{ nil }
+#  sleep(0.01) if i % 1000 == 0
+#end
+
+executor.post{ latch.count_down }
+latch.wait
+
+puts "Max length:           #{executor.max_length}" if executor.respond_to?(:max_length)
+puts "Largest length:       #{executor.largest_length}" if executor.respond_to?(:largest_length)
+puts "Scheduled task count: #{executor.scheduled_task_count}" if executor.respond_to?(:scheduled_task_count)
+puts "Completed task count: #{executor.completed_task_count}" if executor.respond_to?(:completed_task_count)

--- a/lib/concurrent/executor/java_fixed_thread_pool.rb
+++ b/lib/concurrent/executor/java_fixed_thread_pool.rb
@@ -18,12 +18,12 @@ if Concurrent.on_jruby?
       #
       # @see http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html#newFixedThreadPool-int-
       def initialize(num_threads, opts = {})
-
-        opts = {
-            min_threads: num_threads,
-            max_threads: num_threads
-        }.merge(opts)
-        super(opts)
+        raise ArgumentError.new('number of threads must be greater than zero') if num_threads.to_i < 1
+        defaults  = { max_queue:   DEFAULT_MAX_QUEUE_SIZE,
+                      idletime:    DEFAULT_THREAD_IDLETIMEOUT }
+        overrides = { min_threads: num_threads,
+                      max_threads: num_threads }
+        super(defaults.merge(opts).merge(overrides))
       end
     end
   end

--- a/lib/concurrent/executor/java_thread_pool_executor.rb
+++ b/lib/concurrent/executor/java_thread_pool_executor.rb
@@ -141,9 +141,10 @@ if Concurrent.on_jruby?
         @fallback_policy = opts.fetch(:fallback_policy, opts.fetch(:overflow_policy, :abort))
         deprecated ' :overflow_policy is deprecated terminology, please use :fallback_policy instead' if opts.has_key?(:overflow_policy)
 
-        raise ArgumentError.new('max_threads must be greater than zero') if max_length <= 0
-        raise ArgumentError.new('min_threads cannot be less than zero') if min_length < 0
-        raise ArgumentError.new('min_threads cannot be more than max_threads') if min_length > max_length
+        raise ArgumentError.new("`max_threads` cannot be less than #{DEFAULT_MIN_POOL_SIZE}") if max_length < DEFAULT_MIN_POOL_SIZE
+        raise ArgumentError.new("`max_threads` cannot be greater than #{DEFAULT_MAX_POOL_SIZE}") if max_length > DEFAULT_MAX_POOL_SIZE
+        raise ArgumentError.new("`min_threads` cannot be less than #{DEFAULT_MIN_POOL_SIZE}") if min_length < DEFAULT_MIN_POOL_SIZE
+        raise ArgumentError.new("`min_threads` cannot be more than `max_threads`") if min_length > max_length
         raise ArgumentError.new("#{fallback_policy} is not a valid fallback policy") unless FALLBACK_POLICY_CLASSES.include?(@fallback_policy)
 
         if @max_queue == 0

--- a/lib/concurrent/executor/ruby_cached_thread_pool.rb
+++ b/lib/concurrent/executor/ruby_cached_thread_pool.rb
@@ -13,15 +13,10 @@ module Concurrent
     #
     # @raise [ArgumentError] if `fallback_policy` is not a known policy
     def initialize(opts = {})
-      fallback_policy = opts.fetch(:fallback_policy, opts.fetch(:overflow_policy, :abort))
-      raise ArgumentError.new("#{fallback_policy} is not a valid fallback policy") unless FALLBACK_POLICIES.include?(fallback_policy)
-
       defaults  = { idletime: DEFAULT_THREAD_IDLETIMEOUT }
       overrides = { min_threads:     0,
                     max_threads:     DEFAULT_MAX_POOL_SIZE,
-                    fallback_policy: fallback_policy,
                     max_queue:       DEFAULT_MAX_QUEUE_SIZE }
-
       super(defaults.merge(opts).merge(overrides))
     end
   end

--- a/lib/concurrent/executor/ruby_fixed_thread_pool.rb
+++ b/lib/concurrent/executor/ruby_fixed_thread_pool.rb
@@ -15,19 +15,12 @@ module Concurrent
     # @raise [ArgumentError] if `num_threads` is less than or equal to zero
     # @raise [ArgumentError] if `fallback_policy` is not a known policy
     def initialize(num_threads, opts = {})
-      fallback_policy = opts.fetch(:fallback_policy, opts.fetch(:overflow_policy, :abort))
-      raise ArgumentError.new("#{fallback_policy} is not a valid fallback policy") unless FALLBACK_POLICIES.include?(fallback_policy)
-
-      raise ArgumentError.new('number of threads must be greater than zero') if num_threads < 1
-
-      opts = {
-        min_threads: num_threads,
-        max_threads: num_threads,
-        fallback_policy: fallback_policy,
-        max_queue: DEFAULT_MAX_QUEUE_SIZE,
-        idletime: DEFAULT_THREAD_IDLETIMEOUT,
-      }.merge(opts)
-      super(opts)
+      raise ArgumentError.new('number of threads must be greater than zero') if num_threads.to_i < 1
+      defaults  = { max_queue:   DEFAULT_MAX_QUEUE_SIZE,
+                    idletime:    DEFAULT_THREAD_IDLETIMEOUT }
+      overrides = { min_threads: num_threads,
+                    max_threads: num_threads }
+      super(defaults.merge(opts).merge(overrides))
     end
   end
 end

--- a/spec/concurrent/executor/thread_pool_executor_shared.rb
+++ b/spec/concurrent/executor/thread_pool_executor_shared.rb
@@ -60,6 +60,11 @@ shared_examples :thread_pool_executor do
       end
     end
 
+    it 'raises an exception if :max_threads is less than zero' do
+      expect {
+        described_class.new(max_threads: -1)
+      }.to raise_error(ArgumentError)
+    end
 
     it 'raises an exception if :min_threads is less than zero' do
       expect {
@@ -67,9 +72,15 @@ shared_examples :thread_pool_executor do
       }.to raise_error(ArgumentError)
     end
 
-    it 'raises an exception if :max_threads is not greater than zero' do
+    it 'raises an exception if :max_threads greater than the max allowable' do
       expect {
-        described_class.new(max_threads: 0)
+        described_class.new(max_threads: described_class::DEFAULT_MAX_POOL_SIZE+1)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an exception if :max_threads is less than :min_threads' do
+      expect {
+        described_class.new(max_threads: 1, min_threads: 100)
       }.to raise_error(ArgumentError)
     end
 


### PR DESCRIPTION
In testing I've discovered that MRI will raise a `ThreadError` if threads are created too fast. I believe I've been able to get more than 2046 threads in the past (see e3bb86f00fd06595e76674027ce72c7ce63eacd7) but I cannot verify. In my current testing on 2.2.2 I've not been able to get more than 2046.

I have mixed feelings about this PR. With this change a pure-Ruby thread pool will gracefully handle `ThreadError` exceptions when adding threads to the pool. In such cases the `:fallback_policy` will be triggered. This seems like a reasonable response. Unfortunately, suppressing this exception may mask other problems that we haven't discovered yet.

Thought, anyone?