### PR TITLE
Fix call of disable_executor_auto_termination! in deprecated auto_terminate=

### DIFF
--- a/lib/concurrent/configuration.rb
+++ b/lib/concurrent/configuration.rb
@@ -249,10 +249,10 @@ module Concurrent
       Concurrent.new_fast_executor
     end
 
-    # @deprecated Use Concurrent.disable_auto_termination_of_global_executors! instead
+    # @deprecated Use Concurrent.disable_executor_auto_termination! instead
     def auto_terminate=(value)
-      deprecated_method 'Concurrent.configuration.auto_terminate=', 'Concurrent.disable_auto_termination_of_global_executors!'
-      Concurrent.disable_auto_termination_of_global_executors! if !value
+      deprecated_method 'Concurrent.configuration.auto_terminate=', 'Concurrent.disable_executor_auto_termination!'
+      Concurrent.disable_executor_auto_termination! if !value
     end
 
     # @deprecated Use Concurrent.auto_terminate_global_executors? instead


### PR DESCRIPTION
It was missed in 349c46ef466ebf1573e0c077b002e4a64fa9a685