### PR TITLE
Fix edge Event#wait timeout on ruby 1.9.3

### DIFF
--- a/lib/concurrent/edge/future.rb
+++ b/lib/concurrent/edge/future.rb
@@ -345,8 +345,8 @@ module Concurrent
             # ok only if completing thread did not start signaling
             next unless @Waiters.compare_and_push last_waiter, Thread.current
             ns_wait_until(timeout) { completed? }
-            break
           end
+          break
         end
         self
       end

--- a/spec/concurrent/edge/future_spec.rb
+++ b/spec/concurrent/edge/future_spec.rb
@@ -171,6 +171,22 @@ describe 'Concurrent::Edge futures' do
       expect([queue.pop, queue.pop, queue.pop, queue.pop].sort).to eq [:async, :async, :sync, :sync]
     end
 
+    it 'supports setting timeout while waiting' do
+      start_latch = Concurrent::CountDownLatch.new
+      end_latch = Concurrent::CountDownLatch.new
+
+      future = Concurrent.future do
+        start_latch.count_down
+        end_latch.wait(1)
+      end
+
+      start_latch.wait(1)
+      future.wait(0.1)
+      expect(future).not_to be_completed
+      end_latch.count_down
+      future.wait
+    end
+
     it 'chains' do
       future0 = Concurrent.future { 1 }.then { |v| v + 2 } # both executed on default FAST_EXECUTOR
       future1 = future0.then(:fast) { raise 'boo' } # executed on IO_EXECUTOR


### PR DESCRIPTION
The Monitor#synchronize method catches the break signals, causing the timeouts
not to work (just looping forever)