### PR TITLE
Fixes erroneous deprecation warning in TimerTask.

### DIFF
--- a/lib/concurrent/configuration.rb
+++ b/lib/concurrent/configuration.rb
@@ -131,8 +131,6 @@ module Concurrent
   # Global thread pool user for global *timers*.
   #
   # @return [Concurrent::TimerSet] the thread pool
-  #
-  # @see Concurrent::timer
   def self.global_timer_set
     GLOBAL_TIMER_SET.value
   end

--- a/lib/concurrent/timer_task.rb
+++ b/lib/concurrent/timer_task.rb
@@ -297,13 +297,14 @@ module Concurrent
 
     # @!visibility private
     def schedule_next_task(interval = execution_interval)
-      Concurrent::timer(interval, Concurrent::Event.new, &method(:execute_task))
+      ScheduledTask.execute(interval, args: [Concurrent::Event.new], &method(:execute_task))
+      nil
     end
 
     # @!visibility private
     def execute_task(completion)
-      return unless @running.true?
-      Concurrent::timer(execution_interval, completion, &method(:timeout_task))
+      return nil unless @running.true?
+      ScheduledTask.execute(execution_interval, args: [completion], &method(:timeout_task))
       _success, value, reason = @executor.execute(self)
       if completion.try?
         self.value = value
@@ -313,6 +314,7 @@ module Concurrent
           [time, self.value, reason]
         end
       end
+      nil
     end
 
     # @!visibility private


### PR DESCRIPTION
Addresses #341.

`TimerTask` used `Concurrent::timer` internally. When the latter was deprecated it caused the former to erroneously generate continuous deprecation warnings. This update replaces `Concurrent::timer` with `Concurrent::ScheduledTask` which is the correct abstraction.