### PR TITLE
Fix Edge::Future#on_failure callbacks

### DIFF
--- a/lib/concurrent/edge/future.rb
+++ b/lib/concurrent/edge/future.rb
@@ -456,6 +456,10 @@ module Concurrent
         def to_sym
           :failed
         end
+
+        def apply(block)
+          block.call reason
+        end
       end
 
       # @!method state


### PR DESCRIPTION
When using future.on_failure {}; followed by future.fail("error"), I was
getting:
```
     NoMethodError: undefined method `apply' for
/home/inecas/Projects/dynflow/concurrent-ruby/lib/concurrent/edge/future.rb:677:in `pr_callback_on_failure'
           from /home/inecas/Projects/dynflow/concurrent-ruby/lib/concurrent/edge/future.rb:657:in `call_callback'
           from /home/inecas/Projects/dynflow/concurrent-ruby/lib/concurrent/edge/future.rb:612:in `add_callback'
           from /home/inecas/Projects/dynflow/concurrent-ruby/lib/concurrent/edge/future.rb:592:in `on_failure!'
```