### PR TITLE
Fixed compare_and_set on MutexAtomicReference.

### DIFF
--- a/lib/concurrent/atomic_reference/mutex_atomic.rb
+++ b/lib/concurrent/atomic_reference/mutex_atomic.rb
@@ -42,14 +42,14 @@ module Concurrent
 
     # @!macro atomic_reference_method_compare_and_set
     def _compare_and_set(old_value, new_value)
-      return false unless @mutex.try_lock
-      begin
-        return false unless @value.equal? old_value
-        @value = new_value
-      ensure
-        @mutex.unlock
+      @mutex.synchronize do
+        if @value == old_value
+          @value = new_value
+          true
+        else
+          false
+        end
       end
-      true
     end
   end
 end


### PR DESCRIPTION
Addresses #350 

The pure-Ruby version would return false if the lock could not be obtained. This is distinctly different behavior from the C and Java implementations which only return false if the values did not match. This update brings parity to all implementations.