### PR TITLE
Make sure the Monitor is require before using it

### DIFF
--- a/lib/concurrent/synchronization/monitor_object.rb
+++ b/lib/concurrent/synchronization/monitor_object.rb
@@ -1,3 +1,5 @@
+require 'monitor'
+
 module Concurrent
   module Synchronization
 


### PR DESCRIPTION
In production environment there is a posibility that the Monitor
is not present in vanila environment, which lead to `require 'concurrent'`
to fail on `Monitor` const missing.