### PR TITLE
Synchronisation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 
 MRI 1.9.3, 2.0, 2.1, 2.2, JRuby (1.9 mode), and Rubinius 2.x are supported.
 This gem should be fully compatible with any interpreter that is compliant with Ruby 1.9.3 or newer.
+Java 8 is required for JRuby (Java 7 support is deprecated in version 0.9 and will be removed in 1.0).
 
 ## Features & Documentation
 

--- a/doc/synchronization.md
+++ b/doc/synchronization.md
@@ -139,13 +139,14 @@ We are interested in following behaviors:
 
 ### Variables
 
--   **Local variables** - atomic assignment, non-volatile. 
+-   **Local variables** - atomic assignment (only Integer and Object), non-volatile. 
     -   Consequence: a lambda defined on `thread1` executing on `thread2` may not see updated values in local variables captured in its closure.
     -   Reason: local variables are non-volatile on Jruby and Rubinius.
--   **Instance variables** - atomic assignment, non-volatile. 
+-   **Instance variables** - atomic assignment (only Integer and Object), non-volatile. 
     -   Consequence: Different thread may see old values; different thread may see not fully-initialized object.
     -   Reason: local variables are non-volatile on Jruby and Rubinius.
 -   **Constants** - atomic assignment, volatile.
+-   **Assignments of Float** may not be atomic (some implementations (e.g. Truffle) may use native double).
 
 Other:
 

--- a/ext/com/concurrent_ruby/ext/SynchronizationLibrary.java
+++ b/ext/com/concurrent_ruby/ext/SynchronizationLibrary.java
@@ -144,8 +144,8 @@ public class SynchronizationLibrary implements Library {
                 UnsafeHolder.storeFence();
                 return result;
             } else {
+                final IRubyObject result = instance_variable_set(name, value);
                 UnsafeHolder.U.putIntVolatile(this, AN_VOLATILE_FIELD_OFFSET, 1);
-                IRubyObject result = instance_variable_set(name, value);
                 return result;
             }
         }

--- a/lib/concurrent/concern/deprecation.rb
+++ b/lib/concurrent/concern/deprecation.rb
@@ -10,18 +10,25 @@ module Concurrent
       include Concern::Logging
 
       def deprecated(message, strip = 2)
-        caller_line = caller(strip).first
-        klass       = if Class === self
+        caller_line = caller(strip).first if strip > 0
+        klass       = if Module === self
                         self
                       else
                         self.class
                       end
-        log WARN, klass.to_s, format("[DEPRECATED] %s\ncalled on: %s", message, caller_line)
+        message     = if strip > 0
+                        format("[DEPRECATED] %s\ncalled on: %s", message, caller_line)
+                      else
+                        format('[DEPRECATED] %s', message)
+                      end
+        log WARN, klass.to_s, message
       end
 
       def deprecated_method(old_name, new_name)
         deprecated "`#{old_name}` is deprecated and it'll removed in next release, use `#{new_name}` instead", 3
       end
+
+      extend self
     end
   end
 end

--- a/lib/concurrent/concern/logging.rb
+++ b/lib/concurrent/concern/logging.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'concurrent/configuration'
 
 module Concurrent
   module Concern

--- a/lib/concurrent/synchronization/java_object.rb
+++ b/lib/concurrent/synchronization/java_object.rb
@@ -4,7 +4,6 @@ module Concurrent
   module Synchronization
 
     if Concurrent.on_jruby?
-      require 'jruby'
 
       # @!visibility private
       # @!macro internal_implementation_note


### PR DESCRIPTION
* Float assignment is no longer considered atomic.
* We have to discuss 4th commit (it's small please have a look). I do not know about a reliable way how to ensure that full memory barrier is executed on Java 7. Therefore I think it would be best to **support only Java8**.
* related to #354 

cc @jdantonio @chrisseaton 