### PR TITLE
Add rake-compiler-dock for building Windows binary gems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec name: 'concurrent-ruby-edge'
 group :development do
   gem 'rake', '~> 10.4.2'
   gem 'rake-compiler', '~> 0.9.5'
+  gem 'rake-compiler-dock', '~> 0.4.0'
   gem 'gem-compiler', '~> 0.3.0'
   gem 'benchmark-ips', '~> 2.2.0'
 

--- a/Rakefile
+++ b/Rakefile
@@ -70,7 +70,7 @@ elsif Concurrent.allow_c_extensions?
     }
     platforms.each do |platform, prefix|
       task "copy:#{EXT_NAME}:#{platform}:#{ruby_version}" do |t|
-        %w[lib tmp/#{platform}/stage/lib].each do |dir|
+        ["lib", "tmp/#{platform}/stage/lib/concurrent"].each do |dir|
           so_file = "#{dir}/#{ruby_version[/^\d+\.\d+/]}/#{EXT_NAME}.so"
           if File.exists?(so_file)
             sh "#{prefix}-strip -S #{so_file}"

--- a/Rakefile
+++ b/Rakefile
@@ -87,9 +87,8 @@ end
 task :clean do
   rm_rf 'pkg/classes'
   rm_rf 'tmp'
-  rm_rf 'lib/concurrent/1.9'
-  rm_rf 'lib/concurrent/2.0'
-  rm_rf 'lib/concurrent/2.1'
+  rm_rf Dir.glob('lib/concurrent/1.?')
+  rm_rf Dir.glob('lib/concurrent/2.?')
   rm_f Dir.glob('./**/*.so')
   rm_f Dir.glob('./**/*.bundle')
   rm_f Dir.glob('./lib/*.jar')

--- a/Rakefile
+++ b/Rakefile
@@ -135,6 +135,15 @@ namespace :build do
       sh 'mv *.gem pkg/'
     end
   end
+
+  desc "Build the windows binary gems per rake-compiler-dock"
+  task :windows do
+    require 'rake_compiler_dock'
+    RakeCompilerDock.sh <<-EOT
+      bundle --without="development testing" &&
+      rake cross native gem RUBY_CC_VERSION=1.9.3:2.0.0:2.1.6:2.2.2
+    EOT
+  end
 end
 
 if Concurrent.on_jruby?


### PR DESCRIPTION
There is already a section for cross building the extension gem for windows, but no further information how this is done. I would like to contribute this in form of the new rake task 'build:windows'.

The intention of [rake-compiler-dock](https://github.com/larskanis/rake-compiler-dock) is to make cross compiling windows gems simple and reliable.

I tested building the fat binary concurrent-ruby-ext gems successfully on Linux and Windows. I also tested the resulting gems on RubyInstaller versions 2.2.1-x86 and 2.2.1-x64 on Windows-7 successfully.

I was unsure whether 'build:windows' should be part of 'build'. And I noted that the 'pkg' directory isn't part of the clean list. In my experience the 'pkg' directory is sometimes messed and should be cleared (at least when cross building). Can I change 'pkg/classes' to 'pkg' ?