### PR TITLE
Fixed bugs found while building the 0.9 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-### Next Release v0.9.0 (Target Date: 7 June 2015)
-
+## Current Release v0.9.0 (10 July 2015)
 
 * Updated `AtomicReference`
   - `AtomicReference#try_update` now simply returns instead of raising exception
@@ -98,7 +97,7 @@
 * Removed brute-force killing of threads in tests
 * Fixed a thread pool bug when the operating system cannot allocate more threads
 
-## Current Release v0.8.0 (25 January 2015)
+### Release v0.8.0 (25 January 2015)
 
 * C extension for MRI have been extracted into the `concurrent-ruby-ext` companion gem.
   Please see the README for more detail.

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec name: 'concurrent-ruby-edge'
 group :development do
   gem 'rake', '~> 10.4.2'
   gem 'rake-compiler', '~> 0.9.5'
-  gem 'rake-compiler-dock', '~> 0.4.2'
+  gem 'rake-compiler-dock', '~> 0.4.3'
   gem 'gem-compiler', '~> 0.3.0'
   gem 'benchmark-ips', '~> 2.2.0'
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ $:.push File.join(File.dirname(__FILE__), 'lib')
 require 'concurrent/version'
 require 'concurrent/utility/native_extension_loader'
 
-## load the two gemspec files
+## load the gemspec files
 CORE_GEMSPEC = Gem::Specification.load('concurrent-ruby.gemspec')
 EXT_GEMSPEC  = Gem::Specification.load('concurrent-ruby-ext.gemspec')
 EDGE_GEMSPEC = Gem::Specification.load('concurrent-ruby-edge.gemspec')

--- a/lib/concurrent/concern/logging.rb
+++ b/lib/concurrent/concern/logging.rb
@@ -1,5 +1,4 @@
 require 'logger'
-require 'concurrent/configuration'
 
 module Concurrent
   module Concern
@@ -16,6 +15,8 @@ module Concurrent
       # @param [String, nil] message when nil block is used to generate the message
       # @yieldreturn [String] a message
       def log(level, progname, message = nil, &block)
+        #NOTE: Cannot require 'concurrent/configuration' above due to circular references.
+        #      Assume that the gem has been initialized if we've gotten this far.
         (@logger || Concurrent.global_logger).call level, progname, message, &block
       rescue => error
         $stderr.puts "`Concurrent.configuration.logger` failed to log #{[level, progname, message, block]}\n" +

--- a/lib/concurrent/utility/at_exit.rb
+++ b/lib/concurrent/utility/at_exit.rb
@@ -1,4 +1,4 @@
-require 'concurrent/concern/logging'
+require 'logger'
 require 'concurrent/synchronization'
 
 module Concurrent
@@ -8,7 +8,7 @@ module Concurrent
   #
   # @!visibility private
   class AtExitImplementation < Synchronization::Object
-    include Concern::Logging
+    include Logger::Severity
 
     def initialize(*args)
       super()
@@ -46,9 +46,9 @@ module Concurrent
     def install
       synchronize do
         @installed ||= begin
-          at_exit { runner }
-          true
-        end
+                         at_exit { runner }
+                         true
+                       end
         self
       end
     end
@@ -71,7 +71,7 @@ module Concurrent
         begin
           handler.call
         rescue => error
-          log ERROR, error
+          Concurrent.global_logger.call(ERROR, error)
         end
       end
       handlers.keys


### PR DESCRIPTION
* Upgraded `rake-compiler-dock` to a version which runs on OS X
* Fixes circular references that only raised exceptions when running the post-build tests in `build-tests`