### PR TITLE
ReadWriteLock feature parity with Rails ShareLock

### DIFF
--- a/lib/concurrent/atomic/atomic_fixnum.rb
+++ b/lib/concurrent/atomic/atomic_fixnum.rb
@@ -1,3 +1,4 @@
+require 'concurrent/atomic_reference/direct_update'
 require 'concurrent/utility/native_extension_loader'
 require 'concurrent/synchronization'
 
@@ -151,6 +152,12 @@ module Concurrent
   #
   # @see Concurrent::MutexAtomicFixnum
   class AtomicFixnum < AtomicFixnumImplementation
+    include Concurrent::AtomicDirectUpdate
+
+    # @!visibility private
+    # needed for AtomicDirectUpdate
+    alias_method :get, :value
+    private :get
 
     # @!method initialize(initial = 0)
     #   @!macro atomic_fixnum_method_initialize

--- a/lib/concurrent/atomic/atomic_fixnum.rb
+++ b/lib/concurrent/atomic/atomic_fixnum.rb
@@ -82,7 +82,7 @@ module Concurrent
     #
     #   @return [Fixnum] the current value after decrementation
     def decrement
-      synchronize { ns_set(@value -1) }
+      synchronize { ns_set(@value - 1) }
     end
 
     alias_method :down, :decrement

--- a/lib/concurrent/atomic/read_write_lock.rb
+++ b/lib/concurrent/atomic/read_write_lock.rb
@@ -203,7 +203,7 @@ module Concurrent
     #
     # @return [Boolean] true if the lock is successfully released
     def release_write_lock
-      c = @Counter.update { |c| c-RUNNING_WRITER }
+      c = @Counter.update { |count| count-RUNNING_WRITER }
       @WriterLock.set(nil)
       @ReadLock.broadcast
       @WriteLock.signal if waiting_writers(c) > 0

--- a/spec/concurrent/atomic/read_write_lock_spec.rb
+++ b/spec/concurrent/atomic/read_write_lock_spec.rb
@@ -149,10 +149,11 @@ module Concurrent
         }.to raise_error(Concurrent::ResourceLimitError)
       end
 
-      it 'does not release the lock when an exception is raised' do
-        expect(subject).to_not receive(:release_read_lock).with(any_args)
-        lambda do
-          subject.with_read_lock { raise StandardError }
+      it 'releases the lock when an exception is raised' do
+        expect(subject).to receive(:release_read_lock).with(any_args)
+        begin
+          subject.release_read_lock { raise StandardError }
+        rescue
         end
       end
     end
@@ -189,10 +190,11 @@ module Concurrent
         }.to raise_error(Concurrent::ResourceLimitError)
       end
 
-      it 'does not release the lock when an exception is raised' do
-        expect(subject).to_not receive(:release_write_lock).with(any_args)
-        lambda do
+      it 'releases the lock when an exception is raised' do
+        expect(subject).to receive(:release_write_lock).with(any_args)
+        begin
           subject.with_write_lock { raise StandardError }
+        rescue
         end
       end
     end

--- a/spec/concurrent/atomic/read_write_lock_spec.rb
+++ b/spec/concurrent/atomic/read_write_lock_spec.rb
@@ -460,6 +460,11 @@ module Concurrent
         expect(write_flag.value).to be true
       end
 
+      it 'is reentrant' do
+        expect(subject.acquire_write_lock).to be true
+        expect(subject.acquire_write_lock).to be true
+      end
+
       it 'raises an exception if maximum lock limit is exceeded' do
         counter = Concurrent::AtomicFixnum.new(ReadWriteLock::MAX_WRITERS)
         allow(Concurrent::AtomicFixnum).to receive(:new).with(anything).and_return(counter)

--- a/spec/concurrent/atomic/read_write_lock_spec.rb
+++ b/spec/concurrent/atomic/read_write_lock_spec.rb
@@ -142,8 +142,8 @@ module Concurrent
       end
 
       it 'raises an exception if maximum lock limit is exceeded' do
-        counter = Concurrent::AtomicReference.new(ReadWriteLock::MAX_READERS)
-        allow(Concurrent::AtomicReference).to receive(:new).with(anything).and_return(counter)
+        counter = Concurrent::AtomicFixnum.new(ReadWriteLock::MAX_READERS)
+        allow(Concurrent::AtomicFixnum).to receive(:new).with(anything).and_return(counter)
         expect {
           subject.with_read_lock { nil }
         }.to raise_error(Concurrent::ResourceLimitError)
@@ -207,8 +207,8 @@ module Concurrent
       end
 
       it 'raises an exception if maximum lock limit is exceeded' do
-        counter = Concurrent::AtomicReference.new(ReadWriteLock::MAX_WRITERS)
-        allow(Concurrent::AtomicReference).to receive(:new).with(anything).and_return(counter)
+        counter = Concurrent::AtomicFixnum.new(ReadWriteLock::MAX_WRITERS)
+        allow(Concurrent::AtomicFixnum).to receive(:new).with(anything).and_return(counter)
         expect {
           subject.with_write_lock { nil }
         }.to raise_error(Concurrent::ResourceLimitError)
@@ -226,8 +226,8 @@ module Concurrent
     context '#acquire_read_lock' do
 
       it 'increments the lock count' do
-        counter = Concurrent::AtomicReference.new(0)
-        allow(Concurrent::AtomicReference).to receive(:new).with(anything).and_return(counter)
+        counter = Concurrent::AtomicFixnum.new(0)
+        allow(Concurrent::AtomicFixnum).to receive(:new).with(anything).and_return(counter)
         subject.acquire_read_lock
         expect(counter.value).to eq 1
       end
@@ -289,8 +289,8 @@ module Concurrent
       end
 
       it 'does not wait for any running readers' do
-        counter = Concurrent::AtomicReference.new(0)
-        allow(Concurrent::AtomicReference).to receive(:new).with(anything).and_return(counter)
+        counter = Concurrent::AtomicFixnum.new(0)
+        allow(Concurrent::AtomicFixnum).to receive(:new).with(anything).and_return(counter)
 
         latch_1 = Concurrent::CountDownLatch.new(1)
         latch_2 = Concurrent::CountDownLatch.new(1)
@@ -328,8 +328,8 @@ module Concurrent
       end
 
       it 'raises an exception if maximum lock limit is exceeded' do
-        counter = Concurrent::AtomicReference.new(ReadWriteLock::MAX_WRITERS)
-        allow(Concurrent::AtomicReference).to receive(:new).with(anything).and_return(counter)
+        counter = Concurrent::AtomicFixnum.new(ReadWriteLock::MAX_WRITERS)
+        allow(Concurrent::AtomicFixnum).to receive(:new).with(anything).and_return(counter)
         expect {
           subject.acquire_write_lock { nil }
         }.to raise_error(Concurrent::ResourceLimitError)
@@ -343,8 +343,8 @@ module Concurrent
     context '#release_read_lock' do
 
       it 'decrements the counter' do
-        counter = Concurrent::AtomicReference.new(0)
-        allow(Concurrent::AtomicReference).to receive(:new).with(anything).and_return(counter)
+        counter = Concurrent::AtomicFixnum.new(0)
+        allow(Concurrent::AtomicFixnum).to receive(:new).with(anything).and_return(counter)
         subject.acquire_read_lock
         expect(counter.value).to eq 1
         subject.release_read_lock
@@ -386,8 +386,8 @@ module Concurrent
     context '#acquire_write_lock' do
 
       it 'increments the lock count' do
-        counter = Concurrent::AtomicReference.new(0)
-        allow(Concurrent::AtomicReference).to receive(:new).with(anything).and_return(counter)
+        counter = Concurrent::AtomicFixnum.new(0)
+        allow(Concurrent::AtomicFixnum).to receive(:new).with(anything).and_return(counter)
         subject.acquire_write_lock
         expect(counter.value).to be > 1
       end
@@ -461,8 +461,8 @@ module Concurrent
       end
 
       it 'raises an exception if maximum lock limit is exceeded' do
-        counter = Concurrent::AtomicReference.new(ReadWriteLock::MAX_WRITERS)
-        allow(Concurrent::AtomicReference).to receive(:new).with(anything).and_return(counter)
+        counter = Concurrent::AtomicFixnum.new(ReadWriteLock::MAX_WRITERS)
+        allow(Concurrent::AtomicFixnum).to receive(:new).with(anything).and_return(counter)
         expect {
           subject.acquire_write_lock { nil }
         }.to raise_error(Concurrent::ResourceLimitError)
@@ -476,8 +476,8 @@ module Concurrent
     context '#release_write_lock' do
 
       it 'decrements the counter' do
-        counter = Concurrent::AtomicReference.new(0)
-        allow(Concurrent::AtomicReference).to receive(:new).with(anything).and_return(counter)
+        counter = Concurrent::AtomicFixnum.new(0)
+        allow(Concurrent::AtomicFixnum).to receive(:new).with(anything).and_return(counter)
         subject.acquire_write_lock
         expect(counter.value).to be > 1
         subject.release_write_lock


### PR DESCRIPTION
We have a potential opportunity to replaces the [ShareLock](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/concurrency/share_lock.rb) class in Rails with our `ReadWriteLock`. Before we can do so, we need to add features and benchmark against the Rails version. Since the Rails version makes extensive use of locks it's likely we will perform well.

The PR adds all necessary features except "loose upgrades", which may be a bit challenging.

Specific Updates:

* `AtomicFixnum` now supports `AtomicDirectUpdate` (some of those methods were needed by `ReadWriteLock`)
* The counter in `ReadWriteLock` has been changed from `AtomicReference` to `AtomicFixnum`
* `ReadWriteLock` is now reentrant
* Attempts to acquire a write lock can, optionally, return `false` immediately if the write lock is being held.