### PR TITLE
Fix some MRI 2.2.2 warnings

### DIFF
--- a/lib/concurrent/atomic/atomic_fixnum.rb
+++ b/lib/concurrent/atomic/atomic_fixnum.rb
@@ -81,7 +81,7 @@ module Concurrent
     #
     #   @return [Fixnum] the current value after decrementation
     def decrement
-      synchronize { ns_set(@value -1) }
+      synchronize { ns_set(@value - 1) }
     end
 
     alias_method :down, :decrement

--- a/lib/concurrent/atomic/read_write_lock.rb
+++ b/lib/concurrent/atomic/read_write_lock.rb
@@ -192,7 +192,7 @@ module Concurrent
     #
     # @return [Boolean] true if the lock is successfully released
     def release_write_lock
-      c = @Counter.update { |c| c-RUNNING_WRITER }
+      c = @Counter.update { |counter| counter-RUNNING_WRITER }
       @ReadLock.broadcast
       @WriteLock.signal if waiting_writers(c) > 0
       true


### PR DESCRIPTION
```
lib/concurrent/atomic/atomic_fixnum.rb:84: warning: `-' after local variable or literal is interpreted as binary operator
lib/concurrent/atomic/atomic_fixnum.rb:84: warning: even though it seems like unary operator
lib/concurrent/atomic/read_write_lock.rb:195: warning: shadowing outer local variable - c'`
```