### PR TITLE
Add requires to support standalone `atom` require

### DIFF
--- a/lib/concurrent/synchronization/monitor_object.rb
+++ b/lib/concurrent/synchronization/monitor_object.rb
@@ -1,4 +1,5 @@
 require 'monitor'
+require 'concurrent/synchronization/mutex_object'
 
 module Concurrent
   module Synchronization

--- a/lib/concurrent/synchronization/object.rb
+++ b/lib/concurrent/synchronization/object.rb
@@ -1,3 +1,8 @@
+require 'concurrent/synchronization/java_object'
+require 'concurrent/synchronization/monitor_object'
+require 'concurrent/synchronization/mutex_object'
+require 'concurrent/synchronization/rbx_object'
+
 module Concurrent
   module Synchronization
 


### PR DESCRIPTION
The readme says that we should be able to `require` individual components of Concurrent-Ruby gem, like so:

    require 'concurrent/atom'

However, this particular `require` fails because of un-modeled dependencies internal to the gem.

This PR adds the missing dependencies. Now `require 'concurrent/atom'` succeeds.