### PR TITLE
Fix: Concurrent.zip value! logs errors and raise Concurrent::Error

### DIFF
--- a/lib/concurrent/edge/future.rb
+++ b/lib/concurrent/edge/future.rb
@@ -603,7 +603,7 @@ module Concurrent
         raise 'obligation is not failed' unless failed?
         reason = @State.get.reason
         if reason.is_a?(Array)
-          reason.each { |e| log Error, 'Edge::Future', e }
+          reason.each { |e| log ERROR, 'Edge::Future', e }
           Concurrent::Error.new 'multiple exceptions, inspect log'
         else
           reason.exception(*args)

--- a/spec/concurrent/edge/future_spec.rb
+++ b/spec/concurrent/edge/future_spec.rb
@@ -178,6 +178,17 @@ describe 'Concurrent::Edge futures' do
 
       expect(Concurrent.zip.wait(0.1)).to eq true
     end
+
+    context 'when a future raises an error' do
+
+      let(:future) { Concurrent.future { raise 'error' } }
+
+      it 'raises a concurrent error' do
+        expect { Concurrent.zip(future).value! }.to raise_error(Concurrent::Error)
+      end
+
+    end
+
   end
 
   describe 'Future' do


### PR DESCRIPTION
Corrects a minor typo - when futures are zipped, any errors that occur were not being logged correctly.