### PR TITLE
AtomicFixnum increment/decrement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Upcoming Release v0.9.1 (TBD)
+
+* `AtomicFixnum` methods `#increment` and `#decrement` now support optional delta
+
 ## Current Release v0.9.0 (10 July 2015)
 
 * Updated `AtomicReference`

--- a/ext/com/concurrent_ruby/ext/JavaAtomicFixnumLibrary.java
+++ b/ext/com/concurrent_ruby/ext/JavaAtomicFixnumLibrary.java
@@ -66,9 +66,21 @@ public class JavaAtomicFixnumLibrary implements Library {
             return getRuntime().newFixnum(atomicLong.incrementAndGet());
         }
 
+        @JRubyMethod(name = {"increment", "up"})
+        public IRubyObject increment(IRubyObject value) {
+            long delta = rubyFixnumToLong(value);
+            return getRuntime().newFixnum(atomicLong.addAndGet(delta));
+        }
+
         @JRubyMethod(name = {"decrement", "down"})
         public IRubyObject decrement() {
             return getRuntime().newFixnum(atomicLong.decrementAndGet());
+        }
+
+        @JRubyMethod(name = {"decrement", "down"})
+        public IRubyObject decrement(IRubyObject value) {
+            long delta = rubyFixnumToLong(value);
+            return getRuntime().newFixnum(atomicLong.addAndGet(-delta));
         }
 
         @JRubyMethod(name = "compare_and_set")

--- a/ext/concurrent/atomic_fixnum.c
+++ b/ext/concurrent/atomic_fixnum.c
@@ -33,14 +33,26 @@ VALUE method_atomic_fixnum_value_set(VALUE self, VALUE value) {
   return(value);
 }
 
-VALUE method_atomic_fixnum_increment(VALUE self) {
+VALUE method_atomic_fixnum_increment(int argc, VALUE* argv, VALUE self) {
   long long value = NUM2LL((VALUE) DATA_PTR(self));
-  return method_atomic_fixnum_value_set(self, LL2NUM(value + 1));
+  long long delta = 1;
+  rb_check_arity(argc, 0, 1);
+  if (argc == 1) {
+    Check_Type(argv[0], T_FIXNUM);
+    delta = NUM2LL(argv[0]);
+  }
+  return method_atomic_fixnum_value_set(self, LL2NUM(value + delta));
 }
 
-VALUE method_atomic_fixnum_decrement(VALUE self) {
+VALUE method_atomic_fixnum_decrement(int argc, VALUE* argv, VALUE self) {
   long long value = NUM2LL((VALUE) DATA_PTR(self));
-  return method_atomic_fixnum_value_set(self, LL2NUM(value - 1));
+  long long delta = 1;
+  rb_check_arity(argc, 0, 1);
+  if (argc == 1) {
+    Check_Type(argv[0], T_FIXNUM);
+    delta = NUM2LL(argv[0]);
+  }
+  return method_atomic_fixnum_value_set(self, LL2NUM(value - delta));
 }
 
 VALUE method_atomic_fixnum_compare_and_set(VALUE self, VALUE rb_expect, VALUE rb_update) {

--- a/ext/concurrent/atomic_fixnum.h
+++ b/ext/concurrent/atomic_fixnum.h
@@ -6,8 +6,8 @@ VALUE atomic_fixnum_allocate(VALUE);
 VALUE method_atomic_fixnum_initialize(int, VALUE*, VALUE);
 VALUE method_atomic_fixnum_value(VALUE);
 VALUE method_atomic_fixnum_value_set(VALUE, VALUE);
-VALUE method_atomic_fixnum_increment(VALUE);
-VALUE method_atomic_fixnum_decrement(VALUE);
+VALUE method_atomic_fixnum_increment(int, VALUE*, VALUE);
+VALUE method_atomic_fixnum_decrement(int, VALUE*, VALUE);
 VALUE method_atomic_fixnum_compare_and_set(VALUE, VALUE, VALUE);
 
 #endif

--- a/ext/concurrent/rb_concurrent.c
+++ b/ext/concurrent/rb_concurrent.c
@@ -49,8 +49,8 @@ void Init_extension() {
   rb_define_method(rb_cAtomicFixnum, "initialize", method_atomic_fixnum_initialize, -1);
   rb_define_method(rb_cAtomicFixnum, "value", method_atomic_fixnum_value, 0);
   rb_define_method(rb_cAtomicFixnum, "value=", method_atomic_fixnum_value_set, 1);
-  rb_define_method(rb_cAtomicFixnum, "increment", method_atomic_fixnum_increment, 0);
-  rb_define_method(rb_cAtomicFixnum, "decrement", method_atomic_fixnum_decrement, 0);
+  rb_define_method(rb_cAtomicFixnum, "increment", method_atomic_fixnum_increment, -1);
+  rb_define_method(rb_cAtomicFixnum, "decrement", method_atomic_fixnum_decrement, -1);
   rb_define_method(rb_cAtomicFixnum, "compare_and_set", method_atomic_fixnum_compare_and_set, 2);
   rb_define_alias(rb_cAtomicFixnum, "up", "increment");
   rb_define_alias(rb_cAtomicFixnum, "down", "decrement");

--- a/lib/concurrent/atomic/atomic_fixnum.rb
+++ b/lib/concurrent/atomic/atomic_fixnum.rb
@@ -66,22 +66,26 @@ module Concurrent
 
     # @!macro [attach] atomic_fixnum_method_increment
     #
-    #   Increases the current value by 1.
+    #   Increases the current value by the given amount (defaults to 1).
+    #
+    #   @param [Fixnum] delta the amount by which to increase the current value
     #
     #   @return [Fixnum] the current value after incrementation
-    def increment
-      synchronize { ns_set(@value + 1) }
+    def increment(delta = 1)
+      synchronize { ns_set(@value + delta.to_i) }
     end
 
     alias_method :up, :increment
 
     # @!macro [attach] atomic_fixnum_method_decrement
     #
-    #   Decreases the current value by 1.
+    #   Decreases the current value by the given amount (defaults to 1).
+    #
+    #   @param [Fixnum] delta the amount by which to decrease the current value
     #
     #   @return [Fixnum] the current value after decrementation
-    def decrement
-      synchronize { ns_set(@value - 1) }
+    def decrement(delta = 1)
+      synchronize { ns_set(@value - delta.to_i) }
     end
 
     alias_method :down, :decrement
@@ -97,8 +101,8 @@ module Concurrent
     #   @return [Fixnum] true if the value was updated else false
     def compare_and_set(expect, update)
       synchronize do
-        if @value == expect
-          @value = update
+        if @value == expect.to_i
+          @value = update.to_i
           true
         else
           false

--- a/lib/concurrent/edge/lock_free_linked_set.rb
+++ b/lib/concurrent/edge/lock_free_linked_set.rb
@@ -123,8 +123,8 @@ module Concurrent
       #
       #   An iterator to loop through the set.
       #
-      #   @param [Object] item the item you to remove from the set
-      #   @yeild [Object] each item in the set
+      #   @yield [Object] each item in the set
+      #   @yieldparam [Object] item the item you to remove from the set
       #
       #   @return [Object] self: the linked set on which each was called
       def each

--- a/spec/concurrent/atomic/atomic_fixnum_spec.rb
+++ b/spec/concurrent/atomic/atomic_fixnum_spec.rb
@@ -52,15 +52,26 @@ shared_examples :atomic_fixnum do
 
   context '#increment' do
 
-    it 'increases the value by one' do
+    it 'increases the value by one when no argument is given' do
       counter = described_class.new(10)
       3.times{ counter.increment }
       expect(counter.value).to eq 13
     end
 
-    it 'returns the new value' do
+    it 'returns the new value when no argument is given' do
       counter = described_class.new(10)
       expect(counter.increment).to eq 11
+    end
+
+    it 'increases the value by the given argument' do
+      counter = described_class.new(10)
+      counter.increment(5)
+      expect(counter.value).to eq 15
+    end
+
+    it 'returns the new value the given argument' do
+      counter = described_class.new(10)
+      expect(counter.increment(5)).to eq 15
     end
 
     it 'is aliased as #up' do
@@ -70,15 +81,26 @@ shared_examples :atomic_fixnum do
 
   context '#decrement' do
 
-    it 'decreases the value by one' do
+    it 'decreases the value by one when no argument is given' do
       counter = described_class.new(10)
       3.times{ counter.decrement }
       expect(counter.value).to eq 7
     end
 
-    it 'returns the new value' do
+    it 'returns the new value when no argument is given' do
       counter = described_class.new(10)
       expect(counter.decrement).to eq 9
+    end
+
+    it 'decreases the value by the given argument' do
+      counter = described_class.new(10)
+      counter.decrement(5)
+      expect(counter.value).to eq 5
+    end
+
+    it 'returns the new value the given argument' do
+      counter = described_class.new(10)
+      expect(counter.decrement(5)).to eq 5
     end
 
     it 'is aliased as #down' do


### PR DESCRIPTION
`AtomicFixnum` methods `#increment` and `#decrement` now support optional delta.

Suggested [here](https://github.com/ruby-concurrency/concurrent-ruby/issues/383#issuecomment-125378156).
