### PR TITLE
Cleared all interpreter warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ matrix:
     - rvm: jruby-head
     - rvm: 1.9.3
 
-script: bundle exec rake ci
+script: RUBYOPT=-w bundle exec rake ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 ### Upcoming Release v0.9.1 (TBD)
 
+* Fixed a Rubiniux bug in synchronization object
+* Fixed all unterpreter warnings (except circular references)
+* Fixed requires when requiring Atom alone
+* Significantly improved `ThreadLocalVar` on non-JRuby platforms
+* Fixed error handling in Edge `Concurrent.zip`
 * `AtomicFixnum` methods `#increment` and `#decrement` now support optional delta
+* New AtomicFixnum#update` method
+* Minor optimizations in `ReadWriteLock`
+* New `ReentrantReadWriteLock` class
+* `ThreadLocalVar#bind` method is now public
 
 ## Current Release v0.9.0 (10 July 2015)
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Derived from Ruby's [Struct](http://ruby-doc.org/core-2.2.0/Struct.html):
 * [Thread-local variables](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/ThreadLocalVar.html)
 * [Software transactional memory](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/TVar.html) (TVar)
 * [ReadWriteLock](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/ReadWriteLock.html)
+* [ReentrantReadWriteLock](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/ReentrantReadWriteLock.html)
 
 ### Edge Features
 
@@ -127,7 +128,8 @@ be obeyed though. Features developed in `concurrent-ruby-edge` are expected to m
 * [Exchanger](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Exchanger.html)
 * [LazyRegister](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/LazyRegister.html)
 * [Atomic Markable Reference](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Edge/AtomicMarkableReference.html)
-* [Lock Free Linked Set](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Edge/LockFreeLinkedSet.html)
+* [LockFreeLinked Set](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Edge/LockFreeLinkedSet.html)
+* [LockFreeStack](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Edge/LockFreeStack.html)
 
 #### Statuses:
 
@@ -139,8 +141,7 @@ be obeyed though. Features developed in `concurrent-ruby-edge` are expected to m
 - **Channel** - Missing documentation; limted features; stability good.
 - **Exchanger** - Known race condition requiring a new implementation.
 - **LazyRegister** - Missing documentation and tests.
-- **AtomicMarkableReference** - Needs real world battle testing
-- **LockFreeLinkedSet** - Needs real world battle testing
+- **AtomicMarkableReference, LockFreeLinkedSet, LockFreeStack** - Needs real world battle testing
 
 ## Usage
 
@@ -184,8 +185,6 @@ require 'concurrent/actor'          # Concurrent::Actor and supporting code
 require 'concurrent/edge/future'    # new Future Framework
 require 'concurrent/agent'          # Concurrent::Agent
 require 'concurrent/channel '       # Concurrent::Channel and supporting code
-require 'concurrent/exchanger'      # Concurrent::Exchanger
-require 'concurrent/lazy_register'  # Concurrent::LazyRegister
 ```
 
 If the library does not behave as expected, `Concurrent.use_stdlib_logger(Logger::DEBUG)` could help to reveal the problem.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
 build: off
 
 test_script:
-  - bundle exec rake ci
+  - RUBYOPT=-w bundle exec rake ci
 
 environment:
   matrix:

--- a/lib/concurrent/actor/core.rb
+++ b/lib/concurrent/actor/core.rb
@@ -208,7 +208,7 @@ module Concurrent
       end
 
       def initialize_behaviours(opts)
-        @behaviour_definition = (Type! opts[:behaviour_definition] || @context.behaviour_definition, Array).each do |(behaviour, *args)|
+        @behaviour_definition = (Type! opts[:behaviour_definition] || @context.behaviour_definition, Array).each do |(behaviour, _)|
           Child! behaviour, Behaviour::Abstract
         end
         @behaviours           = {}

--- a/lib/concurrent/actor/utils/pool.rb
+++ b/lib/concurrent/actor/utils/pool.rb
@@ -37,7 +37,7 @@ module Concurrent
         end
 
         def on_message(message)
-          command, *rest = message
+          command, _ = message
           return if [:restarted, :reset, :resumed, :terminated].include? command # ignore events from supervised actors
 
           envelope_to_redirect = if envelope.future

--- a/lib/concurrent/collection/copy_on_notify_observer_set.rb
+++ b/lib/concurrent/collection/copy_on_notify_observer_set.rb
@@ -100,7 +100,7 @@ module Concurrent
       end
 
       def duplicate_observers
-        synchronize { observers = @observers.dup }
+        synchronize { @observers.dup }
       end
 
       def notify_to(observers, *args)

--- a/lib/concurrent/configuration.rb
+++ b/lib/concurrent/configuration.rb
@@ -1,9 +1,13 @@
 require 'thread'
-require 'concurrent/atomics'
+require 'concurrent/delay'
 require 'concurrent/errors'
-require 'concurrent/executors'
+require 'concurrent/atomic/atomic_reference'
 require 'concurrent/concern/deprecation'
 require 'concurrent/concern/logging'
+require 'concurrent/executor/timer_set'
+require 'concurrent/executor/immediate_executor'
+require 'concurrent/executor/fixed_thread_pool'
+require 'concurrent/executor/thread_pool_executor'
 require 'concurrent/utility/at_exit'
 require 'concurrent/utility/processor_counter'
 
@@ -32,8 +36,8 @@ module Concurrent
              formatted_message
     end
 
-    lambda do |level, progname, message = nil, &block|
-      logger.add level, message, progname, &block
+    lambda do |loglevel, progname, message = nil, &block|
+      logger.add loglevel, message, progname, &block
     end
   end
 

--- a/lib/concurrent/delay.rb
+++ b/lib/concurrent/delay.rb
@@ -1,5 +1,4 @@
 require 'thread'
-require 'concurrent/configuration'
 require 'concurrent/concern/obligation'
 require 'concurrent/executor/executor'
 require 'concurrent/executor/immediate_executor'

--- a/lib/concurrent/executor/executor.rb
+++ b/lib/concurrent/executor/executor.rb
@@ -1,5 +1,6 @@
-require 'concurrent/executor/executor_service'
+require 'concurrent/configuration'
 require 'concurrent/concern/deprecation'
+require 'concurrent/executor/executor_service'
 
 module Concurrent
 

--- a/lib/concurrent/scheduled_task.rb
+++ b/lib/concurrent/scheduled_task.rb
@@ -1,9 +1,7 @@
 require 'concurrent/errors'
 require 'concurrent/ivar'
-require 'concurrent/configuration'
 require 'concurrent/collection/copy_on_notify_observer_set'
 require 'concurrent/executor/executor'
-require 'concurrent/executor/timer_set'
 require 'concurrent/utility/monotonic_time'
 require 'concurrent/concern/deprecation'
 

--- a/lib/concurrent/utility/at_exit.rb
+++ b/lib/concurrent/utility/at_exit.rb
@@ -12,7 +12,7 @@ module Concurrent
 
     def initialize(*args)
       super()
-      synchronize { ns_initialize *args }
+      synchronize { ns_initialize(*args) }
     end
 
     # Add a handler to be run at `Kernel#at_exit`


### PR DESCRIPTION
* Added parenthesis when using splat operator
* Used _ for unused variables
* Renamed variables when block echoed surrounding scope
* Configuration now autoloads lazily.
* Cleared all circular references.