### PR TITLE
Updates to ThreadLocalVar

### DIFF
--- a/lib/concurrent/atomic/thread_local_var.rb
+++ b/lib/concurrent/atomic/thread_local_var.rb
@@ -83,7 +83,7 @@ module Concurrent
     #
     #   @return [Object] the current value
     def value
-      if array = Thread.current[:__threadlocal_array__]
+      if array = Thread.current.thread_variable_get(:__threadlocal_array__)
         value = array[@index]
         if value.nil?
           @default
@@ -106,8 +106,8 @@ module Concurrent
       # We could keep the thread-local arrays in a hash, keyed by Thread
       # But why? That would require locking
       # Using Ruby's built-in thread-local storage is faster
-      unless array = me[:__threadlocal_array__]
-        array = me[:__threadlocal_array__] = []
+      unless array = me.thread_variable_get(:__threadlocal_array__)
+        array = me.thread_variable_set(:__threadlocal_array__, [])
         LOCK.synchronize { ARRAYS[array.object_id] = array }
         ObjectSpace.define_finalizer(me, self.class.thread_finalizer(array))
       end

--- a/spec/concurrent/atomic/thread_local_var_spec.rb
+++ b/spec/concurrent/atomic/thread_local_var_spec.rb
@@ -27,6 +27,16 @@ module Concurrent
         expect(t1.value).to eq 14
         expect(t2.value).to eq 14
       end
+
+      if Concurrent.on_jruby?
+        it 'extends JavaThreadLocalVar' do
+          expect(subject.class.ancestors).to include(Concurrent::JavaThreadLocalVar)
+        end
+      else
+        it 'extends RubyThreadLocalVar' do
+          expect(subject.class.ancestors).to include(Concurrent::RubyThreadLocalVar)
+        end
+      end
     end
 
     context '#value' do
@@ -37,17 +47,16 @@ module Concurrent
       end
 
       it 'returns the value after modification' do
-        v       = ThreadLocalVar.new(14)
+        v = ThreadLocalVar.new(14)
         v.value = 2
         expect(v.value).to eq 2
       end
-
     end
 
     context '#value=' do
 
       it 'sets a new value' do
-        v       = ThreadLocalVar.new(14)
+        v = ThreadLocalVar.new(14)
         v.value = 2
         expect(v.value).to eq 2
       end
@@ -58,14 +67,14 @@ module Concurrent
       end
 
       it 'does not modify the initial value for other threads' do
-        v       = ThreadLocalVar.new(14)
+        v = ThreadLocalVar.new(14)
         v.value = 2
-        t       = Thread.new { v.value }
+        t = Thread.new { v.value }
         expect(t.value).to eq 14
       end
 
       it 'does not modify the value for other threads' do
-        v       = ThreadLocalVar.new(14)
+        v = ThreadLocalVar.new(14)
         v.value = 2
 
         b1 = CountDownLatch.new(2)
@@ -92,9 +101,6 @@ module Concurrent
         expect(t1.value).to eq 1
         expect(t2.value).to eq 2
       end
-
     end
-
   end
-
 end


### PR DESCRIPTION
This PR included two updates, both of which warrant discussion.

1. Change implementation from fiber-local to thread-local as suggested by @schmurfy [here](https://github.com/ruby-concurrency/concurrent-ruby/pull/376#issuecomment-126299952)
2. Returns the JRuby-specific implementation that was removed in f073cac667cd2daad365ed0b4eda9013d2eca32e.

In my benchmark tests the JRuby version performs significantly worse. The advantage, however, is that it leverages the JVM directly rather than using our Ruby implementation. In our experience, JRuby interop is significantly slower than pure-Java wrappers. Thus we've begun creating pure-Java implementations for some abstraction. It's possible that a pure-Java wrapper--which could be added at any time--will perform significantly better.

My preference is to use the JRuby version since it leveraged the JVM directly, but my feelings aren't strong. I could be convinced otherwise. If memory serves, @pitr-ch echoed this sentiment, but I can't find the comment. I may be wrong on that.

// @alexdowad  