### PR TITLE
MRI 1.9.3 & Rbx updates to TLV

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
 build: off
 
 test_script:
-  - RUBYOPT=-w bundle exec rake ci
+  - bundle exec rake ci
 
 environment:
   matrix:

--- a/spec/concurrent/atomic/reentrant_read_write_lock_spec.rb
+++ b/spec/concurrent/atomic/reentrant_read_write_lock_spec.rb
@@ -1,4 +1,4 @@
-unless Concurrent.on_jruby? || Concurrent.ruby_version(:<, 2)
+unless Concurrent.on_jruby?
 
   # NOTE: These tests depend heavily on the private/undocumented
   # `ThreadLocalVar#value_for` method. This method does not, and cannot work

--- a/spec/concurrent/atomic/thread_local_var_spec.rb
+++ b/spec/concurrent/atomic/thread_local_var_spec.rb
@@ -1,108 +1,105 @@
-unless Concurrent.ruby_version(:<, 2)
+require 'rbconfig'
 
-  require 'rbconfig'
+module Concurrent
 
-  module Concurrent
+  require 'concurrent/atomic/thread_local_var'
 
-    require 'concurrent/atomic/thread_local_var'
+  describe ThreadLocalVar do
 
-    describe ThreadLocalVar do
+    subject { ThreadLocalVar.new }
 
-      subject { ThreadLocalVar.new }
+    context '#initialize' do
 
-      context '#initialize' do
-
-        it 'can set an initial value' do
-          v = ThreadLocalVar.new(14)
-          expect(v.value).to eq 14
-        end
-
-        it 'sets nil as a default initial value' do
-          v = ThreadLocalVar.new
-          expect(v.value).to be_nil
-        end
-
-        it 'sets the same initial value for all threads' do
-          v  = ThreadLocalVar.new(14)
-          t1 = Thread.new { v.value }
-          t2 = Thread.new { v.value }
-          expect(t1.value).to eq 14
-          expect(t2.value).to eq 14
-        end
-
-        if Concurrent.on_jruby?
-          it 'extends JavaThreadLocalVar' do
-            expect(subject.class.ancestors).to include(Concurrent::JavaThreadLocalVar)
-          end
-        else
-          it 'extends RubyThreadLocalVar' do
-            expect(subject.class.ancestors).to include(Concurrent::RubyThreadLocalVar)
-          end
-        end
+      it 'can set an initial value' do
+        v = ThreadLocalVar.new(14)
+        expect(v.value).to eq 14
       end
 
-      context '#value' do
-
-        it 'returns the current value' do
-          v = ThreadLocalVar.new(14)
-          expect(v.value).to eq 14
-        end
-
-        it 'returns the value after modification' do
-          v = ThreadLocalVar.new(14)
-          v.value = 2
-          expect(v.value).to eq 2
-        end
+      it 'sets nil as a default initial value' do
+        v = ThreadLocalVar.new
+        expect(v.value).to be_nil
       end
 
-      context '#value=' do
+      it 'sets the same initial value for all threads' do
+        v  = ThreadLocalVar.new(14)
+        t1 = Thread.new { v.value }
+        t2 = Thread.new { v.value }
+        expect(t1.value).to eq 14
+        expect(t2.value).to eq 14
+      end
 
-        it 'sets a new value' do
-          v = ThreadLocalVar.new(14)
+      if Concurrent.on_jruby?
+        it 'extends JavaThreadLocalVar' do
+          expect(subject.class.ancestors).to include(Concurrent::JavaThreadLocalVar)
+        end
+      else
+        it 'extends RubyThreadLocalVar' do
+          expect(subject.class.ancestors).to include(Concurrent::RubyThreadLocalVar)
+        end
+      end
+    end
+
+    context '#value' do
+
+      it 'returns the current value' do
+        v = ThreadLocalVar.new(14)
+        expect(v.value).to eq 14
+      end
+
+      it 'returns the value after modification' do
+        v = ThreadLocalVar.new(14)
+        v.value = 2
+        expect(v.value).to eq 2
+      end
+    end
+
+    context '#value=' do
+
+      it 'sets a new value' do
+        v = ThreadLocalVar.new(14)
+        v.value = 2
+        expect(v.value).to eq 2
+      end
+
+      it 'returns the new value' do
+        v = ThreadLocalVar.new(14)
+        expect(v.value = 2).to eq 2
+      end
+
+      it 'does not modify the initial value for other threads' do
+        v = ThreadLocalVar.new(14)
+        v.value = 2
+        t = Thread.new { v.value }
+        expect(t.value).to eq 14
+      end
+
+      it 'does not modify the value for other threads' do
+        v = ThreadLocalVar.new(14)
+        v.value = 2
+
+        b1 = CountDownLatch.new(2)
+        b2 = CountDownLatch.new(2)
+
+        t1 = Thread.new do
+          b1.count_down
+          b1.wait
+          v.value = 1
+          b2.count_down
+          b2.wait
+          v.value
+        end
+
+        t2 = Thread.new do
+          b1.count_down
+          b1.wait
           v.value = 2
-          expect(v.value).to eq 2
+          b2.count_down
+          b2.wait
+          v.value
         end
 
-        it 'returns the new value' do
-          v = ThreadLocalVar.new(14)
-          expect(v.value = 2).to eq 2
-        end
-
-        it 'does not modify the initial value for other threads' do
-          v = ThreadLocalVar.new(14)
-          v.value = 2
-          t = Thread.new { v.value }
-          expect(t.value).to eq 14
-        end
-
-        it 'does not modify the value for other threads' do
-          v = ThreadLocalVar.new(14)
-          v.value = 2
-
-          b1 = CountDownLatch.new(2)
-          b2 = CountDownLatch.new(2)
-
-          t1 = Thread.new do
-            b1.count_down
-            b1.wait
-            v.value = 1
-            b2.count_down
-            b2.wait
-            v.value
-          end
-
-          t2 = Thread.new do
-            b1.count_down
-            b1.wait
-            v.value = 2
-            b2.count_down
-            b2.wait
-            v.value
-          end
-
-          expect(t1.value).to eq 1
-          expect(t2.value).to eq 2
-        end
+        expect(t1.value).to eq 1
+        expect(t2.value).to eq 2
       end
     end
   end


### PR DESCRIPTION
In a previous commit (0aa778c8ff2c231ed97b5b24779bd93e0e0d9e57) I updated `ThreadLocalVar` to get/set its internal array using the `thread_variable_get` and `thread_variable_set` methods rather than `[]` and `[]=`. This moved storage from *fiber local* to *thread local*. Unfortunately, neither MRI 1.9.3 nor Rubinius support these methods. This update checks the runtime and adjust accordingly.