### PR TITLE
Renamed PriorityQueue

### DIFF
--- a/lib/concurrent/collection/non_concurrent_priority_queue.rb
+++ b/lib/concurrent/collection/non_concurrent_priority_queue.rb
@@ -12,15 +12,15 @@ module Concurrent
     #
     #   The API is based on the `Queue` class from the Ruby standard library.
     #
-    #   The pure Ruby implementation, `MutexPriorityQueue` uses a heap algorithm
+    #   The pure Ruby implementation, `RubyNonConcurrentPriorityQueue` uses a heap algorithm
     #   stored in an array. The algorithm is based on the work of Robert Sedgewick
     #   and Kevin Wayne.
     #
     #   The JRuby native implementation is a thin wrapper around the standard
-    #   library `java.util.PriorityQueue`.
+    #   library `java.util.NonConcurrentPriorityQueue`.
     #
-    #   When running under JRuby the class `PriorityQueue` extends `JavaPriorityQueue`.
-    #   When running under all other interpreters it extends `MutexPriorityQueue`.
+    #   When running under JRuby the class `NonConcurrentPriorityQueue` extends `JavaNonConcurrentPriorityQueue`.
+    #   When running under all other interpreters it extends `RubyNonConcurrentPriorityQueue`.
     #
     #   @note This implementation is *not* thread safe.
     #
@@ -30,11 +30,11 @@ module Concurrent
     #   @see http://algs4.cs.princeton.edu/24pq/index.php#2.6
     #   @see http://algs4.cs.princeton.edu/24pq/MaxPQ.java.html
     #
-    #   @see http://docs.oracle.com/javase/7/docs/api/java/util/PriorityQueue.html
+    #   @see http://docs.oracle.com/javase/7/docs/api/java/util/NonConcurrentPriorityQueue.html
     # 
     # @!visibility private
     # @!macro internal_implementation_note
-    class MutexPriorityQueue
+    class RubyNonConcurrentPriorityQueue
 
       # @!macro [attach] priority_queue_method_initialize
       #
@@ -161,7 +161,7 @@ module Concurrent
       #   @param [Enumerable] list the list to build the queue from
       #   @param [Hash] opts the options for creating the queue
       #  
-      #   @return [PriorityQueue] the newly created and populated queue
+      #   @return [NonConcurrentPriorityQueue] the newly created and populated queue
       def self.from_list(list, opts = {})
         queue = new(opts)
         list.each{|item| queue << item }
@@ -229,7 +229,7 @@ module Concurrent
       # 
       # @!visibility private
       # @!macro internal_implementation_note
-      class JavaPriorityQueue
+      class JavaNonConcurrentPriorityQueue
 
         # @!macro priority_queue_method_initialize
         def initialize(opts = {})
@@ -303,18 +303,18 @@ module Concurrent
 
     # @!visibility private
     # @!macro internal_implementation_note
-    PriorityQueueImplementation = case
-                                  when Concurrent.on_jruby?
-                                    JavaPriorityQueue
-                                  else
-                                    MutexPriorityQueue
-                                  end
-    private_constant :PriorityQueueImplementation
+    NonConcurrentPriorityQueueImplementation = case
+                                               when Concurrent.on_jruby?
+                                                 JavaNonConcurrentPriorityQueue
+                                               else
+                                                 RubyNonConcurrentPriorityQueue
+                                               end
+    private_constant :NonConcurrentPriorityQueueImplementation
 
     # @!macro priority_queue
     # 
     # @!visibility private
-    class PriorityQueue < PriorityQueueImplementation
+    class NonConcurrentPriorityQueue < NonConcurrentPriorityQueueImplementation
 
       alias_method :has_priority?, :include?
 

--- a/lib/concurrent/executor/timer_set.rb
+++ b/lib/concurrent/executor/timer_set.rb
@@ -1,6 +1,6 @@
 require 'concurrent/scheduled_task'
 require 'concurrent/atomic/event'
-require 'concurrent/collection/priority_queue'
+require 'concurrent/collection/non_concurrent_priority_queue'
 require 'concurrent/executor/executor_service'
 require 'concurrent/executor/single_thread_executor'
 
@@ -72,7 +72,7 @@ module Concurrent
     # @param [Hash] opts the options to create the object with.
     # @!visibility private
     def ns_initialize(opts)
-      @queue          = Collection::PriorityQueue.new(order: :min)
+      @queue          = Collection::NonConcurrentPriorityQueue.new(order: :min)
       @task_executor  = Executor.executor_from_options(opts) || Concurrent.global_io_executor
       @timer_executor = SingleThreadExecutor.new
       @condition      = Event.new

--- a/spec/concurrent/collection/non_concurrent_priority_queue_spec.rb
+++ b/spec/concurrent/collection/non_concurrent_priority_queue_spec.rb
@@ -289,27 +289,27 @@ end
 module Concurrent
   module Collection
 
-    describe MutexPriorityQueue do
+    describe RubyNonConcurrentPriorityQueue do
 
       it_should_behave_like :priority_queue
     end
 
     if Concurrent.on_jruby?
 
-      describe JavaPriorityQueue do
+      describe JavaNonConcurrentPriorityQueue do
 
         it_should_behave_like :priority_queue
       end
     end
 
-    describe PriorityQueue do
+    describe NonConcurrentPriorityQueue do
       if Concurrent.on_jruby?
-        it 'inherits from JavaPriorityQueue' do
-          expect(PriorityQueue.ancestors).to include(JavaPriorityQueue)
+        it 'inherits from JavaNonConcurrentPriorityQueue' do
+          expect(NonConcurrentPriorityQueue.ancestors).to include(JavaNonConcurrentPriorityQueue)
         end
       else
-        it 'inherits from MutexPriorityQueue' do
-          expect(PriorityQueue.ancestors).to include(MutexPriorityQueue)
+        it 'inherits from RubyNonConcurrentPriorityQueue' do
+          expect(NonConcurrentPriorityQueue.ancestors).to include(RubyNonConcurrentPriorityQueue)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,30 +4,32 @@ require 'concurrent-edge'
 
 Concurrent.use_stdlib_logger Logger::FATAL
 
-if ENV['COVERAGE'] || ENV['CI'] || ENV['TRAVIS']
-  require 'simplecov'
-  require 'coveralls'
+unless Concurrent.on_jruby_9000?
+  if ENV['COVERAGE'] || ENV['CI'] || ENV['TRAVIS']
+    require 'simplecov'
+    require 'coveralls'
 
-  if ENV['TRAVIS']
-    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-      SimpleCov::Formatter::HTMLFormatter,
-      Coveralls::SimpleCov::Formatter
-    ]
-  else
-    SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
-  end
+    if ENV['TRAVIS']
+      SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+        SimpleCov::Formatter::HTMLFormatter,
+        Coveralls::SimpleCov::Formatter
+      ]
+    else
+      SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+    end
 
-  SimpleCov.start do
-    project_name 'concurrent-ruby'
-    add_filter '/build-tests/'
-    add_filter '/coverage/'
-    add_filter '/doc/'
-    add_filter '/examples/'
-    add_filter '/pkg/'
-    add_filter '/spec/'
-    add_filter '/tasks/'
-    add_filter '/yard-template/'
-    add_filter '/yardoc/'
+    SimpleCov.start do
+      project_name 'concurrent-ruby'
+      add_filter '/build-tests/'
+      add_filter '/coverage/'
+      add_filter '/doc/'
+      add_filter '/examples/'
+      add_filter '/pkg/'
+      add_filter '/spec/'
+      add_filter '/tasks/'
+      add_filter '/yard-template/'
+      add_filter '/yardoc/'
+    end
   end
 end
 


### PR DESCRIPTION
Renamed `PriorityQueue` to `NonConcurrentPriorityQueue` to better reflect that it is not thread-safe.