### PR TITLE
Priority thread pools

### DIFF
--- a/lib/concurrent/executor/abstract_executor_service.rb
+++ b/lib/concurrent/executor/abstract_executor_service.rb
@@ -10,6 +10,18 @@ module Concurrent
   class AbstractExecutorService < Synchronization::Object
     include ExecutorService
 
+    # @!visibility private
+    Job = Struct.new(:priority, :args, :task) do
+      def execute
+        task.call(*args)
+      end
+    end
+    private_constant :Job
+
+    # @!visibility private
+    Infinity = Float::INFINITY
+    private_constant :Infinity
+
     # The set of possible fallback policies that may be set at thread pool creation.
     FALLBACK_POLICIES = [:abort, :discard, :caller_runs].freeze
 
@@ -67,10 +79,10 @@ module Concurrent
     # Handler which executes the `fallback_policy` once the queue size
     # reaches `max_queue`.
     #
-    # @param [Array] args the arguments to the task which is being handled.
+    # @param [Concurrent::AbstractExecutorService::Job] job the job which is being handled
     #
     # @!visibility private
-    def handle_fallback(*args)
+    def handle_fallback(job)
       case fallback_policy
       when :abort
         raise RejectedExecutionError
@@ -78,7 +90,7 @@ module Concurrent
         false
       when :caller_runs
         begin
-          yield(*args)
+          job.execute
         rescue => ex
           # let it fail
           log DEBUG, ex
@@ -89,7 +101,7 @@ module Concurrent
       end
     end
 
-    def ns_execute(*args, &task)
+    def ns_execute(job)
       raise NotImplementedError
     end
 

--- a/lib/concurrent/executor/cached_thread_pool.rb
+++ b/lib/concurrent/executor/cached_thread_pool.rb
@@ -24,11 +24,15 @@ module Concurrent
   # The API and behavior of this class are based on Java's `CachedThreadPool`
   #
   # @!macro thread_pool_options
+  # @!macro abstract_executor_service_public_api
   class CachedThreadPool < ThreadPoolExecutor
 
     # @!macro [attach] cached_thread_pool_method_initialize
     #
     #   Create a new thread pool.
+    #
+    #   A `CachedThreadPool` cannot be prioritized as the number of threads in the
+    #   pool will grow without bound.
     #
     #   @param [Hash] opts the options defining pool behavior.
     #   @option opts [Symbol] :fallback_policy (`:abort`) the fallback policy
@@ -40,8 +44,15 @@ module Concurrent
       defaults  = { idletime:    DEFAULT_THREAD_IDLETIMEOUT }
       overrides = { min_threads: 0,
                     max_threads: DEFAULT_MAX_POOL_SIZE,
-                    max_queue:   DEFAULT_MAX_QUEUE_SIZE }
+                    max_queue:   DEFAULT_MAX_QUEUE_SIZE,
+                    prioritize:  false }
       super(defaults.merge(opts).merge(overrides))
+    end
+
+    # @!macro executor_service_method_prioritized_question
+    # Always returns false.
+    def prioritized?
+      false
     end
 
     private

--- a/lib/concurrent/executor/executor_service.rb
+++ b/lib/concurrent/executor/executor_service.rb
@@ -39,6 +39,13 @@ module Concurrent
   #     will be post in the order they are received and no two operations may
   #     occur simultaneously. Else false.
 
+  # @!macro [new] executor_service_method_prioritized_question
+  #
+  #   Does this executor allow tasks to be ordered based on a given priority?
+  #
+  #   @return [Boolean] True if the executor provides the caller the ability
+  #   to influence the prioritization of operations post to it. Else false.
+
   ###################################################################
 
   # @!macro [new] executor_service_public_api
@@ -54,6 +61,9 @@ module Concurrent
   #
   #   @!method serialized?
   #     @!macro executor_service_method_serialized_question
+  #
+  #   @!method prioritized?
+  #     @!macro executor_service_method_prioritized_question
 
   ###################################################################
 
@@ -179,6 +189,13 @@ module Concurrent
     #
     # @note Always returns `false`
     def serialized?
+      false
+    end
+
+    # @!macro executor_service_method_prioritized_question
+    #
+    # @note Always returns `false`
+    def prioritized?
       false
     end
   end

--- a/lib/concurrent/executor/executor_service.rb
+++ b/lib/concurrent/executor/executor_service.rb
@@ -17,6 +17,41 @@ module Concurrent
   #
   #   @raise [ArgumentError] if no task is given
 
+  # @!macro [new] executor_service_method_prioritize
+  #
+  #   Submit a prioritized task to the executor for asynchronous processing.
+  #   Tasks will be enqueued in priority order so that tasks with higher
+  #   priority will be executed before tasks with a lower priority.
+  #
+  #   If the queue is empty when a task is post or the pool is capable of
+  #   adding additional threads then prioritization is irrelevant. Tasks
+  #   will be passed to a thread for execution as soon as they are post. When
+  #   the pool is unable to add more threads due to configuration constraints
+  #   and tasks are backing up in the queue then prioritization is important.
+  #   In this situation, tasks with a higher priority will move ahead of tasks
+  #   with a lower priority in the queue.
+  #
+  #   The order in which tasks of the same priority are enqueued with respect
+  #   to one another is undefined.
+  #
+  #   The executor must be configured for prioritization when it is created
+  #   otherwise the `priority` argument is ignored. In that case this
+  #   method becomes the equivalent or the `#post` method.
+  #
+  #   When an executor is configured for prioritization the `#post` method
+  #   posts its tasks with a priority of zero.
+  #
+  #   @param [Fixnum] priority the relative priority of this task with respect
+  #     to all other tasks in the queue
+  #   @param [Array] args zero or more arguments to be passed to the task
+  #
+  #   @yield the asynchronous task to perform
+  #
+  #   @return [Boolean] `true` if the task is queued, `false` if the executor
+  #     is not running
+  #
+  #   @raise [ArgumentError] if no task is given
+
   # @!macro [new] executor_service_method_left_shift
   #
   #   Submit a task to the executor for asynchronous processing.
@@ -44,7 +79,7 @@ module Concurrent
   #   Does this executor allow tasks to be ordered based on a given priority?
   #
   #   @return [Boolean] True if the executor provides the caller the ability
-  #   to influence the prioritization of operations post to it. Else false.
+  #     to influence the prioritization of operations post to it. Else false.
 
   ###################################################################
 
@@ -66,9 +101,6 @@ module Concurrent
   #     @!macro executor_service_method_prioritized_question
 
   ###################################################################
-
-  # @!macro [new] executor_service_attr_reader_fallback_policy
-  #   @return [Symbol] The fallback policy in effect. Either `:abort`, `:discard`, or `:caller_runs`.
 
   # @!macro [new] executor_service_method_shutdown
   #
@@ -132,9 +164,6 @@ module Concurrent
   # @!macro [new] abstract_executor_service_public_api
   #
   #   @!macro executor_service_public_api
-  #
-  #   @!attribute [r] fallback_policy
-  #     @!macro executor_service_attr_reader_fallback_policy
   #
   #   @!method shutdown
   #     @!macro executor_service_method_shutdown

--- a/lib/concurrent/executor/fixed_thread_pool.rb
+++ b/lib/concurrent/executor/fixed_thread_pool.rb
@@ -36,6 +36,9 @@ module Concurrent
   #   The number of tasks that have been completed by the pool since construction.
   #   @return [Integer] The number of tasks that have been completed by the pool since construction.
 
+  # @!macro [new] thread_pool_executor_attr_reader_fallback_policy
+  #   @return [Symbol] The fallback policy in effect. Either `:abort`, `:discard`, or `:caller_runs`.
+
   # @!macro [new] thread_pool_executor_attr_reader_idletime
   #   The number of seconds that a thread may be idle before being reclaimed.
   #   @return [Integer] The number of seconds that a thread may be idle before being reclaimed.
@@ -87,6 +90,9 @@ module Concurrent
   #   @!attribute [r] completed_task_count
   #     @!macro thread_pool_executor_attr_reader_completed_task_count
   #
+  #   @!attribute [r] fallback_policy
+  #     @!macro thread_pool_executor_attr_reader_fallback_policy
+  #
   #   @!attribute [r] idletime
   #     @!macro thread_pool_executor_attr_reader_idletime
   #
@@ -104,6 +110,9 @@ module Concurrent
   #
   #   @!method can_overflow?
   #     @!macro executor_service_method_can_overflow_question
+  #
+  #   @!method prioritized?
+  #     @!macro executor_service_method_prioritized_question
 
 
 
@@ -122,6 +131,8 @@ module Concurrent
   #     will stop the thread pool when the application exits. See below for more information
   #     on shutting down thread pools.
   #   * `fallback_policy`: The policy defining how rejected tasks are handled.
+  #   * `prioritize`: Whether or not tasks waiting in the queue can be given relative
+  #     priority with respect to one another (default: false).
   #
   #   Three fallback policies are supported:
   #
@@ -180,6 +191,7 @@ module Concurrent
   #   The API and behavior of this class are based on Java's `FixedThreadPool`
   #
   # @!macro thread_pool_options
+  # @!macro abstract_executor_service_public_api
   class FixedThreadPool < ThreadPoolExecutor
 
     # @!macro [attach] fixed_thread_pool_method_initialize
@@ -189,6 +201,9 @@ module Concurrent
     #   @param [Integer] num_threads the number of threads to allocate
     #   @param [Hash] opts the options defining pool behavior.
     #   @option opts [Symbol] :fallback_policy (`:abort`) the fallback policy
+    #   @option opts [Boolean] :prioritize (false) when true the queue will be configured
+    #     to prioritize waiting tasks. When false tasks will be enqueued in strict
+    #     first in, first out (FIFO) order. See `#prioritize` for more information.
     #
     #   @raise [ArgumentError] if `num_threads` is less than or equal to zero
     #   @raise [ArgumentError] if `fallback_policy` is not a known policy
@@ -197,10 +212,14 @@ module Concurrent
     def initialize(num_threads, opts = {})
       raise ArgumentError.new('number of threads must be greater than zero') if num_threads.to_i < 1
       defaults  = { max_queue:   DEFAULT_MAX_QUEUE_SIZE,
-                    idletime:    DEFAULT_THREAD_IDLETIMEOUT }
+                    idletime:    DEFAULT_THREAD_IDLETIMEOUT,
+                    prioritize:  false }
       overrides = { min_threads: num_threads,
                     max_threads: num_threads }
       super(defaults.merge(opts).merge(overrides))
     end
+
+    # @!method prioritize(priority, *args, &task)
+    #   @!macro executor_service_method_prioritize
   end
 end

--- a/lib/concurrent/executor/java_single_thread_executor.rb
+++ b/lib/concurrent/executor/java_single_thread_executor.rb
@@ -17,12 +17,34 @@ if Concurrent.on_jruby?
         super(opts)
       end
 
+      # @!macro executor_service_method_prioritized_question
+      def prioritized?
+        @prioritized
+      end
+
+      # @!method prioritize(priority, *args, &task)
+      #   @!macro executor_service_method_prioritize
+      public :prioritize
+
       private
-      
+
       def ns_initialize(opts)
-        @executor = java.util.concurrent.Executors.newSingleThreadExecutor
+
         @fallback_policy = opts.fetch(:fallback_policy, :discard)
         raise ArgumentError.new("#{@fallback_policy} is not a valid fallback policy") unless FALLBACK_POLICY_CLASSES.keys.include?(@fallback_policy)
+
+        @prioritized = opts.fetch(:prioritize, false)
+
+        if @prioritized
+          queue = java.util.concurrent.PriorityBlockingQueue.new
+          @executor = java.util.concurrent.ThreadPoolExecutor.new(
+            1, 1,
+            java.lang.Long::MAX_VALUE, java.util.concurrent.TimeUnit::NANOSECONDS,
+            queue, FALLBACK_POLICY_CLASSES[@fallback_policy].new)
+        else
+          @executor = java.util.concurrent.Executors.newSingleThreadExecutor
+        end
+
         self.auto_terminate = opts.fetch(:auto_terminate, true)
       end
     end

--- a/lib/concurrent/executor/ruby_executor_service.rb
+++ b/lib/concurrent/executor/ruby_executor_service.rb
@@ -16,10 +16,11 @@ module Concurrent
 
     def post(*args, &task)
       raise ArgumentError.new('no block given') unless block_given?
+      job = Job.new(0, args, task)
+      # If the executor is shut down, reject this task
+      return handle_fallback(job) unless running?
       synchronize do
-        # If the executor is shut down, reject this task
-        return handle_fallback(*args, &task) unless running?
-        ns_execute(*args, &task)
+        ns_execute(job)
         true
       end
     end

--- a/lib/concurrent/executor/ruby_single_thread_executor.rb
+++ b/lib/concurrent/executor/ruby_single_thread_executor.rb
@@ -1,6 +1,8 @@
 require 'thread'
+require 'concurrent/collection/non_concurrent_priority_queue'
 require 'concurrent/executor/ruby_executor_service'
 require 'concurrent/executor/serial_executor_service'
+require 'concurrent/synchronization/object'
 
 module Concurrent
 
@@ -11,19 +13,52 @@ module Concurrent
   class RubySingleThreadExecutor < RubyExecutorService
     include SerialExecutorService
 
-    # @!visibility private
     STOP_JOB = Job.new(-Infinity, :stop, :stop).freeze
     private_constant :STOP_JOB
+
+    class PriorityBlockingQueue < Synchronization::Object
+      def initialize
+        super()
+        @queue = Concurrent::Collection::NonConcurrentPriorityQueue.new(order: :max)
+        ensure_ivar_visibility!
+      end
+
+      def clear
+        synchronize { @queue.clear }
+      end
+
+      def push(item)
+        synchronize { @queue.push(item) }
+      end
+
+      def pop
+        loop do
+          item = synchronize { @queue.pop }
+          break item if item
+        end
+      end
+    end
+    private_constant :PriorityBlockingQueue
 
     # @!macro single_thread_executor_method_initialize
     def initialize(opts = {})
       super
     end
 
+    # @!macro executor_service_method_prioritized_question
+    def prioritized?
+      @prioritized
+    end
+
+    # @!method prioritize(priority, *args, &task)
+    #   @!macro executor_service_method_prioritize
+    public :prioritize
+
     private
 
     def ns_initialize(opts)
-      @queue = Queue.new
+      @prioritized = opts.fetch(:prioritize, false)
+      @queue = @prioritized ? PriorityBlockingQueue.new : Queue.new
       @thread = nil
       @fallback_policy = opts.fetch(:fallback_policy, :discard)
       raise ArgumentError.new("#{@fallback_policy} is not a valid fallback policy") unless FALLBACK_POLICIES.include?(@fallback_policy)
@@ -33,12 +68,12 @@ module Concurrent
     # @!visibility private
     def ns_execute(job)
       supervise
-      @queue << job
+      @queue.push(job)
     end
 
     # @!visibility private
     def ns_shutdown_execution
-      @queue << STOP_JOB
+      @queue.push(STOP_JOB)
       stopped_event.set unless alive?
     end
 
@@ -72,7 +107,7 @@ module Concurrent
         job = @queue.pop
         break if job == STOP_JOB
         begin
-          job.execute
+          job.run
         rescue => ex
           # let it fail
           log DEBUG, ex

--- a/lib/concurrent/executor/single_thread_executor.rb
+++ b/lib/concurrent/executor/single_thread_executor.rb
@@ -35,6 +35,9 @@ module Concurrent
     #   @option opts [Symbol] :fallback_policy (:discard) the policy for
     #     handling new tasks that are received when the queue size has
     #     reached `max_queue` or after the executor has shut down
+    #   @option opts [Boolean] :prioritize (false) when true the queue will be configured
+    #     to prioritize waiting tasks. When false tasks will be enqueued in strict
+    #     first in, first out (FIFO) order. See `#prioritize` for more information.
     #
     #   @see http://docs.oracle.com/javase/tutorial/essential/concurrency/pools.html
     #   @see http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Executors.html
@@ -42,5 +45,8 @@ module Concurrent
 
     # @!method initialize(opts = {})
     #   @!macro single_thread_executor_method_initialize
+
+    # @!method prioritize(priority, *args, &task)
+    #   @!macro executor_service_method_prioritize
   end
 end

--- a/lib/concurrent/executor/thread_pool_executor.rb
+++ b/lib/concurrent/executor/thread_pool_executor.rb
@@ -67,6 +67,9 @@ module Concurrent
     #   @option opts [Symbol] :fallback_policy (:abort) the policy for handling new
     #     tasks that are received when the queue size has reached
     #     `max_queue` or the executor has shut down
+    #   @option opts [Boolean] :prioritize (false) when true the queue will be configured
+    #     to prioritize waiting tasks. When false tasks will be enqueued in strict
+    #     first in, first out (FIFO) order. See `#prioritize` for more information.
     #  
     #   @raise [ArgumentError] if `:max_threads` is less than one
     #   @raise [ArgumentError] if `:min_threads` is less than zero
@@ -77,5 +80,8 @@ module Concurrent
 
     # @!method initialize(opts = {})
     #   @!macro thread_pool_executor_method_initialize
+
+    # @!method prioritize(priority, *args, &task)
+    #   @!macro executor_service_method_prioritize
   end
 end

--- a/spec/concurrent/executor/cached_thread_pool_spec.rb
+++ b/spec/concurrent/executor/cached_thread_pool_spec.rb
@@ -10,7 +10,7 @@ module Concurrent
 
     after(:each) do
       subject.kill
-      sleep(0.1)
+      subject.wait_for_termination(0.1)
     end
 
     it_should_behave_like :thread_pool

--- a/spec/concurrent/executor/executor_service_shared.rb
+++ b/spec/concurrent/executor/executor_service_shared.rb
@@ -4,7 +4,7 @@ shared_examples :executor_service do
 
   after(:each) do
     subject.kill
-    sleep(0.1)
+    subject.wait_for_termination(0.1)
   end
 
   it_should_behave_like :global_thread_pool

--- a/spec/concurrent/executor/fixed_thread_pool_spec.rb
+++ b/spec/concurrent/executor/fixed_thread_pool_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'thread_pool_shared'
+require_relative 'prioritized_thread_pool_shared'
 
 module Concurrent
 
@@ -9,10 +10,15 @@ module Concurrent
 
     after(:each) do
       subject.kill
-      sleep(0.1)
+      subject.wait_for_termination(0.1)
     end
 
     it_should_behave_like :thread_pool
+
+    context 'when prioritized' do
+      subject { described_class.new(1, prioritize: true) }
+      it_behaves_like :prioritized_thread_pool
+    end
 
     context '#initialize default values' do
 

--- a/spec/concurrent/executor/java_single_thread_executor_spec.rb
+++ b/spec/concurrent/executor/java_single_thread_executor_spec.rb
@@ -1,6 +1,7 @@
 if Concurrent.on_jruby?
 
   require_relative 'executor_service_shared'
+  require_relative 'prioritized_thread_pool_shared'
 
   module Concurrent
 
@@ -8,12 +9,16 @@ if Concurrent.on_jruby?
 
       after(:each) do
         subject.kill
-        sleep(0.1)
+        subject.wait_for_termination(0.1)
       end
 
       subject { JavaSingleThreadExecutor.new }
-
       it_should_behave_like :executor_service
+
+      context 'when prioritized' do
+        subject { JavaSingleThreadExecutor.new(prioritize: true) }
+        it_behaves_like :prioritized_thread_pool
+      end
     end
   end
 end

--- a/spec/concurrent/executor/prioritized_thread_pool_shared.rb
+++ b/spec/concurrent/executor/prioritized_thread_pool_shared.rb
@@ -1,0 +1,63 @@
+shared_examples :prioritized_thread_pool do
+
+  after(:each) do
+    subject.kill
+    subject.wait_for_termination(0.1)
+  end
+
+  specify { expect(subject).to be_prioritized }
+
+  it 'executes tasks in priority order' do
+    count = 10
+    start_latch = Concurrent::CountDownLatch.new
+    continue_latch = Concurrent::CountDownLatch.new
+    end_latch = Concurrent::CountDownLatch.new(count)
+    actual = []
+
+    subject.post{ start_latch.count_down; continue_latch.wait(1) }
+    start_latch.wait(1)
+
+    [*1..count].shuffle.each do |i|
+      subject.prioritize(i, i) do |x|
+        actual << x
+        end_latch.count_down
+      end
+    end
+
+    continue_latch.count_down
+    end_latch.wait(1)
+
+    expect(actual).to eq [*1..count].reverse
+  end
+
+  it 'executes unprioritized tasks last' do
+    count = 5
+    filler = 42
+    start_latch = Concurrent::CountDownLatch.new
+    continue_latch = Concurrent::CountDownLatch.new
+    end_latch = Concurrent::CountDownLatch.new(count * 2)
+    actual = []
+
+    subject.post{ start_latch.count_down; continue_latch.wait(1) }
+    start_latch.wait(1)
+
+    [*1..count].shuffle.each do |i|
+      subject.prioritize(i, i) do |x|
+        actual << x
+        end_latch.count_down
+      end
+    end
+
+    [*count+1..count*2].shuffle.each do |i|
+      subject.post do
+        actual << filler
+        end_latch.count_down
+      end
+    end
+
+    continue_latch.count_down
+    end_latch.wait(1)
+
+    expect(actual).to eq [*1..count].reverse + Array.new(count, filler)
+  end
+end

--- a/spec/concurrent/executor/ruby_single_thread_executor_spec.rb
+++ b/spec/concurrent/executor/ruby_single_thread_executor_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'executor_service_shared'
+require_relative 'prioritized_thread_pool_shared'
 
 module Concurrent
 
@@ -6,11 +7,15 @@ module Concurrent
 
     after(:each) do
       subject.kill
-      sleep(0.1)
+      subject.wait_for_termination(0.1)
     end
 
     subject { RubySingleThreadExecutor.new }
+    it_behaves_like :executor_service
 
-    it_should_behave_like :executor_service
+    context 'when prioritized' do
+      subject { RubySingleThreadExecutor.new(prioritize: true) }
+      it_behaves_like :prioritized_thread_pool
+    end
   end
 end

--- a/spec/concurrent/executor/ruby_thread_pool_executor_spec.rb
+++ b/spec/concurrent/executor/ruby_thread_pool_executor_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'thread_pool_executor_shared'
+require_relative 'prioritized_thread_pool_shared'
 
 module Concurrent
 
@@ -6,11 +7,11 @@ module Concurrent
 
     after(:each) do
       subject.kill
-      sleep(0.1)
+      subject.wait_for_termination(0.1)
     end
 
     subject do
-      RubyThreadPoolExecutor.new(
+      described_class.new(
         min_threads: 2,
         max_threads: 5,
         idletime: 60,
@@ -23,12 +24,17 @@ module Concurrent
 
     it_should_behave_like :thread_pool_executor
 
+    context 'when prioritized' do
+      subject { described_class.new(min_threads: 1, max_threads: 1, prioritize: true) }
+      it_behaves_like :prioritized_thread_pool
+    end
+
     context '#remaining_capacity' do
 
       let!(:expected_max){ 100 }
 
       subject do
-        RubyThreadPoolExecutor.new(
+        described_class.new(
           min_threads: 10,
           max_threads: 20,
           idletime: 60,

--- a/spec/concurrent/executor/thread_pool_shared.rb
+++ b/spec/concurrent/executor/thread_pool_shared.rb
@@ -4,7 +4,7 @@ shared_examples :thread_pool do
 
   after(:each) do
     subject.kill
-    sleep(0.1)
+    subject.wait_for_termination(0.1)
   end
 
   it_should_behave_like :executor_service


### PR DESCRIPTION
The thread pool classes listed below now have a `:prioritize` constructor option that allows jobs waiting in queue to be prioritized. When `false` (the default) the pools work the way they previously did. When `true` the internal queue is prioritized based on an integer value given when the job is post.

This is a continuation of the spikes done in PRs #400 and #404

The `#prioritized?` predicate methods indicates whether the thread pool is working in prioritized mode or not.

The `#post` method works the way it always did. When the pool is prioritized the `#post` method sets the priority to zero.

The new `#prioritize` method is a copy of the `#post` method except that it takes an integer `priority` parameter. When the pool is in non-priority mode the `priority` parameter is ignored.

When operating in non-priority mode the thread pools have nearly identical performance as they did before.

When in priority mode, thread pool performance is degraded slightly, but this is to be expected. Prioritizing the queue involves overhead.

The Java implementation uses `java.util.concurrent.PriorityBlockingQueue` internally so performance is still very good,