### PR TITLE
Fix if statement in atomic_reference_spec.rb

### DIFF
--- a/lib/concurrent/utility/native_extension_loader.rb
+++ b/lib/concurrent/utility/native_extension_loader.rb
@@ -14,6 +14,10 @@ module Concurrent
       def allow_c_extensions?
         Concurrent.on_cruby?
       end
+   
+      def loaded_c_extensions?
+        NativeExtensionLoader.instance_variable_get(:@c_ext_loaded)
+      end
 
       if Concurrent.on_cruby? && !@c_ext_loaded
         tries = [

--- a/spec/concurrent/atomic/atomic_reference_spec.rb
+++ b/spec/concurrent/atomic/atomic_reference_spec.rb
@@ -172,7 +172,7 @@ module Concurrent
       it 'inherits from JavaAtomicReference' do
         expect(AtomicReference.ancestors).to include(Concurrent::JavaAtomicReference)
       end
-    elsif Concurrent.allow_c_extensions?
+    elsif Concurrent.loaded_c_extensions?
       it 'inherits from CAtomicReference' do
         expect(AtomicReference.ancestors).to include(Concurrent::CAtomicReference)
       end
@@ -210,7 +210,7 @@ module Concurrent
       it 'inherits from JavaAtomicReference' do
         expect(AtomicReference.ancestors).to include(Concurrent::JavaAtomicReference)
       end
-    elsif Concurrent.allow_c_extensions?
+    elsif Concurrent.loaded_c_extensions?
       it 'inherits from CAtomicReference' do
         expect(AtomicReference.ancestors).to include(Concurrent::CAtomicReference)
       end


### PR DESCRIPTION
Running the test after executing ``` rake clean clobber ``` shows the following errors if we use mri ruby,(ruby 2.1.0, 2.2.2) 

```ruby
> bundle exec rake clean clobber
> bundle exec rspec spec/concurrent/atomic/atomic_reference_spec.rb

1) Concurrent::AtomicReference inherits from CAtomicReference
     Failure/Error: expect(AtomicReference.ancestors).to include(Concurrent::CAtomicReference)
     NameError:
       uninitialized constant Concurrent::CAtomicReference
     # ./spec/concurrent/atomic/atomic_reference_spec.rb:177:in `block (2 levels) in <module:Concurrent>'

  2) Concurrent::AtomicReference inherits from CAtomicReference
     Failure/Error: expect(AtomicReference.ancestors).to include(Concurrent::CAtomicReference)
     NameError:
       uninitialized constant Concurrent::CAtomicReference
     # ./spec/concurrent/atomic/atomic_reference_spec.rb:215:in `block (2 levels) in <module:Concurrent>'
```

No error occurs if we execute ``` rake compile ``` before running the test.

```ruby
> bundle exec rake compile
> bundle exec rspec spec/concurrent/atomic/atomic_reference_spec.rb

52 examples, 0 failures
```

In this commit, the `'Concurrent::AtomicReference inherits from CAtomicReference'` test cases are run only if `@c_ext_loaded` is true.