### PR TITLE
Fixed circular reference.

### DIFF
--- a/build-tests/runner.rb
+++ b/build-tests/runner.rb
@@ -102,13 +102,13 @@ puts RUBY_PLATFORM
 puts SUITE_BREAK
 
 run_test_suite(TEST_FILES, false)
-#if mri?
-  #if ! windows?
-    #puts SUITE_BREAK
-    #run_test_suite(TEST_FILES, true)
-  #end
-  #if platform_specific_extensions?(RUBY_PLATFORM)
-    #puts SUITE_BREAK
-    #run_test_suite(TEST_FILES, true, RUBY_PLATFORM)
-  #end
-#end
+if mri?
+  if ! windows?
+    puts SUITE_BREAK
+    run_test_suite(TEST_FILES, true)
+  end
+  if platform_specific_extensions?(RUBY_PLATFORM)
+    puts SUITE_BREAK
+    run_test_suite(TEST_FILES, true, RUBY_PLATFORM)
+  end
+end

--- a/lib/concurrent/synchronization.rb
+++ b/lib/concurrent/synchronization.rb
@@ -1,6 +1,8 @@
 require 'concurrent/utility/engine'
 
 require 'concurrent/synchronization/abstract_object'
+require 'concurrent/utility/native_extension_loader' # load native parts first
+
 require 'concurrent/synchronization/mri_object'
 require 'concurrent/synchronization/jruby_object'
 require 'concurrent/synchronization/rbx_object'
@@ -11,7 +13,6 @@ require 'concurrent/synchronization/mri_lockable_object'
 require 'concurrent/synchronization/jruby_lockable_object'
 require 'concurrent/synchronization/rbx_lockable_object'
 
-require 'concurrent/utility/native_extension_loader' # load native part first
 require 'concurrent/synchronization/lockable_object'
 
 require 'concurrent/synchronization/condition'

--- a/lib/concurrent/utility/native_extension_loader.rb
+++ b/lib/concurrent/utility/native_extension_loader.rb
@@ -1,4 +1,4 @@
-require 'concurrent/synchronization' # has to be loaded before JRuby extensions
+require 'concurrent/synchronization/abstract_object' # must be loaded before JRuby extensions
 require 'concurrent/utility/engine'
 
 module Concurrent


### PR DESCRIPTION
The master branch generates a circular reference warning when the gem is loaded. This PR fixes that warning. The warning can be seen by running the command `bundle exec ruby -w -e "require 'concurrent'"`. The output of running this command is below.

On MRI:

```
[19:58:44 jerry ~/Projects/ruby-concurrency/concurrent-ruby (master)]$ bundle exec ruby -w -e "require 'concurrent'"
/home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/utility/native_extension_loader.rb:1: warning: loading in progress, circular require considered harmful - /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/synchronization.rb
	from -e:1:in  `<main>'
	from -e:1:in  `require'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent.rb:4:in  `<top (required)>'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent.rb:4:in  `require'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/configuration.rb:2:in  `<top (required)>'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/configuration.rb:2:in  `require'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/delay.rb:2:in  `<top (required)>'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/delay.rb:2:in  `require'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/concern/obligation.rb:4:in  `<top (required)>'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/concern/obligation.rb:4:in  `require'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/atomic/event.rb:2:in  `<top (required)>'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/atomic/event.rb:2:in  `require'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/synchronization.rb:14:in  `<top (required)>'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/synchronization.rb:14:in  `require'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/utility/native_extension_loader.rb:1:in  `<top (required)>'
	from /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/utility/native_extension_loader.rb:1:in  `require'
```

On JRuby:

```
[19:57:29 jerry ~/Projects/ruby-concurrency/concurrent-ruby (master)]$ bundle exec ruby -w -e "require 'concurrent'"
Picked up JAVA_TOOL_OPTIONS: -javaagent:/usr/share/java/jayatanaag.jar 
Picked up JAVA_TOOL_OPTIONS: -javaagent:/usr/share/java/jayatanaag.jar 
/home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/utility/native_extension_loader.rb:1 warning: loading in progress, circular require considered harmful - concurrent/synchronization
  require at org/jruby/RubyKernel.java:1071
   (root) at /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/utility/native_extension_loader.rb:1
  require at org/jruby/RubyKernel.java:1071
   (root) at /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/synchronization.rb:1
  require at org/jruby/RubyKernel.java:1071
   (root) at /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/synchronization.rb:14
  require at org/jruby/RubyKernel.java:1071
   (root) at /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/atomic/event.rb:1
  require at org/jruby/RubyKernel.java:1071
   (root) at /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/atomic/event.rb:2
  require at org/jruby/RubyKernel.java:1071
   (root) at /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/concern/obligation.rb:1
  require at org/jruby/RubyKernel.java:1071
   (root) at /home/jerry/Projects/ruby-concurrency/concurrent-ruby/lib/concurrent/concern/obligation.rb:4
  require at org/jruby/RubyKernel.java:1071
   (root) at -e:1
```