### PR TITLE
Fix buggy tests

### DIFF
--- a/spec/concurrent/future_spec.rb
+++ b/spec/concurrent/future_spec.rb
@@ -85,8 +85,9 @@ module Concurrent
         Future.execute(executor: executor){ nil }
       end
 
-      it 'uses the global io executor by default', buggy: true do
-        expect(Concurrent).to receive(:global_io_executor).and_return(executor)
+      it 'uses the global io executor by default' do
+        allow(Concurrent).to receive(:global_io_executor).and_return(executor)
+        expect(executor).to receive(:post).and_call_original
         Future.execute{ nil }
       end
     end


### PR DESCRIPTION
### Fixed a few buggy tests:

- Concurrent::Agent#restart when #failed? does not clear the action queue when :clear_actions is false
- Concurrent::Future#initialize uses the global io executor by default