### PR TITLE
move attr_volatile into Concurrent::Synchronization::Volatile module

### DIFF
--- a/ext/com/concurrent_ruby/ext/SynchronizationLibrary.java
+++ b/ext/com/concurrent_ruby/ext/SynchronizationLibrary.java
@@ -87,6 +87,10 @@ public class SynchronizationLibrary implements Library {
 
     // module JRubyAttrVolatile
     public static class JRubyAttrVolatile {
+
+        // volatile threadContext is used as a memory barrier per the JVM memory model happens-before semantic
+        // on volatile fields. any volatile field could have been used but using the thread context is an
+        // attempt to avoid code elimination.
         private static volatile ThreadContext threadContext = null;
 
         @JRubyMethod(name = "full_memory_barrier", visibility = Visibility.PRIVATE)

--- a/lib/concurrent/synchronization.rb
+++ b/lib/concurrent/synchronization.rb
@@ -5,6 +5,7 @@ require 'concurrent/synchronization/mri_object'
 require 'concurrent/synchronization/jruby_object'
 require 'concurrent/synchronization/rbx_object'
 require 'concurrent/synchronization/object'
+require 'concurrent/synchronization/volatile'
 
 require 'concurrent/synchronization/abstract_lockable_object'
 require 'concurrent/synchronization/mri_lockable_object'

--- a/lib/concurrent/synchronization/jruby_object.rb
+++ b/lib/concurrent/synchronization/jruby_object.rb
@@ -3,33 +3,41 @@ module Concurrent
 
     if Concurrent.on_jruby?
 
+      module JRubyAttrVolatile
+        def self.included(base)
+          base.extend(ClassMethods)
+        end
+
+        module ClassMethods
+          def attr_volatile(*names)
+            names.each do |name|
+
+              ivar = :"@volatile_#{name}"
+
+              class_eval <<-RUBY, __FILE__, __LINE__ + 1
+                def #{name}
+                  instance_variable_get_volatile(:#{ivar})
+                end
+
+                def #{name}=(value)
+                  instance_variable_set_volatile(:#{ivar}, value)
+                end
+              RUBY
+
+            end
+            names.map { |n| [n, :"#{n}="] }.flatten
+          end
+        end
+      end
+
       # @!visibility private
       # @!macro internal_implementation_note
       class JRubyObject < AbstractObject
+        include JRubyAttrVolatile
 
         def initialize
           # nothing to do
         end
-
-        def self.attr_volatile(*names)
-          names.each do |name|
-
-            ivar = :"@volatile_#{name}"
-
-            class_eval <<-RUBY, __FILE__, __LINE__ + 1
-              def #{name}
-                instance_variable_get_volatile(:#{ivar})
-              end
-
-              def #{name}=(value)
-                instance_variable_set_volatile(:#{ivar}, value)
-              end
-            RUBY
-
-          end
-          names.map { |n| [n, :"#{n}="] }.flatten
-        end
-
       end
     end
   end

--- a/lib/concurrent/synchronization/mri_object.rb
+++ b/lib/concurrent/synchronization/mri_object.rb
@@ -1,35 +1,43 @@
 module Concurrent
   module Synchronization
 
-    # @!visibility private
-    # @!macro internal_implementation_note
-    class MriObject < AbstractObject
+    module MriAttrVolatile
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
 
-      def initialize
-        # nothing to do
+      module ClassMethods
+        def attr_volatile(*names)
+          names.each do |name|
+            ivar = :"@volatile_#{name}"
+            class_eval <<-RUBY, __FILE__, __LINE__ + 1
+              def #{name}
+                #{ivar}
+              end
+
+              def #{name}=(value)
+                #{ivar} = value
+              end
+            RUBY
+          end
+          names.map { |n| [n, :"#{n}="] }.flatten
+        end
       end
 
       def full_memory_barrier
         # relying on undocumented behavior of CRuby, GVL acquire has lock which ensures visibility of ivars
         # https://github.com/ruby/ruby/blob/ruby_2_2/thread_pthread.c#L204-L211
       end
-
-      def self.attr_volatile(*names)
-        names.each do |name|
-          ivar = :"@volatile_#{name}"
-          class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def #{name}
-          #{ivar}
-            end
-
-            def #{name}=(value)
-              #{ivar} = value
-            end
-          RUBY
-        end
-        names.map { |n| [n, :"#{n}="] }.flatten
-      end
     end
 
+    # @!visibility private
+    # @!macro internal_implementation_note
+    class MriObject < AbstractObject
+      include MriAttrVolatile
+
+      def initialize
+        # nothing to do
+      end
+    end
   end
 end

--- a/lib/concurrent/synchronization/rbx_object.rb
+++ b/lib/concurrent/synchronization/rbx_object.rb
@@ -1,37 +1,45 @@
 module Concurrent
   module Synchronization
 
+    module RbxAttrVolatile
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
 
-    # @!visibility private
-    # @!macro internal_implementation_note
-    class RbxObject < AbstractObject
-      def initialize
-        # nothing to do
+      module ClassMethods
+        def attr_volatile(*names)
+          names.each do |name|
+            ivar = :"@volatile_#{name}"
+            class_eval <<-RUBY, __FILE__, __LINE__ + 1
+              def #{name}
+                Rubinius.memory_barrier
+                #{ivar}
+              end
+
+              def #{name}=(value)
+                #{ivar} = value
+                Rubinius.memory_barrier
+              end
+            RUBY
+          end
+          names.map { |n| [n, :"#{n}="] }.flatten
+        end
       end
 
       def full_memory_barrier
         # Rubinius instance variables are not volatile so we need to insert barrier
         Rubinius.memory_barrier
       end
-
-      def self.attr_volatile *names
-        names.each do |name|
-          ivar = :"@volatile_#{name}"
-          class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def #{name}
-              Rubinius.memory_barrier
-              #{ivar}
-            end
-
-            def #{name}=(value)
-              #{ivar} = value
-              Rubinius.memory_barrier
-            end
-          RUBY
-        end
-        names.map { |n| [n, :"#{n}="] }.flatten
-      end
     end
 
+    # @!visibility private
+    # @!macro internal_implementation_note
+    class RbxObject < AbstractObject
+      include RbxAttrVolatile
+
+      def initialize
+        # nothing to do
+      end
+    end
   end
 end

--- a/lib/concurrent/synchronization/volatile.rb
+++ b/lib/concurrent/synchronization/volatile.rb
@@ -1,0 +1,35 @@
+module Concurrent
+  module Synchronization
+
+    # Volatile adds the attr_volatile class method when included.
+    #
+    # @example
+    #   class Foo
+    #     include Concurrent::Synchronization::Volatile
+    #
+    #     attr_volatile :bar
+    #
+    #     def initialize
+    #       @volatile_bar = 1
+    #     end
+    #   end
+    #
+    #  foo = Foo.new
+    #  foo.bar
+    #  => 1
+    #  foo.bar = 2
+    #  => 2
+
+    Volatile = case
+    when Concurrent.on_cruby?
+      MriAttrVolatile
+    when Concurrent.on_jruby?
+      JRubyAttrVolatile
+    when Concurrent.on_rbx?
+      RbxAttrVolatile
+    else
+      warn 'Possibly unsupported Ruby implementation'
+      MriAttrVolatile
+    end
+  end
+end

--- a/lib/concurrent/synchronization/volatile.rb
+++ b/lib/concurrent/synchronization/volatile.rb
@@ -10,7 +10,7 @@ module Concurrent
     #     attr_volatile :bar
     #
     #     def initialize
-    #       @volatile_bar = 1
+    #       self.bar = 1
     #     end
     #   end
     #


### PR DESCRIPTION
add a new `Concurrent::Synchronization::Volatile` module which can be included into any class to add the `attr_volatile` class method. 

Example:
```ruby
class Foo
  include Concurrent::Synchronization::Volatile

  attr_volatile :bar

  def initialize
    self.bar = 1
  end
end

foo = Foo.new
foo.bar
=> 1
foo.bar = 2
=> 2
```

For this the respective `{jruby|mri|rbx}_object.rb` have been refactored into modules but the original classes were preserved and uses the new modules so not to break backward compatibility.

The Java JRuby synchronization library has been refactored to also add the previous `JRubyObject` method in the new `JRubyAttrVolatile ` module. 

I believe the only risk with the Java synchronization library changes is related to having the volatile  `threadContext` field used as a memory barrier to now be located at the module level and thus will be shared across the including objects using the module. I believe the `happens-before` / memory barrier is preserved but may be less efficient than having per-object volatile field as memory barrier. 

I only tested on JRuby 1.7.22 and all specs are passing.

- [x] add specific specs for the module inclusion
- [x] mri build and run specs
- [ ] rbx build and run specs