### PR TITLE
Concurrent::Edge::AbstractPromise now rescues Exception

### DIFF
--- a/lib/concurrent/edge/future.rb
+++ b/lib/concurrent/edge/future.rb
@@ -925,8 +925,11 @@ module Concurrent
       # @return [Future]
       def evaluate_to(*args, block)
         complete_with Future::Success.new(block.call(*args))
-      rescue => error
+      rescue StandardError => error
         complete_with Future::Failed.new(error)
+      rescue Exception => error
+        complete_with Future::Failed.new(error)
+        raise error
       end
     end
 

--- a/spec/concurrent/edge/future_spec.rb
+++ b/spec/concurrent/edge/future_spec.rb
@@ -313,6 +313,14 @@ describe 'Concurrent::Edge futures' do
       f = Concurrent.future { Concurrent.future { 1 } }.flat.then(&:succ)
       expect(f.value!).to eq 2
     end
+
+    it 'completes future when Exception raised' do
+      f = Concurrent.future { raise Exception, 'fail' }
+      sleep 0.2
+      expect(f).to be_completed
+      expect(f).to be_failed
+      expect{ f.value! }.to raise_error(Exception, 'fail')
+    end
   end
 
   describe 'interoperability' do


### PR DESCRIPTION
This fixes a bug which causes Futures to hang and never complete if the code within raises a subclass of `Exception`.

Example:

```ruby
module WebMock
  class NetConnectNotAllowedError < Exception; end
end

f = Concurrent.future { raise WebMock::NetConnectNotAllowedError, 'fail' }
f.value! # Hangs
```

See https://github.com/bblimke/webmock/pull/301 for WebMock's (valid) justification for subclassing `Exception` over `StandardError`.