### PR TITLE
Improved java extension loading.

### DIFF
--- a/lib/concurrent/atomic/atomic_boolean.rb
+++ b/lib/concurrent/atomic/atomic_boolean.rb
@@ -48,7 +48,7 @@ module Concurrent
   #   Explicitly sets the value to false.
   #
   #   @return [Boolean] true is value has changed, otherwise false
-  
+
   ###################################################################
 
   # @!macro [new] atomic_boolean_public_api
@@ -79,7 +79,7 @@ module Concurrent
   # @!visibility private
   # @!macro internal_implementation_note
   AtomicBooleanImplementation = case
-                                when Concurrent.on_jruby?
+                                when defined?(JavaAtomicBoolean)
                                   JavaAtomicBoolean
                                 when defined?(CAtomicBoolean)
                                   CAtomicBoolean

--- a/lib/concurrent/atomic/atomic_fixnum.rb
+++ b/lib/concurrent/atomic/atomic_fixnum.rb
@@ -96,7 +96,7 @@ module Concurrent
   # @!visibility private
   # @!macro internal_implementation_note
   AtomicFixnumImplementation = case
-                               when Concurrent.on_jruby?
+                               when defined?(JavaAtomicFixnum)
                                  JavaAtomicFixnum
                                when defined?(CAtomicFixnum)
                                  CAtomicFixnum

--- a/lib/concurrent/atomic/semaphore.rb
+++ b/lib/concurrent/atomic/semaphore.rb
@@ -91,7 +91,7 @@ module Concurrent
   # @!visibility private
   # @!macro internal_implementation_note
   SemaphoreImplementation = case
-                            when Concurrent.on_jruby?
+                            when defined?(JavaSemaphore)
                               JavaSemaphore
                             else
                               MutexSemaphore

--- a/lib/concurrent/map.rb
+++ b/lib/concurrent/map.rb
@@ -1,30 +1,31 @@
 require 'thread'
 require 'concurrent/constants'
+require 'concurrent/utility/native_extension_loader'
 
 module Concurrent
   # @!visibility private
   module Collection
 
     # @!visibility private
-    MapImplementation = if defined?(RUBY_ENGINE)
-                   case RUBY_ENGINE
-                   when 'jruby'
-                     # noinspection RubyResolve
-                     JRubyMapBackend
-                   when 'ruby'
-                     require 'concurrent/collection/map/mri_map_backend'
-                     MriMapBackend
-                   when 'rbx'
-                     require 'concurrent/collection/map/atomic_reference_map_backend'
-                     AtomicReferenceMapBackend
-                   else
-                     warn 'Concurrent::Map: unsupported Ruby engine, using a fully synchronized Concurrent::Map implementation' if $VERBOSE
-                     require 'concurrent/collection/map/synchronized_map_backend'
-                     SynchronizedMapBackend
-                   end
-                 else
-                   MriMapBackend
-                 end
+    MapImplementation = if Concurrent.java_extensions_loaded?
+                          # noinspection RubyResolve
+                          JRubyMapBackend
+                        elsif defined?(RUBY_ENGINE)
+                          case RUBY_ENGINE
+                          when 'ruby'
+                            require 'concurrent/collection/map/mri_map_backend'
+                            MriMapBackend
+                          when 'rbx'
+                            require 'concurrent/collection/map/atomic_reference_map_backend'
+                            AtomicReferenceMapBackend
+                          else
+                            warn 'Concurrent::Map: unsupported Ruby engine, using a fully synchronized Concurrent::Map implementation' if $VERBOSE
+                            require 'concurrent/collection/map/synchronized_map_backend'
+                            SynchronizedMapBackend
+                          end
+                        else
+                          MriMapBackend
+                        end
   end
 
   # `Concurrent::Map` is a hash-like object and should have much better performance

--- a/lib/concurrent/synchronization/jruby_lockable_object.rb
+++ b/lib/concurrent/synchronization/jruby_lockable_object.rb
@@ -1,7 +1,7 @@
 module Concurrent
   module Synchronization
 
-    if Concurrent.on_jruby?
+    if Concurrent.on_jruby? && Concurrent.java_extensions_loaded?
 
       # @!visibility private
       # @!macro internal_implementation_note

--- a/lib/concurrent/synchronization/jruby_object.rb
+++ b/lib/concurrent/synchronization/jruby_object.rb
@@ -1,7 +1,7 @@
 module Concurrent
   module Synchronization
 
-    if Concurrent.on_jruby?
+    if Concurrent.on_jruby? && Concurrent.java_extensions_loaded?
 
       # @!visibility private
       # @!macro internal_implementation_note

--- a/lib/concurrent/synchronization/lockable_object.rb
+++ b/lib/concurrent/synchronization/lockable_object.rb
@@ -8,7 +8,7 @@ module Concurrent
                                      MriMonitorLockableObject
                                    when Concurrent.on_cruby? && Concurrent.ruby_version(:>, 1, 9, 3)
                                      MriMutexLockableObject
-                                   when Concurrent.on_jruby?
+                                   when defined? JRubyLockableObject
                                      JRubyLockableObject
                                    when Concurrent.on_rbx?
                                      RbxLockableObject

--- a/lib/concurrent/synchronization/object.rb
+++ b/lib/concurrent/synchronization/object.rb
@@ -6,7 +6,7 @@ module Concurrent
     ObjectImplementation = case
                            when Concurrent.on_cruby?
                              MriObject
-                           when Concurrent.on_jruby?
+                           when defined? JRubyObject
                              JRubyObject
                            when Concurrent.on_rbx?
                              RbxObject

--- a/lib/concurrent/utility/native_extension_loader.rb
+++ b/lib/concurrent/utility/native_extension_loader.rb
@@ -7,42 +7,57 @@ module Concurrent
     # @!visibility private
     module NativeExtensionLoader
 
-      @c_ext_loaded    ||= false
-      @java_ext_loaded ||= false
-
-      # @!visibility private
       def allow_c_extensions?
         Concurrent.on_cruby?
       end
 
-      if Concurrent.on_cruby? && !@c_ext_loaded
-        tries = [
-          lambda do
-            require 'concurrent/extension'
-            @c_ext_loaded = true
-          end,
-          lambda do
-            # may be a Windows cross-compiled native gem
-            require "concurrent/#{RUBY_VERSION[0..2]}/extension"
-            @c_ext_loaded = true
-          end]
-
-        tries.each do |try|
-          begin
-            try.call
-            break
-          rescue LoadError
-            next
-          end
-        end
+      def c_extensions_loaded?
+        @c_extensions_loaded ||= false
       end
 
-      if Concurrent.on_jruby? && !@java_ext_loaded
-        begin
-          require 'concurrent_ruby_ext'
-          @java_ext_loaded = true
-        rescue LoadError
-          # move on with pure-Ruby implementations
+      def java_extensions_loaded?
+        @java_extensions_loaded ||= false
+      end
+
+      def set_c_extensions_loaded
+        @c_extensions_loaded = true
+      end
+
+      def set_java_extensions_loaded
+        @java_extensions_loaded = true
+      end
+
+      def load_native_extensions
+        if Concurrent.on_cruby? && !c_extensions_loaded?
+          tries = [
+            lambda do
+              require 'concurrent/extension'
+              set_c_extensions_loaded
+            end,
+            lambda do
+              # may be a Windows cross-compiled native gem
+              require "concurrent/#{RUBY_VERSION[0..2]}/extension"
+              set_c_extensions_loaded
+            end]
+
+          tries.each do |try|
+            begin
+              try.call
+              break
+            rescue LoadError
+              next
+            end
+          end
+        end
+
+        if Concurrent.on_jruby? && !java_extensions_loaded?
+          begin
+            require 'concurrent_ruby_ext'
+            set_java_extensions_loaded
+          rescue LoadError
+            # move on with pure-Ruby implementations
+            warn 'On JRuby but Java extensions failed to load.'
+          end
         end
       end
     end
@@ -51,3 +66,5 @@ module Concurrent
   # @!visibility private
   extend Utility::NativeExtensionLoader
 end
+
+Concurrent.load_native_extensions


### PR DESCRIPTION
Addresses the issue first noticed in #431.

The original implementation assumed that the Java extensions would always be compiled and loaded when running on JRuby. This is not always the case. During development and testing if the gem in included directly from source, as when the Gemfile references git directly, none of the native extensions will exist. In production if the pure-Ruby gem is loaded under JRuby the extensions won't exist, either.

This commit updates Java extension loading to follow the existing pattern for C extensions. Relevant parts of the code check to see if the extensions have been correctly loaded first, rather than assuming they are. The test suite still assumes that Java and C extensions are loaded, however. This is necessary to catch bugs which prevent extensions from properly compiling and loading.
