### PR TITLE
clean up a few warnings

### DIFF
--- a/lib/concurrent/channel/buffer/timer.rb
+++ b/lib/concurrent/channel/buffer/timer.rb
@@ -62,7 +62,6 @@ module Concurrent
 
             if Concurrent.monotonic_time > @tick
               # only one listener gets notified
-              closed = empty = true
               return :tick, Concurrent::Channel::Tick.new(@tick)
             else
               return :wait, true

--- a/lib/concurrent/edge/atomic_markable_reference.rb
+++ b/lib/concurrent/edge/atomic_markable_reference.rb
@@ -11,7 +11,7 @@ module Concurrent
     #   @api Edge
     class AtomicMarkableReference < ::Concurrent::Synchronization::Object
 
-      private *attr_volatile_with_cas(:reference)
+      private(*attr_volatile_with_cas(:reference))
 
       # @!macro [attach] atomic_markable_reference_method_initialize
       def initialize(value = nil, mark = false)

--- a/lib/concurrent/edge/lock_free_stack.rb
+++ b/lib/concurrent/edge/lock_free_stack.rb
@@ -23,7 +23,7 @@ module Concurrent
 
       EMPTY = Empty[nil, nil]
 
-      private *attr_volatile_with_cas(:head)
+      private(*attr_volatile_with_cas(:head))
 
       def initialize
         super(EMPTY)


### PR DESCRIPTION
The bare `*` is ambiguous, so I added parens to make it unambiguous.
Also I removed some unused assignments.

I don't know how to turn on warnings for RSpec, so I just ran the tests
like this:

```
RUBYOPT=-w be rake spec
```