### PR TITLE
MVar#take accepts a block as parameter

### DIFF
--- a/lib/concurrent/mvar.rb
+++ b/lib/concurrent/mvar.rb
@@ -68,10 +68,14 @@ module Concurrent
 
         # If we timed out we'll still be empty
         if unlocked_full?
-          value = @value
-          @value = EMPTY
-          @empty_condition.signal
-          apply_deref_options(value)
+          if block_given?
+            yield @value
+          else
+            value = @value
+            @value = EMPTY
+            @empty_condition.signal
+            apply_deref_options(value)
+          end
         else
           TIMEOUT
         end

--- a/spec/concurrent/mvar_spec.rb
+++ b/spec/concurrent/mvar_spec.rb
@@ -68,6 +68,28 @@ module Concurrent
         expect(m.take(0.1)).to eq MVar::TIMEOUT
       end
 
+      context 'when a block is given' do
+        it 'yields current value to the block and puts back value' do
+          m = MVar.new(14)
+          expect { |b| m.take(&b) }.to yield_with_args(14)
+          expect(m.take).to eq(14)
+        end
+        it 'puts back value even if an exception is raised' do
+          m = MVar.new(14)
+          expect { m.take { fail 'boom!' } }.to raise_error('boom!')
+          expect(m.take).to eq(14)
+        end
+        it 'returns the returned value of the block' do
+          m = MVar.new(14)
+          expect(m.take{2}).to eq(2)
+          expect(m.take).to eq(14)
+        end
+        it 'returns TIMEOUT on timeout on an empty MVar' do
+          m = MVar.new
+          expect(m.take(0.1){}).to eq MVar::TIMEOUT
+        end
+      end
+
     end
 
     describe '#put' do

--- a/spec/concurrent/mvar_spec.rb
+++ b/spec/concurrent/mvar_spec.rb
@@ -68,34 +68,35 @@ module Concurrent
         expect(m.take(0.1)).to eq MVar::TIMEOUT
       end
 
-      context 'when a block is given' do
+    end
 
-        it 'yields current value to the block and puts back value' do
-          m = MVar.new(14)
-          expect { |b| m.take(&b) }.to yield_with_args(14)
-          expect(m.take).to eq(14)
-        end
+    describe '#borrow' do
 
-        it 'puts back value even if an exception is raised' do
-          m = MVar.new(14)
-          expect { m.take { fail 'boom!' } }.to raise_error('boom!')
-          expect(m.take).to eq(14)
-        end
+      it 'yields current value to the block and puts back value' do
+        m = MVar.new(14)
+        expect { |b| m.borrow(&b) }.to yield_with_args(14)
+        expect(m.take).to eq(14)
+      end
 
-        it 'returns the returned value of the block' do
-          m = MVar.new(14)
-          expect(m.take{2}).to eq(2)
-          expect(m.take).to eq(14)
-        end
+      it 'puts back value even if an exception is raised' do
+        m = MVar.new(14)
+        expect { m.borrow { fail 'boom!' } }.to raise_error('boom!')
+        expect(m.take).to eq(14)
+      end
 
-        it 'returns TIMEOUT on timeout on an empty MVar' do
-          m = MVar.new
-          expect(m.take(0.1){}).to eq MVar::TIMEOUT
-        end
+      it 'returns the returned value of the block' do
+        m = MVar.new(14)
+        expect(m.borrow{2}).to eq(2)
+        expect(m.take).to eq(14)
+      end
 
+      it 'returns TIMEOUT on timeout on an empty MVar' do
+        m = MVar.new
+        expect(m.borrow(0.1){}).to eq MVar::TIMEOUT
       end
 
     end
+
 
     describe '#put' do
 

--- a/spec/concurrent/mvar_spec.rb
+++ b/spec/concurrent/mvar_spec.rb
@@ -69,25 +69,30 @@ module Concurrent
       end
 
       context 'when a block is given' do
+
         it 'yields current value to the block and puts back value' do
           m = MVar.new(14)
           expect { |b| m.take(&b) }.to yield_with_args(14)
           expect(m.take).to eq(14)
         end
+
         it 'puts back value even if an exception is raised' do
           m = MVar.new(14)
           expect { m.take { fail 'boom!' } }.to raise_error('boom!')
           expect(m.take).to eq(14)
         end
+
         it 'returns the returned value of the block' do
           m = MVar.new(14)
           expect(m.take{2}).to eq(2)
           expect(m.take).to eq(14)
         end
+
         it 'returns TIMEOUT on timeout on an empty MVar' do
           m = MVar.new
           expect(m.take(0.1){}).to eq MVar::TIMEOUT
         end
+
       end
 
     end


### PR DESCRIPTION
When using MVar, one should very often do the following:
 1. acquire the value
 1. perform an action on it
 1. release it.

It seems to me that a block syntax is suitable in this case:
```ruby
f = MVar.new(IO.open('file', 'w'))
new_lines = f.take { |s| s.read }
```
instead of
```ruby
f = MVar.new(IO.open('file', 'w'))
new_lines = nil
begin
  s = f.take
  new_lines = s.read
ensure
  f.put s
end
```
or
```ruby
f = MVar.new(IO.open('file', 'w'))
new_lines = nil
f.modify do |s|
  new_lines = s.read
  s
end
```
