### PR TITLE
Add ready-length attr_reader

### DIFF
--- a/lib/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent/executor/ruby_thread_pool_executor.rb
@@ -70,6 +70,11 @@ module Concurrent
       synchronize { @queue.length }
     end
 
+    # @!macro thread_pool_executor_attr_reader_ready_length
+    def ready_length
+      synchronize { @ready.length }
+    end
+
     # @!macro thread_pool_executor_attr_reader_remaining_capacity
     def remaining_capacity
       synchronize do


### PR DESCRIPTION
The ready queue is available via a local instance variable. Exposing
the length of the array of ready workers will allow the health of the
pool to be measured/monitored as tasks are moving through the pool.

Important values are total workers (`length`), idle workers
(`ready_length`), and busy workers (difference between the 2).

Note: I wasn't sure how to handle the java side. It appears there are some [instance methods](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/lib/concurrent/executor/java_thread_pool_executor.rb#L52) pertaining to accessing this data, but I couldn't find more. I'm happy to make suggested changes if interested.