### PR TITLE
Move completed_task_count incrementer after task is successful

### DIFF
--- a/lib/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent/executor/ruby_thread_pool_executor.rb
@@ -103,7 +103,7 @@ module Concurrent
 
     # @!visibility private
     def worker_task_completed
-      @completed_task_count += 1
+      synchronize { @completed_task_count += 1 }
     end
 
     private

--- a/lib/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent/executor/ruby_thread_pool_executor.rb
@@ -101,6 +101,11 @@ module Concurrent
       synchronize { ns_worker_died worker }
     end
 
+    # @!visibility private
+    def worker_task_completed
+      @completed_task_count += 1
+    end
+
     private
 
     # @!visibility private
@@ -180,7 +185,6 @@ module Concurrent
       worker = (@ready.pop if @pool.size >= @min_length) || ns_add_busy_worker
       if worker
         worker << [task, args]
-        @completed_task_count += 1
         true
       else
         false
@@ -327,6 +331,7 @@ module Concurrent
 
       def run_task(pool, task, args)
         task.call(*args)
+        pool.worker_task_completed
       rescue => ex
         # let it fail
         log DEBUG, ex


### PR DESCRIPTION
Completed task count was previously incremented no matter the success of
the task. In hopes to introduce a failed_task_count counter, this moves
the increment of the completed_task_count to the block where the thread
execution takes place