### PR TITLE
Keep track of failed task count

### DIFF
--- a/lib/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent/executor/ruby_thread_pool_executor.rb
@@ -108,7 +108,7 @@ module Concurrent
 
     # @!visibility private
     def worker_task_failed
-      @failed_task_count += 1
+      synchronize { @failed_task_count += 1 }
     end
 
     private

--- a/spec/concurrent/executor/thread_pool_shared.rb
+++ b/spec/concurrent/executor/thread_pool_shared.rb
@@ -93,6 +93,23 @@ shared_examples :thread_pool do
     end
   end
 
+  context '#failed_task_count' do
+
+    it 'returns zero on creation' do
+      expect(subject.failed_task_count).to eq 0
+    end
+
+    unless Concurrent.on_jruby?
+
+      it 'returns the approximate number of tasks that have failed thus far' do
+        5.times{ subject.post{ raise StandardError } }
+        subject.post { latch.count_down }
+        latch.wait(1)
+        expect(subject.failed_task_count).to be > 0
+      end
+    end
+  end
+
   context '#shutdown' do
 
     it 'allows threads to exit normally' do


### PR DESCRIPTION
In hopes to provide a more metrics around Sucker Punch jobs, I'm hoping
to expose the number of failed jobs in the pool.

Failed jobs would be visible in the chart on the left and potentially in the chart if I can find a way to not make it too busy:

<img width="1157" alt="screen shot 2015-10-18 at 9 11 46 pm" src="https://cloud.githubusercontent.com/assets/744212/10567884/fe0a0932-75dc-11e5-8260-788b2a98e4c0.png">
