### PR TITLE
Put debug log statements inside block

### DIFF
--- a/lib/concurrent/actor/core.rb
+++ b/lib/concurrent/actor/core.rb
@@ -91,7 +91,7 @@ module Concurrent
       # @param [Envelope] envelope
       def on_envelope(envelope)
         schedule_execution do
-          log DEBUG, "was #{envelope.future ? 'asked' : 'told'} #{envelope.message.inspect} by #{envelope.sender}"
+          log(DEBUG) { "was #{envelope.future ? 'asked' : 'told'} #{envelope.message.inspect} by #{envelope.sender}" }
           process_envelope envelope
         end
         nil
@@ -128,7 +128,7 @@ module Concurrent
       end
 
       def broadcast(public, event)
-        log DEBUG, "event: #{event.inspect} (#{public ? 'public' : 'private'})"
+        log(DEBUG) { "event: #{event.inspect} (#{public ? 'public' : 'private'})" }
         @first_behaviour.on_event(public, event)
       end
 


### PR DESCRIPTION
This prevents potentially expense calls to #inspect and avoids creating a lot of useless string for applications that send a lot of messages to actors.

When I did some memory profiling, this change halved the number of objects that were getting allocated by my application. (The call to inspect was very expensive for me)

Also of note. I tried to add the same behavior to 2 log debug statements in the behavior classes, but they both caused test failures. I only tried this under MRI 2.2.3.