### PR TITLE
Move AtomicMarkableReference out of Edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Thread-safe variables:
 * [ReadWriteLock](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/ReadWriteLock.html) A lock that supports multiple readers but only one writer.
 * [ReentrantReadWriteLock](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/ReentrantReadWriteLock.html) A read/write lock with reentrant and upgrade features.
 * [Semaphore](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Semaphore.html) A counting-based locking mechanism that uses permits.
+* [AtomicMarkableReference](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Atomic/AtomicMarkableReference.html)
 
 ### Edge Features
 
@@ -143,7 +144,6 @@ be obeyed though. Features developed in `concurrent-ruby-edge` are expected to m
   Functionally equivalent to Go [channels](https://tour.golang.org/concurrency/2) with additional
   inspiration from Clojure [core.async](https://clojure.github.io/core.async/).
 * [LazyRegister](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/LazyRegister.html)
-* [AtomicMarkableReference](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Edge/AtomicMarkableReference.html)
 * [LockFreeLinkedSet](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Edge/LockFreeLinkedSet.html)
 * [LockFreeStack](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Edge/LockFreeStack.html)
 

--- a/lib/concurrent-edge.rb
+++ b/lib/concurrent-edge.rb
@@ -8,5 +8,4 @@ require 'concurrent/lazy_register'
 
 require 'concurrent/edge/future'
 require 'concurrent/edge/lock_free_stack'
-require 'concurrent/edge/atomic_markable_reference'
 require 'concurrent/edge/lock_free_linked_set'

--- a/lib/concurrent.rb
+++ b/lib/concurrent.rb
@@ -7,6 +7,7 @@ require 'concurrent/atomics'
 require 'concurrent/executors'
 require 'concurrent/synchronization'
 
+require 'concurrent/atomic/atomic_markable_reference'
 require 'concurrent/atomic/atomic_reference'
 require 'concurrent/agent'
 require 'concurrent/atom'

--- a/lib/concurrent/atomic/atomic_markable_reference.rb
+++ b/lib/concurrent/atomic/atomic_markable_reference.rb
@@ -1,6 +1,5 @@
 module Concurrent
-  module Edge
-
+  module Atomic
     # @!macro [attach] atomic_markable_reference
     #
     #   An atomic reference which maintains an object reference along with a mark bit
@@ -10,7 +9,6 @@ module Concurrent
     #
     #   @api Edge
     class AtomicMarkableReference < ::Concurrent::Synchronization::Object
-
       private(*attr_volatile_with_cas(:reference))
 
       # @!macro [attach] atomic_markable_reference_method_initialize
@@ -145,9 +143,9 @@ module Concurrent
 
         unless compare_and_set old_val, new_val, old_mark, new_mark
           fail ::Concurrent::ConcurrentUpdateError,
-               'AtomicMarkableReference: Update failed due to race condition.',
-               'Note: If you would like to guarantee an update, please use ' \
-               'the `AtomicMarkableReference#update` method.'
+            'AtomicMarkableReference: Update failed due to race condition.',
+            'Note: If you would like to guarantee an update, please use ' \
+            'the `AtomicMarkableReference#update` method.'
         end
 
         ImmutableArray[new_val, new_mark]

--- a/lib/concurrent/edge/lock_free_linked_set/node.rb
+++ b/lib/concurrent/edge/lock_free_linked_set/node.rb
@@ -1,16 +1,17 @@
-require 'concurrent/edge/atomic_markable_reference'
+require 'concurrent/atomic/atomic_markable_reference'
 
 module Concurrent
   module Edge
     class LockFreeLinkedSet
       class Node < Synchronization::Object
         include Comparable
+        include Concurrent::Atomic
 
         safe_initialization!
 
         def initialize(data = nil, successor = nil)
           super()
-          @SuccessorReference = AtomicMarkableReference.new(successor || Tail.new)
+          @SuccessorReference  = AtomicMarkableReference.new(successor || Tail.new)
           @Data                = data
           @Key                 = key_for data
         end

--- a/spec/concurrent/atomic/atomic_markable_reference_spec.rb
+++ b/spec/concurrent/atomic/atomic_markable_reference_spec.rb
@@ -1,4 +1,4 @@
-describe Concurrent::Edge::AtomicMarkableReference do
+describe Concurrent::Atomic::AtomicMarkableReference do
   subject { described_class.new 1000, true }
 
   describe '.initialize' do


### PR DESCRIPTION
It would be nice to get this in at some point .Originally, it was planned for 1.0 but that is fine if it is not possible. Let me know your thoughts.
