### PR TITLE
Fixed bug with requires for Map.

### DIFF
--- a/lib/concurrent/map.rb
+++ b/lib/concurrent/map.rb
@@ -1,7 +1,6 @@
 require 'thread'
 require 'concurrent/constants'
-require 'concurrent/utility/native_extension_loader'
-Concurrent.load_native_extensions
+require 'concurrent/synchronization'
 
 module Concurrent
   # @!visibility private


### PR DESCRIPTION
PR #421 changed the way we load native extensions. Specifically, requiring the synchronization layer first. `lib/concurrent/map.rb` loaded things in the wrong order. This PR fixes that.