### PR TITLE
Fix typo in spec_helper.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 $VERBOSE = nil # suppress our deprecation warnings
 
-# wwe can't use our helpers here because we need to load the gem _after_ simplecov
+# we can't use our helpers here because we need to load the gem _after_ simplecov
 unless RUBY_ENGINE == 'jruby' && 0 == (JRUBY_VERSION =~ /^9\.0\.0\.0/)
   if ENV['COVERAGE'] || ENV['CI'] || ENV['TRAVIS']
     require 'simplecov'


### PR DESCRIPTION
Alternatively, maybe the whole condition can be removed since 9.0.0.0 is not so recent anymore?