### PR TITLE
Raise better error when input is not an IVar

### DIFF
--- a/lib/concurrent/dataflow.rb
+++ b/lib/concurrent/dataflow.rb
@@ -39,7 +39,7 @@ module Concurrent
     call_dataflow(:value, executor, *inputs, &block)
   end
   module_function :dataflow_with
-  
+
   def dataflow!(*inputs, &block)
     dataflow_with!(Concurrent.global_io_executor, *inputs, &block)
   end
@@ -50,12 +50,14 @@ module Concurrent
   end
   module_function :dataflow_with!
 
-  private 
+  private
 
   def call_dataflow(method, executor, *inputs, &block)
     raise ArgumentError.new('an executor must be provided') if executor.nil?
     raise ArgumentError.new('no block given') unless block_given?
-    raise ArgumentError.new('not all dependencies are IVars') unless inputs.all? { |input| input.is_a? IVar }
+    unless inputs.all? { |input| input.is_a? IVar }
+      raise ArgumentError.new("Not all dependencies are IVars.\nDependencies: #{ inputs.inspect }")
+    end
 
     result = Future.new(executor: executor) do
       values = inputs.map { |input| input.send(method) }


### PR DESCRIPTION
This will show the values received such as:


```
rgumentError: Not all dependencies are IVars.
Dependencies: [false]
/Users/richardschneeman/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.0/lib/concurrent/dataflow.rb:61:in `call_dataflow'
/Users/richardschneeman/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.0/lib/concurrent/dataflow.rb:40:in `dataflow_with'
/Users/richardschneeman/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.0/lib/concurrent/dataflow.rb:35:in `dataflow'
/Users/richardschneeman/Documents/projects/sprockets/lib/sprockets/manifest.rb:203:in `block in compile'
/Users/richardschneeman/Documents/projects/sprockets/lib/sprockets/manifest.rb:131:in `block (2 levels) in find'
/Users/richardschneeman/Documents/projects/sprockets/lib/sprockets/base.rb:76:in `find_all_linked_assets'
/Users/richardschneeman/Documents/projects/sprockets/lib/sprockets/manifest.rb:130:in `block in find'
/Users/richardschneeman/Documents/projects/sprockets/lib/sprockets/manifest.rb:129:in `each'
/Users/richardschneeman/Documents/projects/sprockets/lib/sprockets/manifest.rb:129:in `find'
/Users/richardschneeman/Documents/projects/sprockets/lib/sprockets/manifest.rb:164:in `compile'
/Users/richardschneeman/.gem/ruby/2.3.0/bundler/gems/sprockets-rails-ad4a43bd1bb1/lib/sprockets/rails/task.rb:68:in `block (3 levels) in define'
/Users/richardschneeman/Documents/projects/sprockets/lib/rake/sprocketstask.rb:147:in `with_logger'
/Users/richardschneeman/.gem/ruby/2.3.0/bundler/gems/sprockets-rails-ad4a43bd1bb1/lib/sprockets/rails/task.rb:67:in `block (2 levels) in define'
```