### PR TITLE
Fix typos in async.rb

### DIFF
--- a/lib/concurrent/async.rb
+++ b/lib/concurrent/async.rb
@@ -58,7 +58,7 @@ module Concurrent
   # end
   # ```
   #
-  # When defining a constructor it is critica that the first line be a call to
+  # When defining a constructor it is critical that the first line be a call to
   # `super` with no arguments. The `super` method initializes the background
   # thread and other asynchronous components.
   #
@@ -153,7 +153,7 @@ module Concurrent
   # subtly different.
   #
   # When internal state is accessed via the `async` and `await` proxy methods,
-  # the returned value represents the object's sate *at the time the call is
+  # the returned value represents the object's state *at the time the call is
   # processed*, which may *not* be the state of the object at the time the call
   # is made.
   #


### PR DESCRIPTION
There is also a sentence which made me wonder its meaning:
```
Assignment is not thread-safe in Ruby
```
What kind of assignment? Surely, `var = value` is atomic, right? Is it about visibility?