### PR TITLE
Resolved NameError on JRuby by using fewer autoloads.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 1.9.3
   - ruby-head
   - jruby-1.7.19
+  - jruby-9.0.1.0
   - jruby-9.0.3.0
   - jruby-9.0.4.0
   - jruby-head

--- a/lib/concurrent/delay.rb
+++ b/lib/concurrent/delay.rb
@@ -5,6 +5,7 @@ require 'concurrent/synchronization'
 
 module Concurrent
 
+  # This file has circular require issues. It must be autoloaded here.
   autoload :Options, 'concurrent/options'
 
   # Lazy evaluation of a block yielding an immutable result. Useful for

--- a/lib/concurrent/executor/timer_set.rb
+++ b/lib/concurrent/executor/timer_set.rb
@@ -4,9 +4,9 @@ require 'concurrent/collection/non_concurrent_priority_queue'
 require 'concurrent/executor/executor_service'
 require 'concurrent/executor/single_thread_executor'
 
-module Concurrent
+require 'concurrent/options'
 
-  autoload :Options, 'concurrent/options'
+module Concurrent
 
   # Executes a collection of tasks, each after a given delay. A master task
   # monitors the set and schedules each task for execution at the appropriate
@@ -21,7 +21,7 @@ module Concurrent
     # Create a new set of timed tasks.
     #
     # @!macro [attach] executor_options
-    #  
+    #
     #   @param [Hash] opts the options used to specify the executor on which to perform actions
     #   @option opts [Executor] :executor when set use the given `Executor` instance.
     #     Three special values are also supported: `:task` returns the global task pool,

--- a/lib/concurrent/future.rb
+++ b/lib/concurrent/future.rb
@@ -4,9 +4,9 @@ require 'concurrent/errors'
 require 'concurrent/ivar'
 require 'concurrent/executor/safe_task_executor'
 
-module Concurrent
+require 'concurrent/options'
 
-  autoload :Options, 'concurrent/options'
+module Concurrent
 
   # {include:file:doc/future.md}
   #

--- a/lib/concurrent/options.rb
+++ b/lib/concurrent/options.rb
@@ -1,5 +1,3 @@
-# This file has circular require issues. It must be autoloaded.
-
 require 'concurrent/configuration'
 
 module Concurrent

--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -3,9 +3,9 @@ require 'concurrent/constants'
 require 'concurrent/errors'
 require 'concurrent/ivar'
 
-module Concurrent
+require 'concurrent/options'
 
-  autoload :Options, 'concurrent/options'
+module Concurrent
 
   PromiseExecutionError = Class.new(StandardError)
 

--- a/lib/concurrent/scheduled_task.rb
+++ b/lib/concurrent/scheduled_task.rb
@@ -5,9 +5,9 @@ require 'concurrent/ivar'
 require 'concurrent/collection/copy_on_notify_observer_set'
 require 'concurrent/utility/monotonic_time'
 
-module Concurrent
+require 'concurrent/options'
 
-  autoload :Options, 'concurrent/options'
+module Concurrent
 
   # `ScheduledTask` is a close relative of `Concurrent::Future` but with one
   # important difference: A `Future` is set to execute as soon as possible


### PR DESCRIPTION
See issue #480.