### PR TITLE
Adding `require` to documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ gem install concurrent-ruby
 or add the following line to Gemfile:
 
 ```ruby
-gem 'concurrent-ruby'
+gem 'concurrent-ruby', require: 'concurrent'
 ```
 
 and run `bundle install` from your shell.
@@ -198,7 +198,7 @@ gem install concurrent-ruby-edge
 or add the following line to Gemfile:
 
 ```ruby
-gem 'concurrent-ruby-edge'
+gem 'concurrent-ruby-edge', require: 'concurrent-edge'
 ```
 
 and run `bundle install` from your shell.


### PR DESCRIPTION
Hello, 
I've just added `require` flag to Readme.

Because of different name of gem and for correct way to require gem you have to specify it for Bundler.
That way you just do 
```ruby
# Gemfile
gem 'concurrent-ruby', require: 'concurrent' 
# or
gem 'concurrent-ruby-edge', require: 'concurrent-edge' 

# Your ruby code file
require 'bundler'
Bundler.require
```  
and Bundler will correctly require everything including `concurrent-ruby` gem

Cheers ;-)