### PR TITLE
alias settled? for complete?

### DIFF
--- a/lib/concurrent/concern/obligation.rb
+++ b/lib/concurrent/concern/obligation.rb
@@ -49,6 +49,7 @@ module Concurrent
       def complete?
         [:fulfilled, :rejected].include? state
       end
+      alias_method :settled?, :complete?
 
       # Is the obligation still awaiting completion of processing?
       #

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -641,6 +641,10 @@ module Concurrent
         child = rejected_subject.on_error { 7 }
         expect(child.value).to eq 7
       end
+
+      it 'aliases #settled? for #complete?' do
+        expect(fulfilled_subject).to be_settled
+      end
     end
   end
 end


### PR DESCRIPTION
Discussion of Promises in ES6/ES2015 often refers to the concept of complete as "settled". Since Obligation already has a number of aliases, presumably to match evolving terminology in JS (or other places?), I think maybe it makes sense to alias `complete?` as `settled?` too? 

> A promise is settled (the computation it represents has finished) if it is either fulfilled or rejected

-- http://promises-aplus.github.io/promises-spec/

> Note: A promise is said to be settled if it is either fulfilled or rejected, but not pending. 

-- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise

