### PR TITLE
Better handling of system exceptions

### DIFF
--- a/lib/concurrent/edge/future.rb
+++ b/lib/concurrent/edge/future.rb
@@ -1,6 +1,7 @@
 require 'concurrent' # TODO do not require whole concurrent gem
 require 'concurrent/concern/deprecation'
 require 'concurrent/edge/lock_free_stack'
+require 'concurrent/utility/system_exceptions_handler'
 
 
 # @note different name just not to collide for now
@@ -939,7 +940,7 @@ module Concurrent
       rescue StandardError => error
         complete_with Future::Failed.new(error)
       rescue Exception => error
-        log(ERROR, 'Edge::Future', error)
+        Utility::SystemExceptionsHandler.handle(error, 'Edge::Future')
         complete_with Future::Failed.new(error)
       end
     end

--- a/lib/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent/executor/ruby_thread_pool_executor.rb
@@ -3,6 +3,7 @@ require 'concurrent/atomic/event'
 require 'concurrent/concern/logging'
 require 'concurrent/executor/ruby_executor_service'
 require 'concurrent/utility/monotonic_time'
+require 'concurrent/utility/system_exceptions_handler'
 
 module Concurrent
 
@@ -350,8 +351,8 @@ module Concurrent
       rescue => ex
         # let it fail
         log DEBUG, ex
-      rescue Exception => ex
-        log ERROR, ex
+      rescue Exception => error
+        Utility::SystemExceptionsHandler.handle(error, 'Worker task error')
         pool.worker_died(self)
         throw :stop
       end

--- a/lib/concurrent/executor/safe_task_executor.rb
+++ b/lib/concurrent/executor/safe_task_executor.rb
@@ -23,8 +23,9 @@ module Concurrent
         begin
           value   = @task.call(*args)
           success = true
-        rescue @exception_class => ex
-          reason  = ex
+        rescue @exception_class => error
+          Utility::SystemExceptionsHandler.handle(error, 'Task error')
+          reason  = error
           success = false
         end
 

--- a/lib/concurrent/utility/system_exceptions_handler.rb
+++ b/lib/concurrent/utility/system_exceptions_handler.rb
@@ -1,0 +1,31 @@
+require 'concurrent/concern/logging'
+
+module Concurrent
+  module Utility
+    # Provides common logic for handling System exceptions (at places, where `rescue => Exception` is needed)
+    #
+    # @!visibility private
+    class SystemExceptionsHandler
+      UNHANDLED_EXCEPTIONS = [SystemExit, SystemStackError, NoMemoryError]
+      class << self
+        include Concern::Logging
+
+        # Logs an exception an and re-raises if it's not wise to rescue from it.
+        #
+        # @example by class and name
+        #   rescue Exception => error
+        #     Utility::SystemExceptionsHandler.handle(error, 'Worker task error')
+        #     # ... some other logic if the error was rescued
+        #
+        # @!visibility private
+        def handle(error, context_message)
+          if !error.is_a?(StandardError) && UNHANDLED_EXCEPTIONS.any? { |klass| error.is_a?(klass) }
+            raise error
+          else
+            log(ERROR, context_message, error)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I have a case, where I need to call `Kernel.exit` inside a future:

    Concurrent::Edge.future { Kernel.exit }

I was not able to do it right now, as there few places where the `Exception`
is captured without propagation. What do you think about re-raising
some exceptions that should not be rescuable by definition?

Workaround right now is calling the exit in separate thread:

    Concurrent::Edge.future { Thread.new { Kernel.exit } }