### PR TITLE
Promise.race

### DIFF
--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -438,6 +438,46 @@ module Concurrent
       aggregate(:any?, *promises)
     end
 
+    # Aggregates a collection of promises, and completes as soon as the first
+    # aggregated promise completes, with the same state (fulfilled or rejected)
+    # and reason/value.
+    #
+    #   @param [Array] promises Zero or more promises to aggregate
+    #   @return [Promise] an unscheduled (not executed) promise that aggregates
+    #     the promises given as arguments
+    def self.race(*promises)
+      return Promise.fulfilled if promises.empty?
+
+      Promise.new do
+        latch = Concurrent::CountDownLatch.new(1)
+        finished = Concurrent::AtomicBoolean.new(false)
+        value_and_reason = Concurrent::AtomicReference.new
+
+        promises.each do |promise|
+          promise.execute if promise.unscheduled?
+
+          promise.then do |value|
+            if finished.make_true
+              value_and_reason.set([value, nil])
+              latch.count_down
+            end
+          end
+
+          promise.rescue do |reason|
+            if finished.make_true
+              value_and_reason.set([nil, reason])
+              latch.count_down
+            end
+          end
+        end
+
+        latch.wait
+        value, reason = value_and_reason.get
+        raise reason if reason
+        value
+      end
+    end
+
     protected
 
     def ns_initialize(value, opts)


### PR DESCRIPTION
A stab at implementing Promise.race -- which returns as soon as the _first_ member promise returns, with the value/reason of that member. 

This is off master, not edge. I haven't looked at edge, this functionality may already be in edge implemented differently according to edge.  But master `any` waits for all member promises to complete, unlike `race`. 

I am pretty confident this implementation is semantically correct, but there might be a better more efficient or concise way to implement it. I am not entirely sure about the specs, there might be a better way to spec. 

No worries if you don't want this, although I think it is a valuable addition to the current master Promise API, it was also a useful exersize to me in understanding ruby-concurrent promises. 
