### PR TITLE
Fix Future + Executor example

### DIFF
--- a/doc/thread_pools.md
+++ b/doc/thread_pools.md
@@ -155,7 +155,7 @@ pool = Concurrent::ThreadPoolExecutor.new(
   :fallback_policy => :caller_runs
 )
 
-future = Future.new(:executor => pool).execute do
+future = Future.execute(:executor => pool) do
    #work
 end
 ~~~


### PR DESCRIPTION
When using Future.new you have to pass the block of work to it.