### PR TITLE
Improve AtomicFixnum type-checking error message

### DIFF
--- a/ext/com/concurrent_ruby/ext/JavaAtomicFixnumLibrary.java
+++ b/ext/com/concurrent_ruby/ext/JavaAtomicFixnumLibrary.java
@@ -106,7 +106,7 @@ public class JavaAtomicFixnumLibrary implements Library {
                 RubyFixnum fixNum = (RubyFixnum) value;
                 return fixNum.getLongValue();
             } else {
-                throw getRuntime().newArgumentError("initial value must be a Fixnum");
+                throw getRuntime().newArgumentError("value must be a Fixnum");
             }
         }
     }


### PR DESCRIPTION
`rubyFixnumToLong` is used in increments/updates in addition to initialization
so the error message here should be more generic.