### PR TITLE
TimerTask uses timeout interval

### DIFF
--- a/lib/concurrent/timer_task.rb
+++ b/lib/concurrent/timer_task.rb
@@ -305,7 +305,7 @@ module Concurrent
     # @!visibility private
     def execute_task(completion)
       return nil unless @running.true?
-      ScheduledTask.execute(execution_interval, args: [completion], &method(:timeout_task))
+      ScheduledTask.execute(timeout_interval, args: [completion], &method(:timeout_task))
       _success, value, reason = @executor.execute(self)
       if completion.try?
         self.value = value

--- a/spec/concurrent/timer_task_spec.rb
+++ b/spec/concurrent/timer_task_spec.rb
@@ -243,7 +243,7 @@ module Concurrent
       end
 
       it 'notifies all observers on timeout' do
-        subject = TimerTask.new(execution: 0.1, timeout: 0.1) { sleep }
+        subject = TimerTask.new(execution: 500, timeout: 0.1, run_now: true) { sleep }
         subject.add_observer(observer)
         subject.execute
         observer.latch.wait(1)


### PR DESCRIPTION
Fixes #525. I modified the existing timeout spec to execute immediately and asserts that a timeout occurs but I could just as easily create a new spec to test this behavior.