### PR TITLE
Conc::Map - MRI backend fixes

### DIFF
--- a/lib/concurrent/collection/map/non_concurrent_map_backend.rb
+++ b/lib/concurrent/collection/map/non_concurrent_map_backend.rb
@@ -76,10 +76,6 @@ module Concurrent
         @backend.key?(key)
       end
 
-      def value?(value)
-        @backend.value?(value)
-      end
-
       def delete(key)
         @backend.delete(key)
       end

--- a/lib/concurrent/collection/map/synchronized_map_backend.rb
+++ b/lib/concurrent/collection/map/synchronized_map_backend.rb
@@ -53,10 +53,6 @@ module Concurrent
         synchronize { super }
       end
 
-      def value?(value)
-        synchronize { super }
-      end
-
       def delete(key)
         synchronize { super }
       end

--- a/lib/concurrent/map.rb
+++ b/lib/concurrent/map.rb
@@ -149,7 +149,7 @@ module Concurrent
         return true if value.equal?(v)
       end
       false
-    end unless method_defined?(:value?)
+    end
 
     def keys
       arr = []

--- a/lib/concurrent/map.rb
+++ b/lib/concurrent/map.rb
@@ -202,6 +202,15 @@ module Concurrent
 
     undef :freeze
 
+    # @!visibility private
+    DEFAULT_OBJ_ID_STR_WIDTH = (2**50).class == Fixnum ? 14 : 7 # we want to look "native", 7 for 32-bit, 14 for 64-bit
+    # override default #inspect() method: firstly, we don't want to be spilling our guts (i-vars), secondly, MRI backend's
+    # #inspect() call on its @backend i-var will bump @backend's iter level while possibly yielding GVL
+    def inspect
+      id_str = (object_id << 1).to_s(16).rjust(DEFAULT_OBJ_ID_STR_WIDTH, '0')
+      "#<#{self.class.name}:0x#{id_str} entries=#{size} default_proc=#{@default_proc.inspect}>"
+    end
+
     private
     def raise_fetch_no_key
       raise KeyError, 'key not found'

--- a/spec/concurrent/map_spec.rb
+++ b/spec/concurrent/map_spec.rb
@@ -826,6 +826,15 @@ module Concurrent
       expect { Marshal.dump(Concurrent::Map.new {}) }.to raise_error(TypeError)
     end
 
+    it '#inspect' do
+      regexp = /\A#<Concurrent::Map:0x[0-9a-f]+ entries=[0-9]+ default_proc=.*>\Z/i
+      expect(Concurrent::Map.new.inspect).to match(regexp)
+      expect((Concurrent::Map.new {}).inspect).to match(regexp)
+      map = Concurrent::Map.new
+      map[:foo] = :bar
+      expect(map.inspect).to match(regexp)
+    end
+
     private
 
     def with_or_without_default_proc(&block)


### PR DESCRIPTION
This should hopefully cover all "insertion during iteration" errors for MRI backend.

Fixes #528.
Possibly related: rails/rails#24627.