### PR TITLE
Require SafeTaskExecutor in Promise

### DIFF
--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -2,6 +2,7 @@ require 'thread'
 require 'concurrent/constants'
 require 'concurrent/errors'
 require 'concurrent/ivar'
+require 'concurrent/executor/safe_task_executor'
 
 require 'concurrent/options'
 


### PR DESCRIPTION
Hi,

while trying out promises I've noticed that if I require only `concurrent/promise` in my script and execute a promise, it does not work. I narrowed it down to lack of `SafeTaskExecutor` (and verified that `Future` library requires that file), so I thought it's a bug.

One thing I do not yet understand is why my code is still running if I do not require that one file. Promise calls `SafeTaskExecutor.new(task).execute(*@args)`, and since `SafeTaskExecutor` is not present, it should raise an error. I'm wondering if that error is never raised, or it is raised but rescued and I just never see it?

Here's the code I'm using:

```
require 'concurrent/promise'

promise = Concurrent::Promise.new { 20 }
promise.then { |r| puts r ** r ** 2 }
promise.execute

while promise.pending?
  sleep 1
  puts 'pending'
end

puts promise.value
```

When executing it, it keeps outputting `pending` and never stops