### PR TITLE
Fix JRuby Semaphore not allowing #new and #reduce_permits with zero

### DIFF
--- a/spec/concurrent/atomic/semaphore_spec.rb
+++ b/spec/concurrent/atomic/semaphore_spec.rb
@@ -1,7 +1,7 @@
 shared_examples :semaphore do
   let(:semaphore) { described_class.new(3) }
 
-  context '#initialize' do
+  describe '#initialize' do
     it 'raises an exception if the initial count is not an integer' do
       expect {
         described_class.new('foo')
@@ -102,7 +102,7 @@ shared_examples :semaphore do
 
     it 'reduces permits below zero' do
       semaphore.reduce_permits 1003
-      expect(semaphore.available_permits).to eq -1000
+      expect(semaphore.available_permits).to eq(-1000)
     end
 
     it 'reduces permits' do

--- a/spec/concurrent/atomic/semaphore_spec.rb
+++ b/spec/concurrent/atomic/semaphore_spec.rb
@@ -27,6 +27,14 @@ shared_examples :semaphore do
         expect(semaphore.available_permits).to eq 0
       end
     end
+
+    context 'when acquiring zero permits' do
+      it do
+        expect {
+          semaphore.acquire(0)
+        }.to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe '#drain_permits' do
@@ -53,6 +61,14 @@ shared_examples :semaphore do
       it 'returns false immediately in no permits are available' do
         result = semaphore.try_acquire(20)
         expect(result).to be_falsey
+      end
+
+      context 'when trying to acquire zero permits' do
+        it do
+          expect {
+            semaphore.try_acquire(0)
+          }.to raise_error(ArgumentError)
+        end
       end
     end
 

--- a/spec/concurrent/atomic/semaphore_spec.rb
+++ b/spec/concurrent/atomic/semaphore_spec.rb
@@ -7,6 +7,14 @@ shared_examples :semaphore do
         described_class.new('foo')
       }.to raise_error(ArgumentError)
     end
+
+    context 'when initializing with 0' do
+      let(:semaphore) { described_class.new(0) }
+
+      it do
+        expect(semaphore).to_not be nil
+      end
+    end
   end
 
   describe '#acquire' do
@@ -110,6 +118,11 @@ shared_examples :semaphore do
       expect(semaphore.available_permits).to eq 2
       semaphore.reduce_permits 2
       expect(semaphore.available_permits).to eq 0
+    end
+
+    it 'reduces zero permits' do
+      semaphore.reduce_permits 0
+      expect(semaphore.available_permits).to eq 3
     end
   end
 

--- a/spec/concurrent/atomic/semaphore_spec.rb
+++ b/spec/concurrent/atomic/semaphore_spec.rb
@@ -112,6 +112,28 @@ shared_examples :semaphore do
       expect(semaphore.available_permits).to eq 0
     end
   end
+
+  describe '#release' do
+    it 'increases the number of available permits by one' do
+      semaphore.release
+      expect(semaphore.available_permits).to eq 4
+    end
+
+    context 'when a number of permits is specified' do
+      it 'increases the number of available permits by the specified value' do
+        semaphore.release(2)
+        expect(semaphore.available_permits).to eq 5
+      end
+
+      context 'when permits is set to zero' do
+        it do
+          expect {
+            semaphore.release(0)
+          }.to raise_error(ArgumentError)
+        end
+      end
+    end
+  end
 end
 
 module Concurrent


### PR DESCRIPTION
These behaviors were different from the non-JRuby semaphore implementation, where this was already allowed.

I also improved the test coverage to cover the behavior of the various other methods when getting `0` as argument.