### PR TITLE
Allow ThreadLocalVar to be initialized with a block

### DIFF
--- a/lib/concurrent/atomic/abstract_thread_local_var.rb
+++ b/lib/concurrent/atomic/abstract_thread_local_var.rb
@@ -8,8 +8,17 @@ module Concurrent
   class AbstractThreadLocalVar
 
     # @!macro thread_local_var_method_initialize
-    def initialize(default = nil)
-      @default = default
+    def initialize(default = nil, &default_block)
+      if default && block_given?
+        raise ArgumentError, "Cannot use both value and block as default value"
+      end
+
+      if block_given?
+        @default_block = default_block
+      else
+        @default = default
+      end
+
       allocate_storage
     end
 
@@ -41,6 +50,15 @@ module Concurrent
     # @!visibility private
     def allocate_storage
       raise NotImplementedError
+    end
+
+    # @!visibility private
+    def default
+      if @default_block
+        self.value = @default_block.call
+      else
+        @default
+      end
     end
   end
 end

--- a/lib/concurrent/atomic/abstract_thread_local_var.rb
+++ b/lib/concurrent/atomic/abstract_thread_local_var.rb
@@ -25,7 +25,15 @@ module Concurrent
 
     # @!macro thread_local_var_method_bind
     def bind(value, &block)
-      raise NotImplementedError
+      if block_given?
+        old_value = self.value
+        begin
+          self.value = value
+          yield
+        ensure
+          self.value = old_value
+        end
+      end
     end
 
     protected

--- a/lib/concurrent/atomic/java_thread_local_var.rb
+++ b/lib/concurrent/atomic/java_thread_local_var.rb
@@ -13,7 +13,7 @@ if Concurrent.on_jruby?
         value = @var.get
 
         if value.nil?
-          @default
+          default
         elsif value == NULL
           nil
         else

--- a/lib/concurrent/atomic/java_thread_local_var.rb
+++ b/lib/concurrent/atomic/java_thread_local_var.rb
@@ -26,19 +26,6 @@ if Concurrent.on_jruby?
         @var.set(value)
       end
 
-      # @!macro thread_local_var_method_bind
-      def bind(value, &block)
-        if block_given?
-          old_value = @var.get
-          begin
-            @var.set(value)
-            yield
-          ensure
-            @var.set(old_value)
-          end
-        end
-      end
-
       protected
 
       # @!visibility private

--- a/lib/concurrent/atomic/ruby_thread_local_var.rb
+++ b/lib/concurrent/atomic/ruby_thread_local_var.rb
@@ -40,14 +40,14 @@ module Concurrent
       if array = get_threadlocal_array
         value = array[@index]
         if value.nil?
-          @default
+          default
         elsif value.equal?(NULL)
           nil
         else
           value
         end
       else
-        @default
+        default
       end
     end
 
@@ -135,12 +135,20 @@ module Concurrent
       if array = get_threadlocal_array(thread)
         value = array[@index]
         if value.nil?
-          @default
+          default_for(thread)
         elsif value.equal?(NULL)
           nil
         else
           value
         end
+      else
+        default_for(thread)
+      end
+    end
+
+    def default_for(thread)
+      if @default_block
+        raise "Cannot use default_for with default block"
       else
         @default
       end

--- a/lib/concurrent/atomic/ruby_thread_local_var.rb
+++ b/lib/concurrent/atomic/ruby_thread_local_var.rb
@@ -35,16 +35,6 @@ module Concurrent
     @@next = 0
     private_constant :FREE, :LOCK, :ARRAYS
 
-    # @!macro [attach] thread_local_var_method_initialize
-    #
-    #   Creates a thread local variable.
-    #
-    #   @param [Object] default the default value when otherwise unset
-    def initialize(default = nil)
-      @default = default
-      allocate_storage
-    end
-
     # @!macro thread_local_var_method_get
     def value
       if array = get_threadlocal_array
@@ -74,19 +64,6 @@ module Concurrent
       end
       array[@index] = (value.nil? ? NULL : value)
       value
-    end
-
-    # @!macro thread_local_var_method_bind
-    def bind(value, &block)
-      if block_given?
-        old_value = self.value
-        begin
-          self.value = value
-          yield
-        ensure
-          self.value = old_value
-        end
-      end
     end
 
     protected

--- a/lib/concurrent/atomic/thread_local_var.rb
+++ b/lib/concurrent/atomic/thread_local_var.rb
@@ -11,6 +11,8 @@ module Concurrent
   #   Creates a thread local variable.
   #
   #   @param [Object] default the default value when otherwise unset
+  #   @param [Proc] block Optional block that gets called to obtain the
+  #     default value for each thread
 
   # @!macro [new] thread_local_var_method_get
   #

--- a/spec/concurrent/atomic/thread_local_var_spec.rb
+++ b/spec/concurrent/atomic/thread_local_var_spec.rb
@@ -6,22 +6,20 @@ module Concurrent
 
   describe ThreadLocalVar do
 
-    subject { ThreadLocalVar.new }
-
     context '#initialize' do
 
       it 'can set an initial value' do
-        v = ThreadLocalVar.new(14)
+        v = described_class.new(14)
         expect(v.value).to eq 14
       end
 
       it 'sets nil as a default initial value' do
-        v = ThreadLocalVar.new
+        v = described_class.new
         expect(v.value).to be_nil
       end
 
       it 'sets the same initial value for all threads' do
-        v  = ThreadLocalVar.new(14)
+        v  = described_class.new(14)
         t1 = Thread.new { v.value }
         t2 = Thread.new { v.value }
         expect(t1.value).to eq 14
@@ -30,51 +28,47 @@ module Concurrent
 
       if Concurrent.on_jruby?
         it 'extends JavaThreadLocalVar' do
-          expect(subject.class.ancestors).to include(Concurrent::JavaThreadLocalVar)
+          expect(described_class.ancestors).to include(Concurrent::JavaThreadLocalVar)
         end
       else
         it 'extends RubyThreadLocalVar' do
-          expect(subject.class.ancestors).to include(Concurrent::RubyThreadLocalVar)
+          expect(described_class.ancestors).to include(Concurrent::RubyThreadLocalVar)
         end
       end
     end
 
     context '#value' do
+      let(:v) { described_class.new(14) }
 
       it 'returns the current value' do
-        v = ThreadLocalVar.new(14)
         expect(v.value).to eq 14
       end
 
       it 'returns the value after modification' do
-        v = ThreadLocalVar.new(14)
         v.value = 2
         expect(v.value).to eq 2
       end
     end
 
     context '#value=' do
+      let(:v) { described_class.new(14) }
 
       it 'sets a new value' do
-        v = ThreadLocalVar.new(14)
         v.value = 2
         expect(v.value).to eq 2
       end
 
       it 'returns the new value' do
-        v = ThreadLocalVar.new(14)
         expect(v.value = 2).to eq 2
       end
 
       it 'does not modify the initial value for other threads' do
-        v = ThreadLocalVar.new(14)
         v.value = 2
         t = Thread.new { v.value }
         expect(t.value).to eq 14
       end
 
       it 'does not modify the value for other threads' do
-        v = ThreadLocalVar.new(14)
         v.value = 2
 
         b1 = CountDownLatch.new(2)


### PR DESCRIPTION
`ThreadLocalVar`s can now receive a block in the `#initialize` method, which will be called to initialize the value on each thread.

This allows default initialization to work with non-value types, where
each thread gets its own copy:

```ruby
v = ThreadLocalVar.new { {} }
h1 = Thread.new { v.value }.value
h2 = Thread.new { v.value }.value

h1.equal? h2 # -> false
```