### PR TITLE
Reject promise on any exception

### DIFF
--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -525,7 +525,7 @@ module Concurrent
     # @!visibility private
     def realize(task)
       @executor.post do
-        success, value, reason = SafeTaskExecutor.new(task).execute(*@args)
+        success, value, reason = SafeTaskExecutor.new(task, rescue_exception: true).execute(*@args)
         complete(success, value, reason)
       end
     end

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -620,6 +620,11 @@ module Concurrent
         expect(p.reason).to be_a ArgumentError
       end
 
+      it 'rejects on Exception' do
+        p = Promise.new(executor: :immediate){ raise Exception }.execute
+        expect(p).to be_rejected
+      end
+
     end
 
     context 'aliases' do


### PR DESCRIPTION
Currently, promises will hang if an exception
is raised that does not extend from StandardError.

```
Concurrent::Promise.execute { raise Exception }.value
...
```

This behavior is unexpected and seems likely to be
wrong for most use cases.

Futures already use `safe_execute` which includes the
`rescue_exception` option.