### PR TITLE
Use block form of IO.popen to prevent zombies

### DIFF
--- a/lib/concurrent/utility/processor_counter.rb
+++ b/lib/concurrent/utility/processor_counter.rb
@@ -86,27 +86,25 @@ module Concurrent
               "select NumberOfLogicalProcessors from Win32_Processor")
             result.to_enum.collect(&:NumberOfLogicalProcessors).reduce(:+)
           elsif File.executable?("/usr/bin/nproc")
-            IO.popen("/usr/bin/nproc --all").read.to_i
+            IO.popen("/usr/bin/nproc --all", &:read).to_i
           elsif File.readable?("/proc/cpuinfo")
             IO.read("/proc/cpuinfo").scan(/^processor/).size
           elsif File.executable?("/usr/bin/hwprefs")
-            IO.popen("/usr/bin/hwprefs thread_count").read.to_i
+            IO.popen("/usr/bin/hwprefs thread_count", &:read).to_i
           elsif File.executable?("/usr/sbin/psrinfo")
-            IO.popen("/usr/sbin/psrinfo").read.scan(/^.*on-*line/).size
+            IO.popen("/usr/sbin/psrinfo", &:read).scan(/^.*on-*line/).size
           elsif File.executable?("/usr/sbin/ioscan")
-            IO.popen("/usr/sbin/ioscan -kC processor") do |out|
-              out.read.scan(/^.*processor/).size
-            end
+            IO.popen("/usr/sbin/ioscan -kC processor", &:read).scan(/^.*processor/).size
           elsif File.executable?("/usr/sbin/pmcycles")
-            IO.popen("/usr/sbin/pmcycles -m").read.count("\n")
+            IO.popen("/usr/sbin/pmcycles -m", &:read).count("\n")
           elsif File.executable?("/usr/sbin/lsdev")
-            IO.popen("/usr/sbin/lsdev -Cc processor -S 1").read.count("\n")
+            IO.popen("/usr/sbin/lsdev -Cc processor -S 1", &:read).count("\n")
           elsif File.executable?("/usr/sbin/sysconf") and os_name =~ /irix/i
-            IO.popen("/usr/sbin/sysconf NPROC_ONLN").read.to_i
+            IO.popen("/usr/sbin/sysconf NPROC_ONLN", &:read).to_i
           elsif File.executable?("/usr/sbin/sysctl")
-            IO.popen("/usr/sbin/sysctl -n hw.ncpu").read.to_i
+            IO.popen("/usr/sbin/sysctl -n hw.ncpu", &:read).to_i
           elsif File.executable?("/sbin/sysctl")
-            IO.popen("/sbin/sysctl -n hw.ncpu").read.to_i
+            IO.popen("/sbin/sysctl -n hw.ncpu", &:read).to_i
           else
             1
           end
@@ -118,7 +116,7 @@ module Concurrent
       def compute_physical_processor_count
         ppc = case RbConfig::CONFIG["target_os"]
               when /darwin1/
-                IO.popen("/usr/sbin/sysctl -n hw.physicalcpu").read.to_i
+                IO.popen("/usr/sbin/sysctl -n hw.physicalcpu", &:read).to_i
               when /linux/
                 cores = {} # unique physical ID / core ID combinations
                 phy   = 0

--- a/lib/concurrent/utility/processor_counter.rb
+++ b/lib/concurrent/utility/processor_counter.rb
@@ -85,10 +85,10 @@ module Concurrent
             result = WIN32OLE.connect("winmgmts://").ExecQuery(
               "select NumberOfLogicalProcessors from Win32_Processor")
             result.to_enum.collect(&:NumberOfLogicalProcessors).reduce(:+)
+          elsif File.readable?("/proc/cpuinfo") && (cpuinfo_count = IO.read("/proc/cpuinfo").scan(/^processor/).size) > 0
+            cpuinfo_count
           elsif File.executable?("/usr/bin/nproc")
             IO.popen("/usr/bin/nproc --all", &:read).to_i
-          elsif File.readable?("/proc/cpuinfo")
-            IO.read("/proc/cpuinfo").scan(/^processor/).size
           elsif File.executable?("/usr/bin/hwprefs")
             IO.popen("/usr/bin/hwprefs thread_count", &:read).to_i
           elsif File.executable?("/usr/sbin/psrinfo")


### PR DESCRIPTION
```
107965 ?        Z      0:00      \_ [nproc] <defunct>
```

😟 

---

The fact we do the fork on any linux with an nproc, and not only the one with an untrustworthy cpuinfo, seems separately unfortunate... but we can at least avoid leaving a mess.
