### PR TITLE
Make all?, any? return something more meaningful

### DIFF
--- a/lib/concurrent/promise.rb
+++ b/lib/concurrent/promise.rb
@@ -479,6 +479,7 @@ module Concurrent
         unless completed.empty? || completed.send(method){|promise| promise.fulfilled? }
           raise PromiseExecutionError
         end
+        completed
       end
       composite
     end


### PR DESCRIPTION
Currently all of them return `nil`, what can be confusing when someone comes from JS world.

Also, I'm in need of creating `Promise.all?` function what returns *unscheduled* promise of results of all passed promises promises.. The same as `Promise.all` in JS.

Could we maybe add `Promise.all` in concurrent ruby as well?