### PR TITLE
Minimal changes to avoid Fixnum deprecation warnings

### DIFF
--- a/lib/concurrent/atomic/cyclic_barrier.rb
+++ b/lib/concurrent/atomic/cyclic_barrier.rb
@@ -18,7 +18,7 @@ module Concurrent
     #
     # @raise [ArgumentError] if `parties` is not an integer or is less than zero
     def initialize(parties, &block)
-      if !parties.is_a?(Fixnum) || parties < 1
+      if !parties.is_a?(Integer) || parties < 1
         raise ArgumentError.new('count must be in integer greater than or equal zero')
       end
       super(&nil)

--- a/lib/concurrent/atomic/cyclic_barrier.rb
+++ b/lib/concurrent/atomic/cyclic_barrier.rb
@@ -1,4 +1,5 @@
 require 'concurrent/synchronization'
+require 'concurrent/utility/native_integer'
 
 module Concurrent
 
@@ -18,9 +19,9 @@ module Concurrent
     #
     # @raise [ArgumentError] if `parties` is not an integer or is less than zero
     def initialize(parties, &block)
-      if !parties.is_a?(Integer) || parties < 1
-        raise ArgumentError.new('count must be in integer greater than or equal zero')
-      end
+      Utility::NativeInteger.ensure_integer_and_bounds parties
+      Utility::NativeInteger.ensure_positive_and_no_zero parties
+
       super(&nil)
       synchronize { ns_initialize parties, &block }
     end

--- a/lib/concurrent/atomic/mutex_atomic_fixnum.rb
+++ b/lib/concurrent/atomic/mutex_atomic_fixnum.rb
@@ -77,8 +77,8 @@ module Concurrent
 
     # @!visibility private
     def range_check!(value)
-      if !value.is_a?(Fixnum)
-        raise ArgumentError.new('value value must be a Fixnum')
+      if !value.is_a?(Integer)
+        raise ArgumentError.new('value must be an Integer')
       elsif value > MAX_VALUE
         raise RangeError.new("#{value} is greater than the maximum value of #{MAX_VALUE}")
       elsif value < MIN_VALUE

--- a/lib/concurrent/atomic/mutex_atomic_fixnum.rb
+++ b/lib/concurrent/atomic/mutex_atomic_fixnum.rb
@@ -1,4 +1,5 @@
 require 'concurrent/synchronization'
+require 'concurrent/utility/native_integer'
 
 module Concurrent
 
@@ -6,10 +7,6 @@ module Concurrent
   # @!visibility private
   # @!macro internal_implementation_note
   class MutexAtomicFixnum < Synchronization::LockableObject
-
-    # http://stackoverflow.com/questions/535721/ruby-max-integer
-    MIN_VALUE = -(2**(0.size * 8 - 2))
-    MAX_VALUE = (2**(0.size * 8 - 2) - 1)
 
     # @!macro atomic_fixnum_method_initialize
     def initialize(initial = 0)
@@ -71,21 +68,8 @@ module Concurrent
 
     # @!visibility private
     def ns_set(value)
-      range_check!(value)
+      Utility::NativeInteger.ensure_integer_and_bounds value
       @value = value
-    end
-
-    # @!visibility private
-    def range_check!(value)
-      if !value.is_a?(Integer)
-        raise ArgumentError.new('value must be an Integer')
-      elsif value > MAX_VALUE
-        raise RangeError.new("#{value} is greater than the maximum value of #{MAX_VALUE}")
-      elsif value < MIN_VALUE
-        raise RangeError.new("#{value} is less than the maximum value of #{MIN_VALUE}")
-      else
-        value
-      end
     end
   end
 end

--- a/lib/concurrent/atomic/mutex_count_down_latch.rb
+++ b/lib/concurrent/atomic/mutex_count_down_latch.rb
@@ -9,9 +9,9 @@ module Concurrent
 
     # @!macro count_down_latch_method_initialize
     def initialize(count = 1)
-      unless count.is_a?(Integer) && count >= 0
-        raise ArgumentError.new('count must be in integer greater than or equal zero')
-      end
+      Utility::NativeInteger.ensure_integer_and_bounds count
+      Utility::NativeInteger.ensure_positive count
+
       super()
       synchronize { ns_initialize count }
     end

--- a/lib/concurrent/atomic/mutex_count_down_latch.rb
+++ b/lib/concurrent/atomic/mutex_count_down_latch.rb
@@ -9,7 +9,7 @@ module Concurrent
 
     # @!macro count_down_latch_method_initialize
     def initialize(count = 1)
-      unless count.is_a?(Fixnum) && count >= 0
+      unless count.is_a?(Integer) && count >= 0
         raise ArgumentError.new('count must be in integer greater than or equal zero')
       end
       super()

--- a/lib/concurrent/atomic/mutex_semaphore.rb
+++ b/lib/concurrent/atomic/mutex_semaphore.rb
@@ -9,7 +9,7 @@ module Concurrent
 
     # @!macro semaphore_method_initialize
     def initialize(count)
-      unless count.is_a?(Fixnum) && count >= 0
+      unless count.is_a?(Integer) && count >= 0
         fail ArgumentError, 'count must be an non-negative integer'
       end
       super()
@@ -18,7 +18,7 @@ module Concurrent
 
     # @!macro semaphore_method_acquire
     def acquire(permits = 1)
-      unless permits.is_a?(Fixnum) && permits > 0
+      unless permits.is_a?(Integer) && permits > 0
         fail ArgumentError, 'permits must be an integer greater than zero'
       end
       synchronize do
@@ -45,7 +45,7 @@ module Concurrent
 
     # @!macro semaphore_method_try_acquire
     def try_acquire(permits = 1, timeout = nil)
-      unless permits.is_a?(Fixnum) && permits > 0
+      unless permits.is_a?(Integer) && permits > 0
         fail ArgumentError, 'permits must be an integer greater than zero'
       end
       synchronize do
@@ -59,7 +59,7 @@ module Concurrent
 
     # @!macro semaphore_method_release
     def release(permits = 1)
-      unless permits.is_a?(Fixnum) && permits > 0
+      unless permits.is_a?(Integer) && permits > 0
         fail ArgumentError, 'permits must be an integer greater than zero'
       end
       synchronize do
@@ -81,7 +81,7 @@ module Concurrent
     #
     # @!visibility private
     def reduce_permits(reduction)
-      unless reduction.is_a?(Fixnum) && reduction >= 0
+      unless reduction.is_a?(Integer) && reduction >= 0
         fail ArgumentError, 'reduction must be an non-negative integer'
       end
       synchronize { @free -= reduction }

--- a/lib/concurrent/atomic/mutex_semaphore.rb
+++ b/lib/concurrent/atomic/mutex_semaphore.rb
@@ -1,4 +1,5 @@
 require 'concurrent/synchronization'
+require 'concurrent/utility/native_integer'
 
 module Concurrent
 
@@ -9,18 +10,18 @@ module Concurrent
 
     # @!macro semaphore_method_initialize
     def initialize(count)
-      unless count.is_a?(Integer) && count >= 0
-        fail ArgumentError, 'count must be an non-negative integer'
-      end
+      Utility::NativeInteger.ensure_integer_and_bounds count
+      Utility::NativeInteger.ensure_positive count
+
       super()
       synchronize { ns_initialize count }
     end
 
     # @!macro semaphore_method_acquire
     def acquire(permits = 1)
-      unless permits.is_a?(Integer) && permits > 0
-        fail ArgumentError, 'permits must be an integer greater than zero'
-      end
+      Utility::NativeInteger.ensure_integer_and_bounds permits
+      Utility::NativeInteger.ensure_positive_and_no_zero permits
+
       synchronize do
         try_acquire_timed(permits, nil)
         nil
@@ -45,9 +46,9 @@ module Concurrent
 
     # @!macro semaphore_method_try_acquire
     def try_acquire(permits = 1, timeout = nil)
-      unless permits.is_a?(Integer) && permits > 0
-        fail ArgumentError, 'permits must be an integer greater than zero'
-      end
+      Utility::NativeInteger.ensure_integer_and_bounds permits
+      Utility::NativeInteger.ensure_positive_and_no_zero permits
+
       synchronize do
         if timeout.nil?
           try_acquire_now(permits)
@@ -59,9 +60,9 @@ module Concurrent
 
     # @!macro semaphore_method_release
     def release(permits = 1)
-      unless permits.is_a?(Integer) && permits > 0
-        fail ArgumentError, 'permits must be an integer greater than zero'
-      end
+      Utility::NativeInteger.ensure_integer_and_bounds permits
+      Utility::NativeInteger.ensure_positive_and_no_zero permits
+
       synchronize do
         @free += permits
         permits.times { ns_signal }
@@ -81,9 +82,9 @@ module Concurrent
     #
     # @!visibility private
     def reduce_permits(reduction)
-      unless reduction.is_a?(Integer) && reduction >= 0
-        fail ArgumentError, 'reduction must be an non-negative integer'
-      end
+      Utility::NativeInteger.ensure_integer_and_bounds reduction
+      Utility::NativeInteger.ensure_positive reduction
+
       synchronize { @free -= reduction }
       nil
     end

--- a/lib/concurrent/map.rb
+++ b/lib/concurrent/map.rb
@@ -203,7 +203,7 @@ module Concurrent
     undef :freeze
 
     # @!visibility private
-    DEFAULT_OBJ_ID_STR_WIDTH = (2**50).class == Fixnum ? 14 : 7 # we want to look "native", 7 for 32-bit, 14 for 64-bit
+    DEFAULT_OBJ_ID_STR_WIDTH = 0.size == 4 ? 7 : 14 # we want to look "native", 7 for 32-bit, 14 for 64-bit
     # override default #inspect() method: firstly, we don't want to be spilling our guts (i-vars), secondly, MRI backend's
     # #inspect() call on its @backend i-var will bump @backend's iter level while possibly yielding GVL
     def inspect
@@ -227,8 +227,8 @@ module Concurrent
     end
 
     def validate_options_hash!(options)
-      if (initial_capacity = options[:initial_capacity]) && (!initial_capacity.kind_of?(Fixnum) || initial_capacity < 0)
-        raise ArgumentError, ":initial_capacity must be a positive Fixnum"
+      if (initial_capacity = options[:initial_capacity]) && (!initial_capacity.kind_of?(Integer) || initial_capacity < 0)
+        raise ArgumentError, ":initial_capacity must be a positive Integer"
       end
       if (load_factor = options[:load_factor]) && (!load_factor.kind_of?(Numeric) || load_factor <= 0 || load_factor > 1)
         raise ArgumentError, ":load_factor must be a number between 0 and 1"

--- a/lib/concurrent/thread_safe/util.rb
+++ b/lib/concurrent/thread_safe/util.rb
@@ -6,8 +6,10 @@ module Concurrent
     # @!visibility private
     module Util
 
+      # TODO (pitr-ch 15-Oct-2016): migrate to Utility::NativeInteger
       FIXNUM_BIT_SIZE = (0.size * 8) - 2
       MAX_INT         = (2 ** FIXNUM_BIT_SIZE) - 1
+      # TODO (pitr-ch 15-Oct-2016): migrate to Utility::ProcessorCounter
       CPU_COUNT       = 16 # is there a way to determine this?
     end
   end

--- a/lib/concurrent/utility/native_integer.rb
+++ b/lib/concurrent/utility/native_integer.rb
@@ -1,0 +1,53 @@
+module Concurrent
+  module Utility
+    # @private
+    module NativeInteger
+      # http://stackoverflow.com/questions/535721/ruby-max-integer
+      MIN_VALUE = -(2**(0.size * 8 - 2))
+      MAX_VALUE = (2**(0.size * 8 - 2) - 1)
+
+      def ensure_upper_bound(value)
+        if value > MAX_VALUE
+          raise RangeError.new("#{value} is greater than the maximum value of #{MAX_VALUE}")
+        end
+        value
+      end
+
+      def ensure_lower_bound(value)
+        if value < MIN_VALUE
+          raise RangeError.new("#{value} is less than the maximum value of #{MIN_VALUE}")
+        end
+        value
+      end
+
+      def ensure_integer(value)
+        unless value.is_a?(Integer)
+          raise ArgumentError.new("#{value} is not an Integer")
+        end
+        value
+      end
+
+      def ensure_integer_and_bounds(value)
+        ensure_integer value
+        ensure_upper_bound value
+        ensure_lower_bound value
+      end
+
+      def ensure_positive(value)
+        if value < 0
+          raise ArgumentError.new("#{value} cannot be negative")
+        end
+        value
+      end
+
+      def ensure_positive_and_no_zero(value)
+        if value < 1
+          raise ArgumentError.new("#{value} cannot be negative or zero")
+        end
+        value
+      end
+
+      extend self
+    end
+  end
+end

--- a/spec/concurrent/edge/future_spec.rb
+++ b/spec/concurrent/edge/future_spec.rb
@@ -202,7 +202,7 @@ describe 'Concurrent::Edge futures', edge: true do
       c = Concurrent.future { raise 'c' }
 
       Concurrent.zip(a, b, c).chain { |*args| q << args }
-      expect(q.pop.flatten.map(&:class)).to eq [FalseClass, 1.class, NilClass, NilClass, NilClass, RuntimeError, RuntimeError]
+      expect(q.pop.flatten.map(&:class)).to eq [FalseClass, 0.class, NilClass, NilClass, NilClass, RuntimeError, RuntimeError]
       Concurrent.zip(a, b, c).rescue { |*args| q << args }
       expect(q.pop.map(&:class)).to eq [NilClass, RuntimeError, RuntimeError]
 

--- a/spec/concurrent/edge/future_spec.rb
+++ b/spec/concurrent/edge/future_spec.rb
@@ -202,7 +202,7 @@ describe 'Concurrent::Edge futures', edge: true do
       c = Concurrent.future { raise 'c' }
 
       Concurrent.zip(a, b, c).chain { |*args| q << args }
-      expect(q.pop.flatten.map(&:class)).to eq [FalseClass, Fixnum, NilClass, NilClass, NilClass, RuntimeError, RuntimeError]
+      expect(q.pop.flatten.map(&:class)).to eq [FalseClass, 1.class, NilClass, NilClass, NilClass, RuntimeError, RuntimeError]
       Concurrent.zip(a, b, c).rescue { |*args| q << args }
       expect(q.pop.map(&:class)).to eq [NilClass, RuntimeError, RuntimeError]
 


### PR DESCRIPTION
This does not revise the documentation to match -- I figured that might warrant closer attention to which values are happy to mean "all integers", and which feel obliged to now specify "integers in the range X".

As for the changes: simple counts like `parties` will now accept Bignums -- that doesn't seem particularly useful, but also seems no more problematic than `2**60`. The only one that felt potentially notable was `MutexAtomicFixnum` -- but while more values pass the class check, they're caught by the range check immediately following.