### PR TITLE
Avoid forking for processor_count if possible

### DIFF
--- a/lib/concurrent/utility/processor_counter.rb
+++ b/lib/concurrent/utility/processor_counter.rb
@@ -85,10 +85,10 @@ module Concurrent
             result = WIN32OLE.connect("winmgmts://").ExecQuery(
               "select NumberOfLogicalProcessors from Win32_Processor")
             result.to_enum.collect(&:NumberOfLogicalProcessors).reduce(:+)
+          elsif File.readable?("/proc/cpuinfo") and (cpuinfo_count = IO.read("/proc/cpuinfo").scan(/^processor/).size) > 0
+            cpuinfo_count
           elsif File.executable?("/usr/bin/nproc")
             IO.popen("/usr/bin/nproc --all").read.to_i
-          elsif File.readable?("/proc/cpuinfo")
-            IO.read("/proc/cpuinfo").scan(/^processor/).size
           elsif File.executable?("/usr/bin/hwprefs")
             IO.popen("/usr/bin/hwprefs thread_count").read.to_i
           elsif File.executable?("/usr/sbin/psrinfo")


### PR DESCRIPTION
This re-orders the checks for the processor count so that forking is
only done when needed. alpha-linux does not support the processor entry
in /proc/cpuinfo so we must catch that case and fall back to using nproc
which does work on alpha.

This is a rework of #549 based on suggestions made in #576