### PR TITLE
Adding dynamic thread pool executor length setters

### DIFF
--- a/lib/concurrent/executor/fixed_thread_pool.rb
+++ b/lib/concurrent/executor/fixed_thread_pool.rb
@@ -16,13 +16,21 @@ module Concurrent
   #   Default maximum number of seconds a thread in the pool may remain idle
   #   before being reclaimed.
 
-  # @!macro [new] thread_pool_executor_attr_reader_max_length
+  # @!macro [new] thread_pool_executor_max_threads
   #   The maximum number of threads that may be created in the pool.
   #   @return [Integer] The maximum number of threads that may be created in the pool.
 
-  # @!macro [new] thread_pool_executor_attr_reader_min_length
-  #   The minimum number of threads that may be retained in the pool.
-  #   @return [Integer] The minimum number of threads that may be retained in the pool.
+  # @!macro [new] thread_pool_executor_max_threads=
+  #   Sets the maximum number of threads that may be created in the pool.
+  #   @return [Integer] The maximum number of threads that may be created in the pool.
+
+  # @!macro [new] thread_pool_executor_min_threads
+  #   The minimum number of threads that is retained in the pool.
+  #   @return [Integer] The minimum number of threads that is retained in the pool.
+
+  # @!macro [new] thread_pool_executor_min_threads=
+  #   Sets the minimum number of threads that is retained in the pool.
+  #   @return [Integer] The minimum number of threads that is retained in the pool.
 
   # @!macro [new] thread_pool_executor_attr_reader_largest_length
   #   The largest number of threads that have been created in the pool since construction.
@@ -72,11 +80,11 @@ module Concurrent
   #
   #   @!macro abstract_executor_service_public_api
   #
-  #   @!attribute [r] max_length
-  #     @!macro thread_pool_executor_attr_reader_max_length
+  #   @!attribute [rw] max_threads
+  #     @!macro thread_pool_executor_max_threads
   #
-  #   @!attribute [r] min_length
-  #     @!macro thread_pool_executor_attr_reader_min_length
+  #   @!attribute [rw] min_threads
+  #     @!macro thread_pool_executor_min_threads
   #
   #   @!attribute [r] largest_length
   #     @!macro thread_pool_executor_attr_reader_largest_length

--- a/lib/concurrent/executor/java_thread_pool_executor.rb
+++ b/lib/concurrent/executor/java_thread_pool_executor.rb
@@ -1,5 +1,6 @@
 if Concurrent.on_jruby?
 
+  require 'concurrent/concern/deprecation'
   require 'concurrent/executor/java_executor_service'
 
   module Concurrent
@@ -8,6 +9,7 @@ if Concurrent.on_jruby?
     # @!macro thread_pool_options
     # @!visibility private
     class JavaThreadPoolExecutor < JavaExecutorService
+      include Concern::Deprecation
 
       # @!macro thread_pool_executor_constant_default_max_pool_size
       DEFAULT_MAX_POOL_SIZE = java.lang.Integer::MAX_VALUE # 2147483647
@@ -34,29 +36,39 @@ if Concurrent.on_jruby?
         @max_queue != 0
       end
 
-      # @!macro thread_pool_executor_attr_reader_min_length
-      def min_length
+      # @!macro thread_pool_executor_attr_reader_min_threads
+      def min_threads
         @executor.getCorePoolSize
       end
 
-      # @!macro thread_pool_executor_attr_writer_min_length
-      def min_length=(num)
+      def min_length
+        deprecated_method 'min_length', 'min_threads'
+        min_threads
+      end
+
+      # @!macro thread_pool_executor_attr_writer_min_threads
+      def min_threads=(num)
         num = num.to_i
         raise ArgumentError.new("`min_threads` cannot be less than #{DEFAULT_MIN_POOL_SIZE}") if num < DEFAULT_MIN_POOL_SIZE
-        raise ArgumentError.new("`min_threads` cannot be more than `max_threads`") if num > max_length
+        raise ArgumentError.new("`min_threads` cannot be more than `max_threads`") if num > max_threads
 
         @executor.setCorePoolSize(num)
       end
 
-      # @!macro thread_pool_executor_attr_reader_max_length
-      def max_length
+      # @!macro thread_pool_executor_attr_reader_max_threads
+      def max_threads
         @executor.getMaximumPoolSize
       end
 
-      # @!macro thread_pool_executor_attr_reader_max_length
-      def max_length=(num)
+      def max_length
+        deprecated_method 'max_length', 'max_threads'
+        max_threads
+      end
+
+      # @!macro thread_pool_executor_attr_reader_max_threads
+      def max_threads=(num)
         num = num.to_i
-        raise ArgumentError.new("`max_threads` cannot be less than `min_threads`") if num < min_length
+        raise ArgumentError.new("`max_threads` cannot be less than `min_threads`") if num < min_threads
         raise ArgumentError.new("`max_threads` cannot be greater than #{DEFAULT_MAX_POOL_SIZE}") if num > DEFAULT_MAX_POOL_SIZE
 
         @executor.setMaximumPoolSize(num)

--- a/lib/concurrent/executor/java_thread_pool_executor.rb
+++ b/lib/concurrent/executor/java_thread_pool_executor.rb
@@ -21,9 +21,6 @@ if Concurrent.on_jruby?
       # @!macro thread_pool_executor_constant_default_thread_timeout
       DEFAULT_THREAD_IDLETIMEOUT = 60
 
-      # @!macro thread_pool_executor_attr_reader_max_length
-      attr_reader :max_length
-
       # @!macro thread_pool_executor_attr_reader_max_queue
       attr_reader :max_queue
 
@@ -42,9 +39,27 @@ if Concurrent.on_jruby?
         @executor.getCorePoolSize
       end
 
+      # @!macro thread_pool_executor_attr_writer_min_length
+      def min_length=(num)
+        num = num.to_i
+        raise ArgumentError.new("`min_threads` cannot be less than #{DEFAULT_MIN_POOL_SIZE}") if num < DEFAULT_MIN_POOL_SIZE
+        raise ArgumentError.new("`min_threads` cannot be more than `max_threads`") if num > max_length
+
+        @executor.setCorePoolSize(num)
+      end
+
       # @!macro thread_pool_executor_attr_reader_max_length
       def max_length
         @executor.getMaximumPoolSize
+      end
+
+      # @!macro thread_pool_executor_attr_reader_max_length
+      def max_length=(num)
+        num = num.to_i
+        raise ArgumentError.new("`max_threads` cannot be less than `min_threads`") if num < min_length
+        raise ArgumentError.new("`max_threads` cannot be greater than #{DEFAULT_MAX_POOL_SIZE}") if num > DEFAULT_MAX_POOL_SIZE
+
+        @executor.setMaximumPoolSize(num)
       end
 
       # @!macro thread_pool_executor_attr_reader_length

--- a/lib/concurrent/executor/java_thread_pool_executor.rb
+++ b/lib/concurrent/executor/java_thread_pool_executor.rb
@@ -36,17 +36,18 @@ if Concurrent.on_jruby?
         @max_queue != 0
       end
 
-      # @!macro thread_pool_executor_attr_reader_min_threads
+      # @!macro thread_pool_executor_min_threads
       def min_threads
         @executor.getCorePoolSize
       end
 
+      # @see #min_threads
       def min_length
         deprecated_method 'min_length', 'min_threads'
         min_threads
       end
 
-      # @!macro thread_pool_executor_attr_writer_min_threads
+      # @!macro thread_pool_executor_min_threads=
       def min_threads=(num)
         num = num.to_i
         raise ArgumentError.new("`min_threads` cannot be less than #{DEFAULT_MIN_POOL_SIZE}") if num < DEFAULT_MIN_POOL_SIZE
@@ -55,17 +56,18 @@ if Concurrent.on_jruby?
         @executor.setCorePoolSize(num)
       end
 
-      # @!macro thread_pool_executor_attr_reader_max_threads
+      # @!macro thread_pool_executor_max_threads
       def max_threads
         @executor.getMaximumPoolSize
       end
 
+      # @see #max_threads
       def max_length
         deprecated_method 'max_length', 'max_threads'
         max_threads
       end
 
-      # @!macro thread_pool_executor_attr_reader_max_threads
+      # @!macro thread_pool_executor_max_threads=
       def max_threads=(num)
         num = num.to_i
         raise ArgumentError.new("`max_threads` cannot be less than `min_threads`") if num < min_threads

--- a/lib/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent/executor/ruby_thread_pool_executor.rb
@@ -219,7 +219,7 @@ module Concurrent
     # @!visibility private
     def ns_assign_worker(*args, &task)
       # keep growing if the pool is not at the minimum yet
-      worker = (@ready.pop if @pool.size >= min_threads) || ns_add_busy_worker
+      worker = (@ready.pop if @pool.size >= @min_threads) || ns_add_busy_worker
       if worker
         worker << [task, args]
         true
@@ -256,7 +256,7 @@ module Concurrent
     #
     # @!visibility private
     def ns_add_busy_worker
-      return if @pool.size >= max_threads
+      return if @pool.size >= @max_threads
 
       @pool << (worker = Worker.new(self))
       @largest_length = @pool.length if @pool.length > @largest_length
@@ -302,7 +302,7 @@ module Concurrent
     #
     # @!visibility private
     def ns_prune_pool
-      return if @pool.size <= min_threads
+      return if @pool.size <= @min_threads
 
       last_used = @ready.shift
       last_used << :idle_test if last_used

--- a/lib/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent/executor/ruby_thread_pool_executor.rb
@@ -36,17 +36,18 @@ module Concurrent
       super(opts)
     end
 
-    # @!macro thread_pool_executor_attr_reader_min_threads
+    # @!macro thread_pool_executor_min_threads
     def min_threads
       synchronize { @min_threads }
     end
 
+    # @see #min_threads
     def min_length
       deprecated_method 'min_length', 'min_threads'
       min_threads
     end
 
-    # @!macro thread_pool_executor_attr_writer_min_threads
+    # @!macro thread_pool_executor_min_threads=
     def min_threads=(num)
       num = num.to_i
       raise ArgumentError.new("`min_threads` cannot be less than #{DEFAULT_MIN_POOL_SIZE}") if num < DEFAULT_MIN_POOL_SIZE
@@ -55,17 +56,18 @@ module Concurrent
       synchronize { @min_threads = num }
     end
 
-    # @!macro thread_pool_executor_attr_reader_max_threads
+    # @!macro thread_pool_executor_max_threads
     def max_threads
       synchronize { @max_threads }
     end
 
+    # @see #max_threads
     def max_length
       deprecated_method 'max_length', 'max_threads'
       max_threads
     end
 
-    # @!macro thread_pool_executor_attr_writer_max_threads
+    # @!macro thread_pool_executor_max_threads=
     def max_threads=(num)
       num = num.to_i
       raise ArgumentError.new("`max_threads` cannot be less than `min_threads`") if num < min_threads

--- a/lib/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent/executor/ruby_thread_pool_executor.rb
@@ -23,12 +23,6 @@ module Concurrent
     # @!macro thread_pool_executor_constant_default_thread_timeout
     DEFAULT_THREAD_IDLETIMEOUT = 60
 
-    # @!macro thread_pool_executor_attr_reader_max_length
-    attr_reader :max_length
-
-    # @!macro thread_pool_executor_attr_reader_min_length
-    attr_reader :min_length
-
     # @!macro thread_pool_executor_attr_reader_idletime
     attr_reader :idletime
 
@@ -38,6 +32,34 @@ module Concurrent
     # @!macro thread_pool_executor_method_initialize
     def initialize(opts = {})
       super(opts)
+    end
+
+    # @!macro thread_pool_executor_attr_reader_min_length
+    def min_length
+      synchronize { @min_length }
+    end
+
+    # @!macro thread_pool_executor_attr_writer_min_length
+    def min_length=(num)
+      num = num.to_i
+      raise ArgumentError.new("`min_threads` cannot be less than #{DEFAULT_MIN_POOL_SIZE}") if num < DEFAULT_MIN_POOL_SIZE
+      raise ArgumentError.new("`min_threads` cannot be more than `max_threads`") if num > max_length
+
+      synchronize { @min_length = num }
+    end
+
+    # @!macro thread_pool_executor_attr_reader_max_length
+    def max_length
+      synchronize { @max_length }
+    end
+
+    # @!macro thread_pool_executor_attr_writer_max_length
+    def max_length=(num)
+      num = num.to_i
+      raise ArgumentError.new("`max_threads` cannot be less than `min_threads`") if num < min_length
+      raise ArgumentError.new("`max_threads` cannot be greater than #{DEFAULT_MAX_POOL_SIZE}") if num > DEFAULT_MAX_POOL_SIZE
+
+      synchronize { @max_length = num }
     end
 
     # @!macro thread_pool_executor_attr_reader_largest_length

--- a/spec/concurrent/executor/thread_pool_executor_shared.rb
+++ b/spec/concurrent/executor/thread_pool_executor_shared.rb
@@ -538,4 +538,65 @@ shared_examples :thread_pool_executor do
       end
     end
   end
+
+  context '#max_length= invalid value' do
+
+    subject { described_class.new }
+
+    it 'raises an exception if max_length is less than zero' do
+      expect {
+        subject.max_length = -1
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an exception if max_length greater than the max allowable' do
+      expect {
+        subject.max_length = (described_class::DEFAULT_MAX_POOL_SIZE + 1)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an exception if max_length is less than min_length' do
+      expect {
+        subject.max_length = (subject.min_length - 1)
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  context '#max_length= valid value' do
+
+    subject { described_class.new }
+
+    it "sets max_length" do
+      subject.max_length = 17
+      expect(subject.max_length).to eq 17
+    end
+  end
+
+  context '#min_length= invalid value' do
+
+    subject { described_class.new }
+
+    it 'raises an exception if min_length is less than the min allowable' do
+      expect {
+        subject.min_length = (described_class::DEFAULT_MIN_POOL_SIZE - 1)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an exception if min_length is greater than max_length' do
+      expect {
+        subject.min_length = (subject.max_length + 1)
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  context '#min_length= valid value' do
+
+    subject { described_class.new(max_threads: 10) }
+
+    it "sets min_length" do
+      subject.min_length = 9
+      expect(subject.min_length).to eq 9
+    end
+  end
+
 end

--- a/spec/concurrent/executor/thread_pool_executor_shared.rb
+++ b/spec/concurrent/executor/thread_pool_executor_shared.rb
@@ -11,13 +11,12 @@ shared_examples :thread_pool_executor do
 
     subject { described_class.new }
 
-    it 'defaults :min_length to DEFAULT_MIN_POOL_SIZE' do
-      expect(subject.min_length).to eq described_class::DEFAULT_MIN_POOL_SIZE
+    it 'defaults :min_threads to DEFAULT_MIN_POOL_SIZE' do
+      expect(subject.min_threads).to eq described_class::DEFAULT_MIN_POOL_SIZE
     end
 
-
-    it 'defaults :max_length to DEFAULT_MAX_POOL_SIZE' do
-      expect(subject.max_length).to eq described_class::DEFAULT_MAX_POOL_SIZE
+    it 'defaults :max_threads to DEFAULT_MAX_POOL_SIZE' do
+      expect(subject.max_threads).to eq described_class::DEFAULT_MAX_POOL_SIZE
     end
 
     it 'defaults :idletime to DEFAULT_THREAD_IDLETIMEOUT' do
@@ -36,11 +35,11 @@ shared_examples :thread_pool_executor do
   context "#initialize explicit values" do
 
     it "sets :min_threads" do
-      expect(described_class.new(min_threads: 2).min_length).to eq 2
+      expect(described_class.new(min_threads: 2).min_threads).to eq 2
     end
 
     it "sets :max_threads" do
-      expect(described_class.new(max_threads: 2).max_length).to eq 2
+      expect(described_class.new(max_threads: 2).max_threads).to eq 2
     end
 
     it "sets :idletime" do
@@ -172,11 +171,11 @@ shared_examples :thread_pool_executor do
       expect(executor.remaining_capacity).to eq -1
     end
 
-    it 'returns :max_length on creation' do
+    it 'returns :max_threads on creation' do
       expect(subject.remaining_capacity).to eq expected_max
     end
 
-    it 'returns :max_length when stopped' do
+    it 'returns :max_threads when stopped' do
       100.times{ subject.post{ nil } }
       subject.shutdown
       subject.wait_for_termination(1)
@@ -539,63 +538,63 @@ shared_examples :thread_pool_executor do
     end
   end
 
-  context '#max_length= invalid value' do
+  context '#max_threads= invalid value' do
 
     subject { described_class.new }
 
-    it 'raises an exception if max_length is less than zero' do
+    it 'raises an exception if max_threads is less than zero' do
       expect {
-        subject.max_length = -1
+        subject.max_threads = -1
       }.to raise_error(ArgumentError)
     end
 
-    it 'raises an exception if max_length greater than the max allowable' do
+    it 'raises an exception if max_threads greater than the max allowable' do
       expect {
-        subject.max_length = (described_class::DEFAULT_MAX_POOL_SIZE + 1)
+        subject.max_threads = (described_class::DEFAULT_MAX_POOL_SIZE + 1)
       }.to raise_error(ArgumentError)
     end
 
-    it 'raises an exception if max_length is less than min_length' do
+    it 'raises an exception if max_threads is less than min_threads' do
       expect {
-        subject.max_length = (subject.min_length - 1)
+        subject.max_threads = (subject.min_threads - 1)
       }.to raise_error(ArgumentError)
     end
   end
 
-  context '#max_length= valid value' do
+  context '#max_threads= valid value' do
 
     subject { described_class.new }
 
-    it "sets max_length" do
-      subject.max_length = 17
-      expect(subject.max_length).to eq 17
+    it "sets max_threads" do
+      subject.max_threads = 17
+      expect(subject.max_threads).to eq 17
     end
   end
 
-  context '#min_length= invalid value' do
+  context '#min_threads= invalid value' do
 
     subject { described_class.new }
 
-    it 'raises an exception if min_length is less than the min allowable' do
+    it 'raises an exception if min_threads is less than the min allowable' do
       expect {
-        subject.min_length = (described_class::DEFAULT_MIN_POOL_SIZE - 1)
+        subject.min_threads = (described_class::DEFAULT_MIN_POOL_SIZE - 1)
       }.to raise_error(ArgumentError)
     end
 
-    it 'raises an exception if min_length is greater than max_length' do
+    it 'raises an exception if min_threads is greater than max_threads' do
       expect {
-        subject.min_length = (subject.max_length + 1)
+        subject.min_threads = (subject.max_threads + 1)
       }.to raise_error(ArgumentError)
     end
   end
 
-  context '#min_length= valid value' do
+  context '#min_threads= valid value' do
 
     subject { described_class.new(max_threads: 10) }
 
-    it "sets min_length" do
-      subject.min_length = 9
-      expect(subject.min_length).to eq 9
+    it "sets min_threads" do
+      subject.min_threads = 9
+      expect(subject.min_threads).to eq 9
     end
   end
 


### PR DESCRIPTION
- Adding ability to change the thread pool executor @min_length and 
  @max_length variables at runtime
- Removed unnecessary attr_readers, is there a reason why we need them?

- Use case: Spin up new threads dynamically when higher throughput is
  required
- Use case: Spin down threads dynamically to reduce server load

- Question: The initializer options use :max_threads and :min_threads,
  however the current attr_readers are :max_length and :min_length so I
  set up the getters and setters to use the existing terminology. Would
  it be useful to name the getters and setters #max_threads=() and
  #min_threads=()?