### PR TITLE
Output Ruby warnings when running rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --require spec_helper
 --color
+--warnings
 --format documentation

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-$VERBOSE = nil # suppress our deprecation warnings
-
 if ENV['COVERAGE']
   require 'simplecov'
   require 'coveralls'


### PR DESCRIPTION
This implements #588 in that it outputs any warning along with the rspec output. It does not force the test run to fail though.