### PR TITLE
Always initialize @default and @default_block for AbstractThreadLocalVar

### DIFF
--- a/lib/concurrent/atomic/abstract_thread_local_var.rb
+++ b/lib/concurrent/atomic/abstract_thread_local_var.rb
@@ -15,7 +15,9 @@ module Concurrent
 
       if block_given?
         @default_block = default_block
+        @default = nil
       else
+        @default_block = nil
         @default = default
       end
 


### PR DESCRIPTION
This avoids Ruby warnings like this when accessing the default value:

> lib/concurrent/atomic/abstract_thread_local_var.rb:57: warning: instance variable @default_block not initialized

This pull request fixes one of the warnings made visible in #628.