### PR TITLE
Documentation/use the correct url in the comments

### DIFF
--- a/examples/go-by-example-channels/rate-limiting.rb
+++ b/examples/go-by-example-channels/rate-limiting.rb
@@ -7,7 +7,7 @@ require 'time'
 Channel = Concurrent::Channel
 
 ## Go by Example: Rate Limiting
-# https://gobyexample.com/tickers
+# https://gobyexample.com/rate-limiting
 
 requests = Channel.new(buffer: :buffered, capacity: 5)
 (1..5).each do |i|

--- a/examples/go-by-example-channels/worker-pools.rb
+++ b/examples/go-by-example-channels/worker-pools.rb
@@ -5,7 +5,7 @@ require 'concurrent-edge'
 Channel = Concurrent::Channel
 
 ## Go by Example: Go by Example: Worker Pools
-# https://gobyexample.com/tickers
+# https://gobyexample.com/worker-pools
 
 def worker(id, jobs, results)
   jobs.each do |j|


### PR DESCRIPTION
Some of the comments in the `examples/go-by-example-channels` files have the wrong url.