### PR TITLE
Remove warnings

### DIFF
--- a/lib/concurrent/actor/behaviour/termination.rb
+++ b/lib/concurrent/actor/behaviour/termination.rb
@@ -71,7 +71,7 @@ module Concurrent
 
           all_terminations.chain_resolvable(@terminated)
           if envelope && envelope.future
-            all_terminations.chain { |fulfilled, _, reason| envelope.future.resolve fulfilled, true, reason }
+            all_terminations.chain { |fulfilled, _, t_reason| envelope.future.resolve fulfilled, true, t_reason }
           end
 
           broadcast(true, [:terminated, reason]) # TODO do not end up in Dead Letter Router

--- a/lib/concurrent/edge/cancellation.rb
+++ b/lib/concurrent/edge/cancellation.rb
@@ -113,7 +113,7 @@ module Concurrent
       # @param [Token] tokens to combine
       # @return [Token] new token
       def join(*tokens, &block)
-        block ||= -> tokens { Promises.any_event(*tokens.map(&:to_event)) }
+        block ||= -> token_list { Promises.any_event(*token_list.map(&:to_event)) }
         self.class.new block.call([@Cancel, *tokens])
       end
 

--- a/lib/concurrent/edge/promises.rb
+++ b/lib/concurrent/edge/promises.rb
@@ -902,7 +902,7 @@ module Concurrent
       end
 
       def callback_on_resolution(state, args, callback)
-        callback.call *args
+        callback.call(*args)
       end
     end
 
@@ -1226,7 +1226,7 @@ module Concurrent
       end
 
       def callback_on_resolution(state, args, callback)
-        callback.call *state.result, *args
+        callback.call(*state.result, *args)
       end
 
     end
@@ -1558,7 +1558,7 @@ module Concurrent
           end
         else
           Concurrent.executor(@Executor).post(@Args, @Task) do |args, task|
-            evaluate_to *args, task
+            evaluate_to(*args, task)
           end
         end
       end

--- a/lib/concurrent/edge/throttle.rb
+++ b/lib/concurrent/edge/throttle.rb
@@ -52,7 +52,7 @@ module Concurrent
     # TODO (pitr-ch 21-Dec-2016): consider using sized channel for implementation instead when available
 
     safe_initialization!
-    private *attr_atomic(:can_run)
+    private(*attr_atomic(:can_run))
 
     # New throttle.
     # @param [Integer] limit

--- a/spec/concurrent/channel/tick_spec.rb
+++ b/spec/concurrent/channel/tick_spec.rb
@@ -27,7 +27,7 @@ module Concurrent
       end
 
       specify '#to_s formats as a time', :truffle_bug => true do
-        expect(subject.to_s).to match /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6} \+\d{4} UTC/
+        expect(subject.to_s).to match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6} \+\d{4} UTC/)
       end
 
       context 'comparison' do

--- a/spec/concurrent/collection_each_shared.rb
+++ b/spec/concurrent/collection_each_shared.rb
@@ -23,7 +23,6 @@ shared_examples :collection_each do
       if i == 0
         i += 1
         next
-        fail
       elsif i == 1
         break :breaked
       end

--- a/spec/concurrent/edge/promises_spec.rb
+++ b/spec/concurrent/edge/promises_spec.rb
@@ -175,28 +175,28 @@ describe 'Concurrent::Promises' do
       z1.then { |*args| q << args }
       expect(q.pop).to eq [1, 2]
 
-      z1.then { |a, b, c| q << [a, b, c] }
+      z1.then { |a1, b1, c1| q << [a1, b1, c1] }
       expect(q.pop).to eq [1, 2, nil]
 
-      z2.then { |a, b, c| q << [a, b, c] }
+      z2.then { |a1, b1, c1| q << [a1, b1, c1] }
       expect(q.pop).to eq [1, 2, 3]
 
-      z3.then { |a| q << a }
+      z3.then { |a1| q << a1 }
       expect(q.pop).to eq 1
 
-      z3.then { |*a| q << a }
+      z3.then { |*as| q << as }
       expect(q.pop).to eq [1]
 
-      z4.then { |a| q << a }
+      z4.then { |a1| q << a1 }
       expect(q.pop).to eq nil
 
-      z4.then { |*a| q << a }
+      z4.then { |*as| q << as }
       expect(q.pop).to eq []
 
-      expect(z1.then { |a, b| a+b }.value!).to eq 3
-      expect(z1.then { |a, b| a+b }.value!).to eq 3
+      expect(z1.then { |a1, b1| a1 + b1 }.value!).to eq 3
+      expect(z1.then { |a1, b1| a1 + b1 }.value!).to eq 3
       expect(z1.then(&:+).value!).to eq 3
-      expect(z2.then { |a, b, c| a+b+c }.value!).to eq 6
+      expect(z2.then { |a1, b1, c1| a1 + b1 + c1 }.value!).to eq 6
 
       expect(future { 1 }.delay).to be_a_kind_of Concurrent::Promises::Future
       expect(future { 1 }.delay.wait!).to be_resolved
@@ -248,21 +248,21 @@ describe 'Concurrent::Promises' do
         queue     = Queue.new
         push_args = -> *args { queue.push args }
 
-        event_or_future.on_resolution! &push_args
+        event_or_future.on_resolution!(&push_args)
         event_or_future.on_resolution!(1, &push_args)
         if event_or_future.is_a? Concurrent::Promises::Future
-          event_or_future.on_fulfillment! &push_args
+          event_or_future.on_fulfillment!(&push_args)
           event_or_future.on_fulfillment!(2, &push_args)
-          event_or_future.on_rejection! &push_args
+          event_or_future.on_rejection!(&push_args)
           event_or_future.on_rejection!(3, &push_args)
         end
 
-        event_or_future.on_resolution &push_args
+        event_or_future.on_resolution(&push_args)
         event_or_future.on_resolution(4, &push_args)
         if event_or_future.is_a? Concurrent::Promises::Future
-          event_or_future.on_fulfillment &push_args
+          event_or_future.on_fulfillment(&push_args)
           event_or_future.on_fulfillment(5, &push_args)
-          event_or_future.on_rejection &push_args
+          event_or_future.on_rejection(&push_args)
           event_or_future.on_rejection(6, &push_args)
         end
         event_or_future.on_resolution_using(:io, &push_args)
@@ -342,7 +342,7 @@ describe 'Concurrent::Promises' do
       future8 = future0.rescue { raise 'never happens' } # future0 fulfills so future8'll have same value as future 0
 
       futures = [future0, future1, future2, future3, future4, future5, future6, future7, future8]
-      futures.each &:wait
+      futures.each(&:wait)
 
       table = futures.each_with_index.map do |f, i|
         '%5i %7s %10s %6s %4s %6s' % [i, f.fulfilled?, f.value, f.reason,
@@ -371,7 +371,7 @@ describe 'Concurrent::Promises' do
       four  = three.delay.then(&:succ)
 
       # meaningful to_s and inspect defined for Future and Promise
-      expect(head.to_s).to match /<#Concurrent::Promises::Future:0x[\da-f]+ pending>/
+      expect(head.to_s).to match(/<#Concurrent::Promises::Future:0x[\da-f]+ pending>/)
       expect(head.inspect).to(
           match(/<#Concurrent::Promises::Future:0x[\da-f]+ pending>/))
 
@@ -641,8 +641,8 @@ end
 
 describe Concurrent::ProcessingActor do
   specify do
-    actor = Concurrent::ProcessingActor.act do |actor|
-      actor.receive.then do |message|
+    actor = Concurrent::ProcessingActor.act do |the_actor|
+      the_actor.receive.then do |message|
         # the actor ends with message
         message
       end
@@ -677,8 +677,8 @@ describe Concurrent::ProcessingActor do
     expect(counter.tell!(2).ask(:count).value!).to eq 2
     expect(counter.tell!(3).tell!(:done).termination.value!).to eq 5
 
-    add_once_actor = Concurrent::ProcessingActor.act do |actor|
-      actor.receive.then do |(a, b), answer|
+    add_once_actor = Concurrent::ProcessingActor.act do |the_actor|
+      the_actor.receive.then do |(a, b), answer|
         result = a + b
         answer.fulfill result
         # terminate with result value

--- a/spec/concurrent/executor/thread_pool_executor_shared.rb
+++ b/spec/concurrent/executor/thread_pool_executor_shared.rb
@@ -169,7 +169,7 @@ shared_examples :thread_pool_executor do
 
     it 'returns -1 when :max_queue is set to zero' do
       executor = described_class.new(max_queue: 0)
-      expect(executor.remaining_capacity).to eq -1
+      expect(executor.remaining_capacity).to eq(-1)
     end
 
     it 'returns :max_length on creation' do

--- a/spec/concurrent/map_spec.rb
+++ b/spec/concurrent/map_spec.rb
@@ -423,7 +423,7 @@ module Concurrent
           expect(nil).to   eq @cache.delete(:a)
         end
         @cache[:a] = 1
-        expect_size_change -1 do
+        expect_size_change(-1) do
           expect(1).to     eq @cache.delete(:a)
         end
         expect_no_size_change do

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -445,7 +445,7 @@ module Concurrent
 
           latch.wait(1)
 
-          expect(counter.value).to eq -1
+          expect(counter.value).to eq(-1)
           end
       end
 
@@ -500,7 +500,7 @@ module Concurrent
 
           latch.wait(1)
 
-          expect(counter.value).to eq -1
+          expect(counter.value).to eq(-1)
           end
       end
     end

--- a/spec/concurrent/thread_safe/synchronized_delegator_spec.rb
+++ b/spec/concurrent/thread_safe/synchronized_delegator_spec.rb
@@ -16,10 +16,10 @@ module Concurrent
     it 'synchronizes access' do
       t1_continue, t2_continue = false, false
 
-      hash = ::Hash.new do |hash, key|
+      hash = ::Hash.new do |the_hash, key|
         t2_continue = true
-        unless hash.find { |e| e[1] == key.to_s } # just to do something
-          hash[key] = key.to_s
+        unless the_hash.find { |e| e[1] == key.to_s } # just to do something
+          the_hash[key] = key.to_s
           Thread.pass until t1_continue
         end
       end


### PR DESCRIPTION
This PR resolves all Ruby warning output reported in Travis test runs.

- most of this is about being explicit using parentheses
- some of it is about not shadowing names that are used outside blocks
- in one place I removed a `fail` which followed on a `next` in an iteration (that code can not be reached)

---

Oh, in addition to the things mentioned above, these "assigned but unused" warnings were visible in the AppVeyor test run output:

<details>

```
C:/projects/concurrent-ruby/spec/concurrent/agent_spec.rb:78: warning: assigned but unused variable - actual
C:/projects/concurrent-ruby/spec/concurrent/agent_spec.rb:319: warning: assigned but unused variable - expected
C:/projects/concurrent-ruby/spec/concurrent/agent_spec.rb:320: warning: assigned but unused variable - actual
C:/projects/concurrent-ruby/spec/concurrent/agent_spec.rb:961: warning: assigned but unused variable - t
C:/projects/concurrent-ruby/spec/concurrent/agent_spec.rb:1014: warning: assigned but unused variable - t
C:/projects/concurrent-ruby/spec/concurrent/agent_spec.rb:1100: warning: assigned but unused variable - t
C:/projects/concurrent-ruby/spec/concurrent/atomic/reentrant_read_write_lock_spec.rb:340: warning: assigned but unused variable - thread
C:/projects/concurrent-ruby/spec/concurrent/atomic/reentrant_read_write_lock_spec.rb:353: warning: assigned but unused variable - thread
C:/projects/concurrent-ruby/spec/concurrent/atomic/reentrant_read_write_lock_spec.rb:394: warning: assigned but unused variable - thread
C:/projects/concurrent-ruby/spec/concurrent/atomic/reentrant_read_write_lock_spec.rb:440: warning: assigned but unused variable - latch
C:/projects/concurrent-ruby/spec/concurrent/channel/tick_spec.rb:20: warning: assigned but unused variable - t
C:/projects/concurrent-ruby/spec/concurrent/channel/tick_spec.rb:48: warning: assigned but unused variable - present
C:/projects/concurrent-ruby/spec/concurrent/edge/promises_spec.rb:484: warning: assigned but unused variable - channel
C:/projects/concurrent-ruby/spec/concurrent/edge/promises_spec.rb:512: warning: assigned but unused variable - source
C:/projects/concurrent-ruby/spec/concurrent/executor/cached_thread_pool_spec.rb:27: warning: assigned but unused variable - subject
C:/projects/concurrent-ruby/spec/concurrent/executor/cached_thread_pool_spec.rb:31: warning: assigned but unused variable - subject
C:/projects/concurrent-ruby/spec/concurrent/executor/cached_thread_pool_spec.rb:35: warning: assigned but unused variable - subject
C:/projects/concurrent-ruby/spec/concurrent/executor/safe_task_executor_spec.rb:13: warning: assigned but unused variable - value
C:/projects/concurrent-ruby/spec/concurrent/executor/safe_task_executor_spec.rb:13: warning: assigned but unused variable - reason
C:/projects/concurrent-ruby/spec/concurrent/executor/safe_task_executor_spec.rb:18: warning: assigned but unused variable - success
C:/projects/concurrent-ruby/spec/concurrent/executor/safe_task_executor_spec.rb:18: warning: assigned but unused variable - reason
C:/projects/concurrent-ruby/spec/concurrent/executor/safe_task_executor_spec.rb:23: warning: assigned but unused variable - success
C:/projects/concurrent-ruby/spec/concurrent/executor/safe_task_executor_spec.rb:23: warning: assigned but unused variable - value
C:/projects/concurrent-ruby/spec/concurrent/executor/safe_task_executor_spec.rb:46: warning: assigned but unused variable - value
C:/projects/concurrent-ruby/spec/concurrent/executor/safe_task_executor_spec.rb:46: warning: assigned but unused variable - reason
C:/projects/concurrent-ruby/spec/concurrent/executor/safe_task_executor_spec.rb:51: warning: assigned but unused variable - success
C:/projects/concurrent-ruby/spec/concurrent/executor/safe_task_executor_spec.rb:51: warning: assigned but unused variable - reason
C:/projects/concurrent-ruby/spec/concurrent/executor/safe_task_executor_spec.rb:56: warning: assigned but unused variable - success
C:/projects/concurrent-ruby/spec/concurrent/executor/safe_task_executor_spec.rb:56: warning: assigned but unused variable - value
C:/projects/concurrent-ruby/spec/concurrent/maybe_spec.rb:24: warning: assigned but unused variable - maybe
C:/projects/concurrent-ruby/spec/concurrent/mvar_spec.rb:58: warning: assigned but unused variable - putter
C:/projects/concurrent-ruby/spec/concurrent/mvar_spec.rb:118: warning: assigned but unused variable - putter
C:/projects/concurrent-ruby/spec/concurrent/mvar_spec.rb:187: warning: assigned but unused variable - putter
C:/projects/concurrent-ruby/spec/concurrent/mvar_spec.rb:201: warning: assigned but unused variable - modifier
C:/projects/concurrent-ruby/spec/concurrent/promise_spec.rb:413: warning: assigned but unused variable - composite
C:/projects/concurrent-ruby/spec/concurrent/promise_spec.rb:427: warning: assigned but unused variable - composite
C:/projects/concurrent-ruby/spec/concurrent/promise_spec.rb:441: warning: assigned but unused variable - composite
C:/projects/concurrent-ruby/spec/concurrent/promise_spec.rb:468: warning: assigned but unused variable - composite
C:/projects/concurrent-ruby/spec/concurrent/promise_spec.rb:482: warning: assigned but unused variable - composite
C:/projects/concurrent-ruby/spec/concurrent/promise_spec.rb:496: warning: assigned but unused variable - composite
C:/projects/concurrent-ruby/spec/concurrent/scheduled_task_spec.rb:59: warning: assigned but unused variable - now
C:/projects/concurrent-ruby/spec/concurrent/scheduled_task_spec.rb:136: warning: assigned but unused variable - task
C:/projects/concurrent-ruby/spec/concurrent/scheduled_task_spec.rb:148: warning: assigned but unused variable - task
C:/projects/concurrent-ruby/spec/concurrent/timer_task_spec.rb:12: warning: assigned but unused variable - ex

```

</details>