### PR TITLE
CI: Use ruby-2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 
 rvm:
   # start with the latest
-  - 2.4.0
+  - 2.4.1
   - jruby-9.1.8.0
 
   # older versions


### PR DESCRIPTION
This PR updates ruby-2.4.0 to ruby-2.4.1 in CI.