### PR TITLE
Fixes #641 - remove sharp dependency edge -> core

### DIFF
--- a/concurrent-ruby-edge.gemspec
+++ b/concurrent-ruby-edge.gemspec
@@ -28,5 +28,5 @@ Please see http://concurrent-ruby.com for more information.
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'concurrent-ruby', "= #{Concurrent::VERSION}"
+  s.add_runtime_dependency 'concurrent-ruby', "~> #{Concurrent::VERSION}"
 end


### PR DESCRIPTION
Since we follow semantic version of concurrent-ruby, the changes
in '1.0.x' should not influence the current edge version and we
should not have have the sharp dependency there. This makes it easier
for people brave enough to give the edge a try to keep up with
the changes while keeping their projects working with others that are
on the same core version.

My motivation is we're on edge 0.2.3 at the moment, and we are pushed
to concurrent 1.0.5 in packaging distribution. And while transitioning
to 0.3.1 we've hit some issues that will need a fix in concurrent ruby
(patches will follow). However, since the semantic versioning is followed,
there should not be any core change in 1.0.x that would influence previous
edge release and I can confirm that with 0.2.3.

If there is core change that would break compatibility with older edge releases,
at least a minor version of concurrent ruby version should be bumped.