### PR TITLE
Fix Map#each and #each_pair not returning enumerator outside of MRI

### DIFF
--- a/lib/concurrent/collection/map/non_concurrent_map_backend.rb
+++ b/lib/concurrent/collection/map/non_concurrent_map_backend.rb
@@ -95,7 +95,6 @@ module Concurrent
       end
 
       def each_pair
-        return enum_for :each_pair unless block_given?
         dupped_backend.each_pair do |k, v|
           yield k, v
         end

--- a/lib/concurrent/map.rb
+++ b/lib/concurrent/map.rb
@@ -171,6 +171,11 @@ module Concurrent
       each_pair {|k, v| yield v}
     end unless method_defined?(:each_value)
 
+    def each_pair
+      return enum_for :each_pair unless block_given?
+      super
+    end
+
     alias_method :each, :each_pair unless method_defined?(:each)
 
     def key(value)

--- a/spec/concurrent/collection_each_shared.rb
+++ b/spec/concurrent/collection_each_shared.rb
@@ -42,4 +42,20 @@ shared_examples :collection_each do
       end
     end
   end
+
+  context 'when no block is given' do
+    it 'returns an enumerator' do
+      @cache[:a] = 1
+      @cache[:b] = 2
+
+      expect(@cache.send(method)).to be_a Enumerator
+    end
+
+    it 'returns an object which is enumerable' do
+      @cache[:a] = 1
+      @cache[:b] = 2
+
+      expect(@cache.send(method).to_a).to contain_exactly([:a, 1], [:b, 2])
+    end
+  end
 end

--- a/spec/concurrent/map_spec.rb
+++ b/spec/concurrent/map_spec.rb
@@ -255,6 +255,10 @@ module Concurrent
     end
 
     it 'updates dont block reads' do
+      if defined?(Concurrent::Collection::SynchronizedMapBackend) && described_class <= Concurrent::Collection::SynchronizedMapBackend
+        skip("Test does not apply to #{Concurrent::Collection::SynchronizedMapBackend}")
+      end
+
       getters_count = 20
       key_klass     = Concurrent::ThreadSafe::Test::HashCollisionKey
       keys          = [key_klass.new(1, 100), 


### PR DESCRIPTION
When no block was passed to Map#each_pair or its alias Map#each, the NonConcurrentMapBackend would return an enumerator, which would allow enumerable methods to be used on a Map.

But the alternate Map backends, JRubyMapBackend and AtomicReferenceMapBackend did not implement the same logic.

As a fix, let's move the logic down to the shared Map class, so all implementations can use it.

Fixes #643