### PR TITLE
Fix code comment in Concurrent::Array

### DIFF
--- a/lib/concurrent/array.rb
+++ b/lib/concurrent/array.rb
@@ -15,7 +15,7 @@ module Concurrent
     #
     #   @note `a += b` is **not** a **thread-safe** operation on
     #   `Concurrent::Array`. It reads array `a`, then it creates new `Concurrent::Array`
-    #   which is concatenation of `a` and `b`, then it writes the concatenation to `b`.
+    #   which is concatenation of `a` and `b`, then it writes the concatenation to `a`.
     #   The read and write are independent operations they do not form a single atomic
     #   operation therefore when two `+=` operations are executed concurrently updates
     #   may be lost. Use `#concat` instead.


### PR DESCRIPTION
With `a += b`, the result will get assigned to the `a` variable.

Thus fixes a typo introduced in 6faa8a91ae1ac52dfbd97f8e05113359d91fe966 for #570.