### PR TITLE
#inspect should not output negative object IDs.

### DIFF
--- a/lib/concurrent/edge/processing_actor.rb
+++ b/lib/concurrent/edge/processing_actor.rb
@@ -146,7 +146,7 @@ module Concurrent
 
     # @return [String] string representation.
     def inspect
-      format '<#%s:0x%x termination:%s>', self.class, object_id << 1, termination.state
+      format '%s termination:%s>', super[0..-2], termination.state
     end
 
     private

--- a/lib/concurrent/map.rb
+++ b/lib/concurrent/map.rb
@@ -210,12 +210,8 @@ module Concurrent
     undef :freeze
 
     # @!visibility private
-    DEFAULT_OBJ_ID_STR_WIDTH = 0.size == 4 ? 7 : 14 # we want to look "native", 7 for 32-bit, 14 for 64-bit
-    # override default #inspect() method: firstly, we don't want to be spilling our guts (i-vars), secondly, MRI backend's
-    # #inspect() call on its @backend i-var will bump @backend's iter level while possibly yielding GVL
     def inspect
-      id_str = (object_id << 1).to_s(16).rjust(DEFAULT_OBJ_ID_STR_WIDTH, '0')
-      "#<#{self.class.name}:0x#{id_str} entries=#{size} default_proc=#{@default_proc.inspect}>"
+      format '%s entries=%d default_proc=%s>', to_s[0..-2], size.to_s, @default_proc.inspect
     end
 
     private


### PR DESCRIPTION
It might happen that object ID is 'negative', since Ruby tries to avoid Bignums:

https://bugs.ruby-lang.org/issues/13397

However, I am not sure if this does not break any precondition for the fec11e79839ded538f15159933ed2275a1aa28e9 commit which introduced one of the #inspect methods. But I am using Kernel#to_s (as suggested by @nobu) instead of #inspect, so hopefully this is correct ...