### PR TITLE
Travis: jruby-9.1.10.0, jruby-1.7.27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   # start with the latest
   - 2.4.1
-  - jruby-9.1.8.0
+  - jruby-9.1.10.0
 
   # older versions
   - 2.3.4
@@ -13,7 +13,7 @@ rvm:
   - 1.9.3
 
   - jruby-9.0.5.0
-  - jruby-1.7.26
+  - jruby-1.7.27
 
   - ruby-head
   - jruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.