### PR TITLE
Fix error handling in edge promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Current
+
+concurrent-ruby-edge:
+
+* (#659) Edge promises fail during error handling
+
 ## Release v1.0.5, edge v0.3.1 (26 Feb 2017)
 
 concurrent-ruby:

--- a/lib/concurrent/edge/promises.rb
+++ b/lib/concurrent/edge/promises.rb
@@ -982,12 +982,12 @@ module Concurrent
       # @return [Exception]
       def exception(*args)
         raise Concurrent::Error, 'it is not rejected' unless rejected?
-        reason = Array(internal_state.reason).compact
+        reason = Array(internal_state.reason).flatten.compact
         if reason.size > 1
           Concurrent::MultipleErrors.new reason
         else
           ex = reason[0].exception(*args)
-          ex.set_backtrace ex.backtrace + caller
+          ex.set_backtrace Array(ex.backtrace) + caller
           ex
         end
       end

--- a/spec/concurrent/edge/promises_spec.rb
+++ b/spec/concurrent/edge/promises_spec.rb
@@ -220,9 +220,14 @@ describe 'Concurrent::Promises' do
       let(:a_future) { future { raise 'error' } }
 
       it 'raises a concurrent error' do
-        expect { zip(a_future).value! }.to raise_error(StandardError)
+        expect { zip(a_future).value! }.to raise_error(StandardError, 'error')
       end
 
+      context 'when deeply nested' do
+        it 'raises the original error' do
+          expect { zip(zip(a_future)).value! }.to raise_error(StandardError, 'error')
+        end
+      end
     end
   end
 
@@ -239,6 +244,13 @@ describe 'Concurrent::Promises' do
       expect(z2.resolved?).to be_truthy
       expect(z3.resolved?).to be_truthy
       expect(z4.resolved?).to be_truthy
+    end
+  end
+
+  describe '.rejected_future' do
+    it 'raises the correct error when passed an unraised error' do
+      f = rejected_future(StandardError.new('boom'))
+      expect { f.value! }.to raise_error(StandardError, 'boom')
     end
   end
 


### PR DESCRIPTION
* Now properly handles errors raised within deeply nested futures.
* `value!` now properly works with `rejected_future`

Fixes #659