### PR TITLE
Initialize the monitor for new subarrays on Rubinius

### DIFF
--- a/lib/concurrent/thread_safe/util/array_hash_rbx.rb
+++ b/lib/concurrent/thread_safe/util/array_hash_rbx.rb
@@ -18,11 +18,22 @@ module Concurrent
         end
 
         klass.superclass.instance_methods(false).each do |method|
-          klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def #{method}(*args)
-              @_monitor.synchronize { super }
-            end
-          RUBY
+          case method
+          when :new_range, :new_reserved
+            klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+              def #{method}(*args)
+                obj = super
+                obj.send(:_mon_initialize)
+                obj
+              end
+            RUBY
+          else
+            klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+              def #{method}(*args)
+                @_monitor.synchronize { super }
+              end
+            RUBY
+          end
         end
       end
     end

--- a/spec/concurrent/array_spec.rb
+++ b/spec/concurrent/array_spec.rb
@@ -14,5 +14,15 @@ module Concurrent
         end
       end.map(&:join)
     end
+
+    describe '#slice' do
+      # This is mostly relevant on Rubinius and Truffle
+      it 'correctly initializes the monitor' do
+        ary.concat([0, 1, 2, 3, 4, 5, 6, 7, 8])
+
+        sliced = ary.slice!(0..2)
+        expect { sliced[0] }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request should fix #559.

Rubinius uses the public methods `new_range` and `new_reserved` to
create new sub-arrays in methods like `Array#slice`, `Array#[](range)`
or similar.

Here, Rubinius does not call `Array.allocate` to create the new object
resulting in the monitor not being initialized which then causes errors
like

    NoMethodError: undefined method `synchronize' on nil:NilClass.

when calling any methods of the new sub-array. By overwriting the two
methods and explicitly initializing the monitor there, we can ensure
that the monitor is always initialized correctly.