### PR TITLE
Avoid RSpec monkey patching, persist spec results locally, use RSpec v3.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ tmtags
 # junk
 .DS_Store
 .githubtoken
+
+spec/examples.txt

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :development do
 end
 
 group :testing do
-  gem 'rspec', '~> 3.3.0'
+  gem 'rspec', '~> 3.7'
   gem 'timecop', '~> 0.7.4'
 end
 

--- a/spec/concurrent/actor_spec.rb
+++ b/spec/concurrent/actor_spec.rb
@@ -6,7 +6,7 @@ module Concurrent
 
     # FIXME better tests!
 
-    describe 'Concurrent::Actor', edge: true, if: !defined?(JRUBY_VERSION) do
+    RSpec.describe 'Concurrent::Actor', edge: true, if: !defined?(JRUBY_VERSION) do
 
       def terminate_actors(*actors)
         actors.each do |actor|

--- a/spec/concurrent/agent_spec.rb
+++ b/spec/concurrent/agent_spec.rb
@@ -2,7 +2,7 @@ require_relative 'concern/observable_shared'
 
 module Concurrent
 
-  describe Agent do
+  RSpec.describe Agent do
 
     let!(:immediate) { Concurrent::ImmediateExecutor.new }
     let!(:executor) { Concurrent::SingleThreadExecutor.new }

--- a/spec/concurrent/array_spec.rb
+++ b/spec/concurrent/array_spec.rb
@@ -1,5 +1,5 @@
 module Concurrent
-  describe Array do
+  RSpec.describe Array do
     let!(:ary) { described_class.new }
 
     it 'concurrency' do

--- a/spec/concurrent/async_spec.rb
+++ b/spec/concurrent/async_spec.rb
@@ -1,6 +1,6 @@
 module Concurrent
 
-  describe Async do
+  RSpec.describe Async do
 
     let(:async_class) do
       Class.new do

--- a/spec/concurrent/atom_spec.rb
+++ b/spec/concurrent/atom_spec.rb
@@ -2,7 +2,7 @@ require_relative 'concern/observable_shared'
 
 module Concurrent
 
-  describe Atom do
+  RSpec.describe Atom do
 
     context 'construction' do
 

--- a/spec/concurrent/atomic/atomic_boolean_spec.rb
+++ b/spec/concurrent/atomic/atomic_boolean_spec.rb
@@ -1,4 +1,4 @@
-shared_examples :atomic_boolean do
+RSpec.shared_examples :atomic_boolean do
 
   describe 'construction' do
 
@@ -104,7 +104,7 @@ end
 
 module Concurrent
 
-  describe MutexAtomicBoolean do
+  RSpec.describe MutexAtomicBoolean do
 
     it_should_behave_like :atomic_boolean
 
@@ -142,19 +142,19 @@ module Concurrent
 
   if defined? Concurrent::CAtomicBoolean
 
-    describe CAtomicBoolean, ext: true do
+    RSpec.describe CAtomicBoolean, ext: true do
       it_should_behave_like :atomic_boolean
     end
   end
 
   if Concurrent.on_jruby?
 
-    describe JavaAtomicBoolean do
+    RSpec.describe JavaAtomicBoolean do
       it_should_behave_like :atomic_boolean
     end
   end
 
-  describe AtomicBoolean do
+  RSpec.describe AtomicBoolean do
     if RUBY_ENGINE != 'ruby'
       it 'does not load the C extension' do
         expect(defined?(Concurrent::CAtomicBoolean)).to be_falsey

--- a/spec/concurrent/atomic/atomic_fixnum_spec.rb
+++ b/spec/concurrent/atomic/atomic_fixnum_spec.rb
@@ -1,4 +1,4 @@
-shared_examples :atomic_fixnum do
+RSpec.shared_examples :atomic_fixnum do
 
   context 'construction' do
 
@@ -153,7 +153,7 @@ end
 
 module Concurrent
 
-  describe MutexAtomicFixnum do
+  RSpec.describe MutexAtomicFixnum do
 
     it_should_behave_like :atomic_fixnum
 
@@ -202,19 +202,19 @@ module Concurrent
 
   if defined? Concurrent::CAtomicFixnum
 
-    describe CAtomicFixnum, ext: true do
+    RSpec.describe CAtomicFixnum, ext: true do
       it_should_behave_like :atomic_fixnum
     end
   end
 
   if Concurrent.on_jruby?
 
-    describe JavaAtomicFixnum do
+    RSpec.describe JavaAtomicFixnum do
       it_should_behave_like :atomic_fixnum
     end
   end
 
-  describe AtomicFixnum do
+  RSpec.describe AtomicFixnum do
     if RUBY_ENGINE != 'ruby'
       it 'does not load the C extension' do
         expect(defined?(Concurrent::CAtomicFixnum)).to be_falsey

--- a/spec/concurrent/atomic/atomic_markable_reference_spec.rb
+++ b/spec/concurrent/atomic/atomic_markable_reference_spec.rb
@@ -1,4 +1,4 @@
-describe Concurrent::Edge::AtomicMarkableReference do
+RSpec.describe Concurrent::Edge::AtomicMarkableReference do
   subject { described_class.new 1000, true }
 
   describe '.initialize' do

--- a/spec/concurrent/atomic/atomic_reference_spec.rb
+++ b/spec/concurrent/atomic/atomic_reference_spec.rb
@@ -1,4 +1,4 @@
-shared_examples :atomic_reference do
+RSpec.shared_examples :atomic_reference do
 
   specify :test_construct do
     atomic = described_class.new
@@ -145,7 +145,7 @@ end
 
 module Concurrent
 
-  describe AtomicReference do
+  RSpec.describe AtomicReference do
     it_should_behave_like :atomic_reference
 
     describe '#to_s and #inspect' do
@@ -157,25 +157,25 @@ module Concurrent
     end
   end
 
-  describe MutexAtomicReference do
+  RSpec.describe MutexAtomicReference do
     it_should_behave_like :atomic_reference
   end
 
   if defined? Concurrent::CAtomicReference
-    describe CAtomicReference, ext: true do
+    RSpec.describe CAtomicReference, ext: true do
       it_should_behave_like :atomic_reference
     end
   elsif defined? Concurrent::JavaAtomicReference
-    describe JavaAtomicReference do
+    RSpec.describe JavaAtomicReference do
       it_should_behave_like :atomic_reference
     end
   elsif defined? Concurrent::RbxAtomicReference
-    describe RbxAtomicReference do
+    RSpec.describe RbxAtomicReference do
       it_should_behave_like :atomic_reference
     end
   end
 
-  describe AtomicReference do
+  RSpec.describe AtomicReference do
     if Concurrent.on_jruby?
       it 'inherits from JavaAtomicReference' do
         expect(AtomicReference.ancestors).to include(Concurrent::JavaAtomicReference)
@@ -195,40 +195,40 @@ module Concurrent
     end
   end
 
-  describe MutexAtomicReference do
+  RSpec.describe MutexAtomicReference do
     it_should_behave_like :atomic_reference
   end
 
   if defined? Concurrent::CAtomicReference
-    describe CAtomicReference, ext: true do
+    RSpec.describe CAtomicReference, ext: true do
       it_should_behave_like :atomic_reference
     end
   elsif defined? Concurrent::JavaAtomicReference
-    describe JavaAtomicReference do
+    RSpec.describe JavaAtomicReference do
       it_should_behave_like :atomic_reference
     end
   elsif defined? Concurrent::RbxAtomicReference
-    describe RbxAtomicReference do
+    RSpec.describe RbxAtomicReference do
       it_should_behave_like :atomic_reference
     end
   end
 
-  describe AtomicReference do
+  RSpec.describe AtomicReference do
     if Concurrent.on_jruby?
       it 'inherits from JavaAtomicReference' do
-        expect(AtomicReference.ancestors).to include(Concurrent::JavaAtomicReference)
+        expect(described_class.ancestors).to include(Concurrent::JavaAtomicReference)
       end
     elsif Concurrent.allow_c_extensions?
       it 'inherits from CAtomicReference', ext: true do
-        expect(AtomicReference.ancestors).to include(Concurrent::CAtomicReference)
+        expect(described_class.ancestors).to include(Concurrent::CAtomicReference)
       end
     elsif Concurrent.on_rbx?
       it 'inherits from RbxAtomicReference' do
-        expect(AtomicReference.ancestors).to include(Concurrent::RbxAtomicReference)
+        expect(described_class.ancestors).to include(Concurrent::RbxAtomicReference)
       end
     else
       it 'inherits from MutexAtomicReference' do
-        expect(AtomicReference.ancestors).to include(Concurrent::MutexAtomicReference)
+        expect(described_class.ancestors).to include(Concurrent::MutexAtomicReference)
       end
     end
   end

--- a/spec/concurrent/atomic/count_down_latch_spec.rb
+++ b/spec/concurrent/atomic/count_down_latch_spec.rb
@@ -1,4 +1,4 @@
-shared_examples :count_down_latch do
+RSpec.shared_examples :count_down_latch do
 
   let(:latch) { described_class.new(3) }
   let(:zero_count_latch) { described_class.new(0) }
@@ -88,7 +88,7 @@ end
 
 module Concurrent
 
-  describe MutexCountDownLatch do
+  RSpec.describe MutexCountDownLatch do
 
     it_should_behave_like :count_down_latch
 
@@ -150,13 +150,13 @@ module Concurrent
 
   if Concurrent.on_jruby?
 
-    describe JavaCountDownLatch do
+    RSpec.describe JavaCountDownLatch do
 
       it_should_behave_like :count_down_latch
     end
   end
 
-  describe CountDownLatch do
+  RSpec.describe CountDownLatch do
     if Concurrent.on_jruby?
       it 'inherits from JavaCountDownLatch' do
         expect(CountDownLatch.ancestors).to include(JavaCountDownLatch)

--- a/spec/concurrent/atomic/cyclic_barrier_spec.rb
+++ b/spec/concurrent/atomic/cyclic_barrier_spec.rb
@@ -1,6 +1,6 @@
 module Concurrent
 
-  describe CyclicBarrier do
+  RSpec.describe CyclicBarrier do
 
     let(:parties) { 3 }
     let!(:barrier) { described_class.new(3) }

--- a/spec/concurrent/atomic/event_spec.rb
+++ b/spec/concurrent/atomic/event_spec.rb
@@ -1,6 +1,6 @@
 module Concurrent
 
-  describe Event do
+  RSpec.describe Event do
 
     subject{ Event.new }
 

--- a/spec/concurrent/atomic/read_write_lock_spec.rb
+++ b/spec/concurrent/atomic/read_write_lock_spec.rb
@@ -1,6 +1,6 @@
 module Concurrent
 
-  describe ReadWriteLock do
+  RSpec.describe ReadWriteLock do
 
     context '#write_locked?' do
 

--- a/spec/concurrent/atomic/reentrant_read_write_lock_spec.rb
+++ b/spec/concurrent/atomic/reentrant_read_write_lock_spec.rb
@@ -72,7 +72,7 @@ unless Concurrent.on_jruby?
 
     # *******************************************************
 
-    describe ReentrantReadWriteLock do
+    RSpec.describe ReentrantReadWriteLock do
 
       let(:lock) { RRWL.new }
 

--- a/spec/concurrent/atomic/semaphore_spec.rb
+++ b/spec/concurrent/atomic/semaphore_spec.rb
@@ -1,4 +1,4 @@
-shared_examples :semaphore do
+RSpec.shared_examples :semaphore do
   let(:semaphore) { described_class.new(3) }
 
   describe '#initialize' do
@@ -159,17 +159,17 @@ shared_examples :semaphore do
 end
 
 module Concurrent
-  describe MutexSemaphore do
+  RSpec.describe MutexSemaphore do
     it_should_behave_like :semaphore
   end
 
   if Concurrent.on_jruby?
-    describe JavaSemaphore do
+    RSpec.describe JavaSemaphore do
       it_should_behave_like :semaphore
     end
   end
 
-  describe Semaphore do
+  RSpec.describe Semaphore do
     if Concurrent.on_jruby?
       it 'inherits from JavaSemaphore' do
         expect(Semaphore.ancestors).to include(JavaSemaphore)

--- a/spec/concurrent/atomic/thread_local_var_spec.rb
+++ b/spec/concurrent/atomic/thread_local_var_spec.rb
@@ -4,7 +4,7 @@ module Concurrent
 
   require 'concurrent/atomic/thread_local_var'
 
-  describe ThreadLocalVar do
+  RSpec.describe ThreadLocalVar do
 
     context '#initialize' do
 

--- a/spec/concurrent/channel/buffer/base_shared.rb
+++ b/spec/concurrent/channel/buffer/base_shared.rb
@@ -1,4 +1,4 @@
-shared_examples :channel_buffer do
+RSpec.shared_examples :channel_buffer do
 
   specify do
     expect(subject).to respond_to(:blocking?)

--- a/spec/concurrent/channel/buffer/base_spec.rb
+++ b/spec/concurrent/channel/buffer/base_spec.rb
@@ -2,7 +2,7 @@ require_relative 'buffered_shared'
 
 module Concurrent::Channel::Buffer
 
-  describe Base, edge: true do
+  RSpec.describe Base, edge: true do
 
     subject { described_class.new }
 

--- a/spec/concurrent/channel/buffer/buffered_shared.rb
+++ b/spec/concurrent/channel/buffer/buffered_shared.rb
@@ -1,6 +1,6 @@
 require_relative 'base_shared'
 
-shared_examples :channel_buffered_buffer do
+RSpec.shared_examples :channel_buffered_buffer do
 
   it_behaves_like :channel_buffer
 

--- a/spec/concurrent/channel/buffer/buffered_spec.rb
+++ b/spec/concurrent/channel/buffer/buffered_spec.rb
@@ -2,7 +2,7 @@ require_relative 'buffered_shared'
 
 module Concurrent::Channel::Buffer
 
-  describe Buffered, edge: true do
+  RSpec.describe Buffered, edge: true do
 
     let(:capacity) { 10 }
     subject { described_class.new(capacity) }

--- a/spec/concurrent/channel/buffer/dropping_spec.rb
+++ b/spec/concurrent/channel/buffer/dropping_spec.rb
@@ -2,7 +2,7 @@ require_relative 'buffered_shared'
 
 module Concurrent::Channel::Buffer
 
-  describe Dropping, edge: true do
+  RSpec.describe Dropping, edge: true do
 
     subject { described_class.new(10) }
 

--- a/spec/concurrent/channel/buffer/sliding_spec.rb
+++ b/spec/concurrent/channel/buffer/sliding_spec.rb
@@ -2,7 +2,7 @@ require_relative 'buffered_shared'
 
 module Concurrent::Channel::Buffer
 
-  describe Sliding, edge: true do
+  RSpec.describe Sliding, edge: true do
 
     subject { described_class.new(10) }
 

--- a/spec/concurrent/channel/buffer/ticker_spec.rb
+++ b/spec/concurrent/channel/buffer/ticker_spec.rb
@@ -2,7 +2,7 @@ require_relative 'timing_buffer_shared'
 
 module Concurrent::Channel::Buffer
 
-  describe Ticker, edge: true do
+  RSpec.describe Ticker, edge: true do
 
     let(:delay) { 0.1 }
     subject { described_class.new(delay) }

--- a/spec/concurrent/channel/buffer/timer_spec.rb
+++ b/spec/concurrent/channel/buffer/timer_spec.rb
@@ -2,7 +2,7 @@ require_relative 'timing_buffer_shared'
 
 module Concurrent::Channel::Buffer
 
-  describe Timer, edge: true do
+  RSpec.describe Timer, edge: true do
 
     let(:delay) { 0.1 }
     subject { described_class.new(0.1) }

--- a/spec/concurrent/channel/buffer/timing_buffer_shared.rb
+++ b/spec/concurrent/channel/buffer/timing_buffer_shared.rb
@@ -1,6 +1,6 @@
 require_relative 'base_shared'
 
-shared_examples :channel_timing_buffer do
+RSpec.shared_examples :channel_timing_buffer do
 
   specify do
     expect(subject).to be_blocking

--- a/spec/concurrent/channel/buffer/unbuffered_spec.rb
+++ b/spec/concurrent/channel/buffer/unbuffered_spec.rb
@@ -2,7 +2,7 @@ require_relative 'base_shared'
 
 module Concurrent::Channel::Buffer
 
-  describe Unbuffered, edge: true do
+  RSpec.describe Unbuffered, edge: true do
 
     subject { described_class.new }
 

--- a/spec/concurrent/channel/integration_spec.rb
+++ b/spec/concurrent/channel/integration_spec.rb
@@ -1,4 +1,4 @@
-describe 'channel integration tests', edge: true, notravis: true do
+RSpec.describe 'channel integration tests', edge: true, notravis: true do
 
   let!(:examples_root) { File.expand_path(File.join(File.dirname(__FILE__), '../../../examples')) }
 

--- a/spec/concurrent/channel/tick_spec.rb
+++ b/spec/concurrent/channel/tick_spec.rb
@@ -2,7 +2,7 @@ module Concurrent
 
   class Channel
 
-    describe Tick, edge: true do
+    RSpec.describe Tick, edge: true do
 
       it 'initializes to current time when no argument given' do
         allow(Concurrent).to receive(:monotonic_time).and_return(42)

--- a/spec/concurrent/channel_spec.rb
+++ b/spec/concurrent/channel_spec.rb
@@ -1,6 +1,6 @@
 module Concurrent
 
-  describe Channel, edge: true, buggy: true do
+ RSpec.describe Channel, edge: true, buggy: true do
 
     context 'initialization' do
 
@@ -657,5 +657,5 @@ module Concurrent
         Channel.select { |s| s.error {  } }
       end
     end
-  end
+ end
 end

--- a/spec/concurrent/collection/copy_on_notify_observer_set_spec.rb
+++ b/spec/concurrent/collection/copy_on_notify_observer_set_spec.rb
@@ -2,8 +2,7 @@ require_relative 'observer_set_shared'
 
 module Concurrent
   module Collection
-
-    describe CopyOnNotifyObserverSet do
+    RSpec.describe CopyOnNotifyObserverSet do
       it_behaves_like 'an observer set'
     end
   end

--- a/spec/concurrent/collection/copy_on_write_observer_set_spec.rb
+++ b/spec/concurrent/collection/copy_on_write_observer_set_spec.rb
@@ -3,7 +3,7 @@ require_relative 'observer_set_shared'
 module Concurrent
   module Collection
 
-    describe CopyOnWriteObserverSet do
+    RSpec.describe CopyOnWriteObserverSet do
       it_behaves_like 'an observer set'
     end
   end

--- a/spec/concurrent/collection/non_concurrent_priority_queue_spec.rb
+++ b/spec/concurrent/collection/non_concurrent_priority_queue_spec.rb
@@ -1,4 +1,4 @@
-shared_examples :priority_queue do
+RSpec.shared_examples :priority_queue do
 
   subject{ described_class.new }
 
@@ -301,20 +301,20 @@ end
 module Concurrent
   module Collection
 
-    describe RubyNonConcurrentPriorityQueue do
+    RSpec.describe RubyNonConcurrentPriorityQueue do
 
       it_should_behave_like :priority_queue
     end
 
     if Concurrent.on_jruby?
 
-      describe JavaNonConcurrentPriorityQueue do
+      RSpec.describe JavaNonConcurrentPriorityQueue do
 
         it_should_behave_like :priority_queue
       end
     end
 
-    describe NonConcurrentPriorityQueue do
+    RSpec.describe NonConcurrentPriorityQueue do
       if Concurrent.on_jruby?
         it 'inherits from JavaNonConcurrentPriorityQueue' do
           expect(NonConcurrentPriorityQueue.ancestors).to include(JavaNonConcurrentPriorityQueue)

--- a/spec/concurrent/collection/observer_set_shared.rb
+++ b/spec/concurrent/collection/observer_set_shared.rb
@@ -1,4 +1,4 @@
-shared_examples "an observer set" do
+RSpec.shared_examples "an observer set" do
 
   let (:observer_set) { described_class.new }
   let (:observer) { double('observer') }

--- a/spec/concurrent/collection_each_shared.rb
+++ b/spec/concurrent/collection_each_shared.rb
@@ -1,4 +1,4 @@
-shared_examples :collection_each do
+RSpec.shared_examples :collection_each do
 
   it 'common' do
     @cache.send(method) { |k, v| fail }

--- a/spec/concurrent/concern/dereferenceable_shared.rb
+++ b/spec/concurrent/concern/dereferenceable_shared.rb
@@ -1,4 +1,4 @@
-shared_examples :dereferenceable do
+RSpec.shared_examples :dereferenceable do
 
   it 'defaults :dup_on_deref to false' do
     value = 'value'

--- a/spec/concurrent/concern/obligation_shared.rb
+++ b/spec/concurrent/concern/obligation_shared.rb
@@ -1,4 +1,4 @@
-shared_examples :obligation do
+RSpec.shared_examples :obligation do
 
   context '#state' do
 

--- a/spec/concurrent/concern/obligation_spec.rb
+++ b/spec/concurrent/concern/obligation_spec.rb
@@ -1,7 +1,7 @@
 module Concurrent
   module Concern
 
-    describe Obligation do
+    RSpec.describe Obligation do
 
       let (:obligation_class) do
 
@@ -15,7 +15,7 @@ module Concurrent
       let (:obligation) { obligation_class.new }
       let (:event) { double 'event' }
 
-      shared_examples :incomplete do
+      RSpec.shared_examples :incomplete do
 
         it 'should be not completed' do
           expect(obligation).not_to be_complete

--- a/spec/concurrent/concern/observable_shared.rb
+++ b/spec/concurrent/concern/observable_shared.rb
@@ -1,4 +1,4 @@
-shared_examples :observable do
+RSpec.shared_examples :observable do
 
   let(:observer_set) do
     subject.instance_variable_get(:@observers)

--- a/spec/concurrent/concern/observable_spec.rb
+++ b/spec/concurrent/concern/observable_spec.rb
@@ -1,7 +1,7 @@
 module Concurrent
   module Concern
 
-    describe Observable do
+    RSpec.describe Observable do
 
       let (:described_class) do
         Class.new do

--- a/spec/concurrent/configuration_spec.rb
+++ b/spec/concurrent/configuration_spec.rb
@@ -1,6 +1,6 @@
 module Concurrent
 
-  describe 'configuration', notravis: true do
+   RSpec.describe 'configuration', notravis: true do
 
     before(:all) do
       reset_gem_configuration
@@ -35,5 +35,5 @@ module Concurrent
         Concurrent::AtExit.run
       end
     end
-  end
+   end
 end

--- a/spec/concurrent/dataflow_spec.rb
+++ b/spec/concurrent/dataflow_spec.rb
@@ -1,6 +1,6 @@
 module Concurrent
 
-  describe 'dataflow' do
+  RSpec.describe 'dataflow' do
 
     let(:executor) { ImmediateExecutor.new }
     let(:root_executor) { SimpleExecutorService.new }

--- a/spec/concurrent/delay_spec.rb
+++ b/spec/concurrent/delay_spec.rb
@@ -3,7 +3,7 @@ require_relative 'concern/obligation_shared'
 
 module Concurrent
 
-  describe Delay do
+  RSpec.describe Delay do
 
     context 'behavior' do
 

--- a/spec/concurrent/edge/lock_free_linked_set_spec.rb
+++ b/spec/concurrent/edge/lock_free_linked_set_spec.rb
@@ -2,7 +2,7 @@ require 'concurrent'
 require 'concurrent/edge'
 require 'securerandom'
 
-describe Concurrent::Edge::LockFreeLinkedSet, edge: true do
+RSpec.describe Concurrent::Edge::LockFreeLinkedSet, edge: true do
   subject { described_class.new }
 
   describe '.new' do

--- a/spec/concurrent/edge/promises_spec.rb
+++ b/spec/concurrent/edge/promises_spec.rb
@@ -2,7 +2,7 @@ require 'concurrent/edge/promises'
 require 'thread'
 
 
-describe 'Concurrent::Promises' do
+RSpec.describe 'Concurrent::Promises' do
 
   include Concurrent::Promises::FactoryMethods
 
@@ -651,7 +651,7 @@ describe 'Concurrent::Promises' do
   end
 end
 
-describe Concurrent::ProcessingActor do
+RSpec.describe Concurrent::ProcessingActor do
   specify do
     actor = Concurrent::ProcessingActor.act do |the_actor|
       the_actor.receive.then do |message|

--- a/spec/concurrent/exchanger_spec.rb
+++ b/spec/concurrent/exchanger_spec.rb
@@ -1,4 +1,4 @@
-shared_examples 'exchanger method with indefinite timeout' do
+RSpec.shared_examples 'exchanger method with indefinite timeout' do
 
   before(:each) do
     subject # ensure proper initialization
@@ -64,7 +64,7 @@ shared_examples 'exchanger method with indefinite timeout' do
   end
 end
 
-shared_examples 'exchanger method with finite timeout' do
+RSpec.shared_examples 'exchanger method with finite timeout' do
 
   it 'blocks until timeout' do
     duration = Concurrent::TestHelpers.monotonic_interval do
@@ -121,7 +121,7 @@ shared_examples 'exchanger method with finite timeout' do
   end
 end
 
-shared_examples 'exchanger method cross-thread interactions' do
+RSpec.shared_examples 'exchanger method cross-thread interactions' do
 
   it 'when first, waits for a second' do
     first_value = nil
@@ -182,7 +182,7 @@ shared_examples 'exchanger method cross-thread interactions' do
   end
 end
 
-shared_examples :exchanger do
+RSpec.shared_examples :exchanger do
 
   context '#exchange' do
     let!(:method) { :exchange }
@@ -211,7 +211,7 @@ end
 
 module Concurrent
 
-  describe RubyExchanger do
+  RSpec.describe RubyExchanger do
 
     it_behaves_like :exchanger
 
@@ -253,12 +253,12 @@ module Concurrent
 
   if defined? JavaExchanger
 
-    describe JavaExchanger do
+    RSpec.describe JavaExchanger do
       it_behaves_like :exchanger
     end
   end
 
-  describe Exchanger do
+  RSpec.describe Exchanger do
 
     context 'class hierarchy'  do
 

--- a/spec/concurrent/executor/cached_thread_pool_spec.rb
+++ b/spec/concurrent/executor/cached_thread_pool_spec.rb
@@ -2,7 +2,7 @@ require_relative 'thread_pool_shared'
 
 module Concurrent
 
-  describe CachedThreadPool do
+  RSpec.describe CachedThreadPool do
 
     subject do
       described_class.new(fallback_policy: :discard)

--- a/spec/concurrent/executor/executor_service_shared.rb
+++ b/spec/concurrent/executor/executor_service_shared.rb
@@ -1,6 +1,6 @@
 require_relative 'global_thread_pool_shared'
 
-shared_examples :executor_service do
+RSpec.shared_examples :executor_service do
 
   after(:each) do
     subject.kill

--- a/spec/concurrent/executor/fixed_thread_pool_spec.rb
+++ b/spec/concurrent/executor/fixed_thread_pool_spec.rb
@@ -2,7 +2,7 @@ require_relative 'thread_pool_shared'
 
 module Concurrent
 
-  describe FixedThreadPool do
+  RSpec.describe FixedThreadPool do
 
     let!(:num_threads){ 5 }
     subject { described_class.new(num_threads) }

--- a/spec/concurrent/executor/global_thread_pool_shared.rb
+++ b/spec/concurrent/executor/global_thread_pool_shared.rb
@@ -1,4 +1,4 @@
-shared_examples :global_thread_pool do
+RSpec.shared_examples :global_thread_pool do
 
   context '#post' do
 

--- a/spec/concurrent/executor/immediate_executor_spec.rb
+++ b/spec/concurrent/executor/immediate_executor_spec.rb
@@ -2,7 +2,7 @@ require_relative 'executor_service_shared'
 
 module Concurrent
 
-  describe ImmediateExecutor do
+  RSpec.describe ImmediateExecutor do
 
     subject { ImmediateExecutor.new }
 

--- a/spec/concurrent/executor/indirect_immediate_executor_spec.rb
+++ b/spec/concurrent/executor/indirect_immediate_executor_spec.rb
@@ -2,7 +2,7 @@ require_relative 'executor_service_shared'
 
 module Concurrent
 
-  describe IndirectImmediateExecutor do
+  RSpec.describe IndirectImmediateExecutor do
 
     subject { IndirectImmediateExecutor.new }
 

--- a/spec/concurrent/executor/java_single_thread_executor_spec.rb
+++ b/spec/concurrent/executor/java_single_thread_executor_spec.rb
@@ -4,7 +4,7 @@ if Concurrent.on_jruby?
 
   module Concurrent
 
-    describe JavaSingleThreadExecutor, :type=>:jruby do
+    RSpec.describe JavaSingleThreadExecutor, :type=>:jruby do
 
       after(:each) do
         subject.kill

--- a/spec/concurrent/executor/java_thread_pool_executor_spec.rb
+++ b/spec/concurrent/executor/java_thread_pool_executor_spec.rb
@@ -4,7 +4,7 @@ if Concurrent.on_jruby?
 
   module Concurrent
 
-    describe JavaThreadPoolExecutor, :type => :jruby do
+    RSpec.describe JavaThreadPoolExecutor, :type => :jruby do
 
       after(:each) do
         subject.kill

--- a/spec/concurrent/executor/ruby_single_thread_executor_spec.rb
+++ b/spec/concurrent/executor/ruby_single_thread_executor_spec.rb
@@ -2,7 +2,7 @@ require_relative 'executor_service_shared'
 
 module Concurrent
 
-  describe RubySingleThreadExecutor, :type=>:mrirbx do
+  RSpec.describe RubySingleThreadExecutor, :type=>:mrirbx do
 
     after(:each) do
       subject.kill

--- a/spec/concurrent/executor/ruby_thread_pool_executor_spec.rb
+++ b/spec/concurrent/executor/ruby_thread_pool_executor_spec.rb
@@ -2,7 +2,7 @@ require_relative 'thread_pool_executor_shared'
 
 module Concurrent
 
-  describe RubyThreadPoolExecutor, :type=>:mrirbx do
+  RSpec.describe RubyThreadPoolExecutor, :type=>:mrirbx do
 
     after(:each) do
       subject.kill

--- a/spec/concurrent/executor/safe_task_executor_spec.rb
+++ b/spec/concurrent/executor/safe_task_executor_spec.rb
@@ -1,6 +1,6 @@
 module Concurrent
 
-  describe SafeTaskExecutor do
+  RSpec.describe SafeTaskExecutor do
 
     describe '#execute' do
 

--- a/spec/concurrent/executor/serialized_execution_spec.rb
+++ b/spec/concurrent/executor/serialized_execution_spec.rb
@@ -2,7 +2,7 @@ require_relative 'executor_service_shared'
 
 module Concurrent
 
-  describe SerializedExecutionDelegator do
+  RSpec.describe SerializedExecutionDelegator do
 
     subject { SerializedExecutionDelegator.new(ImmediateExecutor.new) }
 

--- a/spec/concurrent/executor/simple_executor_service_spec.rb
+++ b/spec/concurrent/executor/simple_executor_service_spec.rb
@@ -2,7 +2,7 @@ require_relative 'executor_service_shared'
 
 module Concurrent
 
-  describe SimpleExecutorService do
+  RSpec.describe SimpleExecutorService do
 
     subject { SimpleExecutorService.new }
 

--- a/spec/concurrent/executor/thread_pool_class_cast_spec.rb
+++ b/spec/concurrent/executor/thread_pool_class_cast_spec.rb
@@ -1,6 +1,6 @@
 module Concurrent
 
-  describe SingleThreadExecutor do
+  RSpec.describe SingleThreadExecutor do
     if Concurrent.on_jruby?
       it 'inherits from JavaSingleThreadExecutor' do
         expect(SingleThreadExecutor.ancestors).to include(JavaSingleThreadExecutor)
@@ -12,7 +12,7 @@ module Concurrent
     end
   end
 
-  describe ThreadPoolExecutor do
+  RSpec.describe ThreadPoolExecutor do
     if Concurrent.on_jruby?
       it 'inherits from JavaThreadPoolExecutor' do
         expect(ThreadPoolExecutor.ancestors).to include(JavaThreadPoolExecutor)

--- a/spec/concurrent/executor/thread_pool_executor_shared.rb
+++ b/spec/concurrent/executor/thread_pool_executor_shared.rb
@@ -1,6 +1,6 @@
 require_relative 'thread_pool_shared'
 
-shared_examples :thread_pool_executor do
+RSpec.shared_examples :thread_pool_executor do
 
   after(:each) do
     subject.kill

--- a/spec/concurrent/executor/thread_pool_shared.rb
+++ b/spec/concurrent/executor/thread_pool_shared.rb
@@ -1,6 +1,6 @@
 require_relative 'executor_service_shared'
 
-shared_examples :thread_pool do
+RSpec.shared_examples :thread_pool do
 
   after(:each) do
     subject.kill

--- a/spec/concurrent/executor/timer_set_spec.rb
+++ b/spec/concurrent/executor/timer_set_spec.rb
@@ -2,7 +2,7 @@ require 'timecop'
 
 module Concurrent
 
-  describe TimerSet do
+  RSpec.describe TimerSet do
 
     let(:executor){ Concurrent::ImmediateExecutor.new }
     subject{ TimerSet.new(executor: executor) }

--- a/spec/concurrent/future_spec.rb
+++ b/spec/concurrent/future_spec.rb
@@ -3,7 +3,7 @@ require_relative 'thread_arguments_shared'
 
 module Concurrent
 
-  describe Future do
+  RSpec.describe Future do
 
     let!(:value) { 10 }
     let(:executor) { SimpleExecutorService.new }

--- a/spec/concurrent/hash_spec.rb
+++ b/spec/concurrent/hash_spec.rb
@@ -1,5 +1,5 @@
 module Concurrent
-  describe Hash do 
+  RSpec.describe Hash do
     let!(:hsh) { described_class.new }
 
     it 'concurrency' do

--- a/spec/concurrent/immutable_struct_spec.rb
+++ b/spec/concurrent/immutable_struct_spec.rb
@@ -1,7 +1,7 @@
 require_relative 'struct_shared'
 
 module Concurrent
-  describe ImmutableStruct do
+  RSpec.describe ImmutableStruct do
     it_should_behave_like :struct
     it_should_behave_like :mergeable_struct
   end

--- a/spec/concurrent/ivar_shared.rb
+++ b/spec/concurrent/ivar_shared.rb
@@ -2,7 +2,7 @@ require_relative 'concern/dereferenceable_shared'
 require_relative 'concern/obligation_shared'
 require_relative 'concern/observable_shared'
 
-shared_examples :ivar do
+RSpec.shared_examples :ivar do
 
   it_should_behave_like :obligation
   it_should_behave_like :dereferenceable

--- a/spec/concurrent/ivar_spec.rb
+++ b/spec/concurrent/ivar_spec.rb
@@ -2,7 +2,7 @@ require_relative 'ivar_shared'
 
 module Concurrent
 
-  describe IVar do
+  RSpec.describe IVar do
 
     let!(:value) { 10 }
 

--- a/spec/concurrent/lazy_register_spec.rb
+++ b/spec/concurrent/lazy_register_spec.rb
@@ -1,5 +1,5 @@
 module Concurrent
-  describe LazyRegister do
+  RSpec.describe LazyRegister do
 
     pending
 

--- a/spec/concurrent/map_spec.rb
+++ b/spec/concurrent/map_spec.rb
@@ -2,7 +2,7 @@ require_relative 'collection_each_shared'
 Thread.abort_on_exception = true
 
 module Concurrent
-  describe Map do
+  RSpec.describe Map do
     before(:each) do
       @cache = described_class.new
     end

--- a/spec/concurrent/maybe_spec.rb
+++ b/spec/concurrent/maybe_spec.rb
@@ -1,6 +1,6 @@
 module Concurrent
 
-  describe Maybe do
+  RSpec.describe Maybe do
 
     context 'construction' do
 

--- a/spec/concurrent/mutable_struct_spec.rb
+++ b/spec/concurrent/mutable_struct_spec.rb
@@ -1,7 +1,7 @@
 require_relative 'struct_shared'
 
 module Concurrent
-  describe MutableStruct do
+  RSpec.describe MutableStruct do
 
     it_should_behave_like :struct
     it_should_behave_like :mergeable_struct

--- a/spec/concurrent/mvar_spec.rb
+++ b/spec/concurrent/mvar_spec.rb
@@ -2,7 +2,7 @@ require_relative 'concern/dereferenceable_shared'
 
 module Concurrent
 
-  describe MVar do
+  RSpec.describe MVar do
 
     context 'behavior' do
 

--- a/spec/concurrent/options_spec.rb
+++ b/spec/concurrent/options_spec.rb
@@ -1,6 +1,6 @@
 module Concurrent
 
-  describe Options do
+  RSpec.describe Options do
 
     context '.executor_from_options' do
 

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -3,7 +3,7 @@ require_relative 'thread_arguments_shared'
 
 module Concurrent
 
-  describe Promise do
+  RSpec.describe Promise do
 
     let!(:value) { 10 }
     let(:executor) { SimpleExecutorService.new }
@@ -418,7 +418,7 @@ module Concurrent
           latch.wait(1)
 
           expect(counter.value).to eq 1
-          end
+        end
 
         it 'executes the #then condition when no promises are given' do
           counter = Concurrent::AtomicFixnum.new(0)
@@ -432,7 +432,7 @@ module Concurrent
           latch.wait(1)
 
           expect(counter.value).to eq 1
-          end
+        end
 
         it 'executes the #rescue handler if even one component fails' do
           counter = Concurrent::AtomicFixnum.new(0)
@@ -446,7 +446,7 @@ module Concurrent
           latch.wait(1)
 
           expect(counter.value).to eq(-1)
-          end
+        end
       end
 
       describe '.any?' do
@@ -473,7 +473,7 @@ module Concurrent
           latch.wait(1)
 
           expect(counter.value).to eq 1
-          end
+        end
 
         it 'executes the #then condition when no promises are given' do
           counter = Concurrent::AtomicFixnum.new(0)
@@ -487,7 +487,7 @@ module Concurrent
           latch.wait(1)
 
           expect(counter.value).to eq 1
-          end
+        end
 
         it 'executes the #rescue handler if all componenst fail' do
           counter = Concurrent::AtomicFixnum.new(0)
@@ -501,7 +501,7 @@ module Concurrent
           latch.wait(1)
 
           expect(counter.value).to eq(-1)
-          end
+        end
       end
     end
 

--- a/spec/concurrent/scheduled_task_spec.rb
+++ b/spec/concurrent/scheduled_task_spec.rb
@@ -5,7 +5,7 @@ require_relative 'concern/observable_shared'
 
 module Concurrent
 
-  describe ScheduledTask do
+  RSpec.describe ScheduledTask do
 
     context 'behavior' do
 

--- a/spec/concurrent/settable_struct_spec.rb
+++ b/spec/concurrent/settable_struct_spec.rb
@@ -1,7 +1,7 @@
 require_relative 'struct_shared'
 
 module Concurrent
-  describe SettableStruct do
+  RSpec.describe SettableStruct do
 
     it_should_behave_like :struct
     it_should_behave_like :mergeable_struct

--- a/spec/concurrent/struct_shared.rb
+++ b/spec/concurrent/struct_shared.rb
@@ -1,4 +1,4 @@
-shared_examples :struct do
+RSpec.shared_examples :struct do
 
   context 'definition' do
 
@@ -430,7 +430,7 @@ shared_examples :struct do
   end
 end
 
-shared_examples :mergeable_struct do
+RSpec.shared_examples :mergeable_struct do
 
   let(:this){ described_class.new(:foo, :bar, :baz).new('foo', nil, nil)}
   let(:other){ {baz: 42} }

--- a/spec/concurrent/synchronization_spec.rb
+++ b/spec/concurrent/synchronization_spec.rb
@@ -2,9 +2,9 @@ require 'timeout'
 
 module Concurrent
 
-  describe Synchronization do
+  RSpec.describe Synchronization do
 
-    shared_examples :attr_volatile do
+    RSpec.shared_examples :attr_volatile do
 
       specify 'older writes are always visible' do
         # store              = BClass.new
@@ -33,7 +33,7 @@ module Concurrent
       end
     end
 
-    describe Synchronization::Object do
+   describe Synchronization::Object do
       class AAClass < Synchronization::Object
       end
 
@@ -78,9 +78,9 @@ module Concurrent
 
       let(:store) { VolatileFieldClass.new }
       it_should_behave_like :attr_volatile
-    end
+   end
 
-    describe Synchronization::LockableObject do
+   describe Synchronization::LockableObject do
 
       class BClass < Synchronization::LockableObject
         safe_initialization!
@@ -183,7 +183,7 @@ module Concurrent
 
       let(:store) { BClass.new }
       it_should_behave_like :attr_volatile
-    end
+   end
 
     describe 'Concurrent::Synchronization::Volatile module' do
       class BareClass

--- a/spec/concurrent/thread_arguments_shared.rb
+++ b/spec/concurrent/thread_arguments_shared.rb
@@ -1,5 +1,5 @@
 
-shared_examples :thread_arguments do
+RSpec.shared_examples :thread_arguments do
 
   it 'passes an empty array when opts is not given' do
     future = get_ivar_from_no_args

--- a/spec/concurrent/thread_safe/map_loops_spec.rb
+++ b/spec/concurrent/thread_safe/map_loops_spec.rb
@@ -2,7 +2,7 @@ Thread.abort_on_exception = true
 
 module Concurrent
 
-  describe 'MapTorture', stress: true, notravis: true do
+  RSpec.describe 'MapTorture', stress: true, notravis: true do
     THREAD_COUNT  = 40
     KEY_COUNT     = (((2**13) - 2) * 0.75).to_i # get close to the doubling cliff
     LOW_KEY_COUNT = (((2**8 ) - 2) * 0.75).to_i # get close to the doubling cliff

--- a/spec/concurrent/thread_safe/synchronized_delegator_spec.rb
+++ b/spec/concurrent/thread_safe/synchronized_delegator_spec.rb
@@ -1,7 +1,7 @@
 require 'concurrent/thread_safe/synchronized_delegator.rb'
 
 module Concurrent
-  describe SynchronizedDelegator do 
+  RSpec.describe SynchronizedDelegator do
     it 'wraps array' do
       array = ::Array.new
       sync_array = described_class.new(array)

--- a/spec/concurrent/timer_task_spec.rb
+++ b/spec/concurrent/timer_task_spec.rb
@@ -3,7 +3,7 @@ require_relative 'concern/observable_shared'
 
 module Concurrent
 
-  describe TimerTask do
+  RSpec.describe TimerTask do
 
     context :dereferenceable do
 

--- a/spec/concurrent/tvar_spec.rb
+++ b/spec/concurrent/tvar_spec.rb
@@ -1,6 +1,6 @@
 module Concurrent
 
-  describe TVar do
+  RSpec.describe TVar do
 
     context '#initialize' do
 
@@ -32,7 +32,7 @@ module Concurrent
 
   end
 
-  describe '#atomically' do
+  RSpec.describe '#atomically' do
 
     it 'raises an exception when no block given' do
       expect { Concurrent::atomically }.to raise_error(ArgumentError)
@@ -185,7 +185,7 @@ module Concurrent
 
   end
 
-  describe '#abort_transaction' do
+  RSpec.describe '#abort_transaction' do
 
     it 'raises an exception outside an #atomically block' do
       expect { Concurrent::abort_transaction }.to raise_error(Concurrent::Transaction::AbortError)
@@ -193,7 +193,7 @@ module Concurrent
 
   end
 
-  describe '#leave_transaction' do
+  RSpec.describe '#leave_transaction' do
 
     it 'raises an exception outside an #atomically block' do
       expect { Concurrent::leave_transaction }.to raise_error(Concurrent::Transaction::LeaveError)

--- a/spec/concurrent/utility/processor_count_spec.rb
+++ b/spec/concurrent/utility/processor_count_spec.rb
@@ -1,6 +1,6 @@
 module Concurrent
 
-  describe '#processor_count' do
+  RSpec.describe '#processor_count' do
 
     it 'retuns a positive integer' do
       expect(Concurrent::processor_count).to be_a Integer
@@ -8,7 +8,7 @@ module Concurrent
     end
   end
 
-  describe '#physical_processor_count' do
+  RSpec.describe '#physical_processor_count' do
 
     it 'retuns a positive integer' do
       expect(Concurrent::physical_processor_count).to be_a Integer

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,4 +31,6 @@ RSpec.configure do |config|
   #config.raise_errors_for_deprecations!
   config.filter_run_excluding stress: true
   config.order = 'random'
+  config.disable_monkey_patching!
+  config.example_status_persistence_file_path = 'spec/examples.txt'
 end


### PR DESCRIPTION
This PR is mechanical configuration of RSpec.

  - update RSpec to [3.7](http://rspec.info/blog/2017/10/rspec-3-7-has-been-released/)
  - configure the [disable monkey patching](http://rspec.info/documentation/3.7/rspec-core/RSpec/Core/Configuration.html#disable_monkey_patching%21-instance_method) feature
  - configure [`--only-failures` feature](https://relishapp.com/rspec/rspec-core/docs/command-line/only-failures)