### PR TITLE
Avoid RSpec warnings about raise_error

### DIFF
--- a/spec/concurrent/actor_spec.rb
+++ b/spec/concurrent/actor_spec.rb
@@ -33,7 +33,7 @@ module Concurrent
       end
 
       it 'forbids Immediate executor' do
-        expect { Utils::AdHoc.spawn! name: 'test', executor: ImmediateExecutor.new }.to raise_error
+        expect { Utils::AdHoc.spawn! name: 'test', executor: ImmediateExecutor.new }.to raise_error(ArgumentError)
       end
 
       describe 'spawning' do

--- a/spec/concurrent/atomic/atomic_fixnum_spec.rb
+++ b/spec/concurrent/atomic/atomic_fixnum_spec.rb
@@ -11,9 +11,9 @@ shared_examples :atomic_fixnum do
     end
 
     it 'raises an exception if the initial value is not a Fixnum' do
-      expect {
-        described_class.new(10.01)
-      }.to raise_error(ArgumentError)
+      expect { described_class.new(10.01) }.to(raise_error { |error|
+        expect(error.class).to be(ArgumentError).or(be(TypeError))
+      })
     end
   end
 
@@ -46,7 +46,9 @@ shared_examples :atomic_fixnum do
       atomic = described_class.new(0)
       expect {
         atomic.value = 'foo'
-      }.to raise_error(ArgumentError)
+      }.to(raise_error { |error|
+        expect(error.class).to be(ArgumentError).or(be(TypeError))
+      })
     end
   end
 

--- a/spec/concurrent/atomic/atomic_fixnum_spec.rb
+++ b/spec/concurrent/atomic/atomic_fixnum_spec.rb
@@ -13,7 +13,7 @@ shared_examples :atomic_fixnum do
     it 'raises an exception if the initial value is not a Fixnum' do
       expect {
         described_class.new(10.01)
-      }.to raise_error
+      }.to raise_error(ArgumentError)
     end
   end
 
@@ -46,7 +46,7 @@ shared_examples :atomic_fixnum do
       atomic = described_class.new(0)
       expect {
         atomic.value = 'foo'
-      }.to raise_error
+      }.to raise_error(ArgumentError)
     end
   end
 
@@ -161,14 +161,14 @@ module Concurrent
 
       it 'raises an exception if the initial value is too big' do
         expect {
-          described_class.new(described_class::MAX_VALUE + 1)
-        }.to raise_error
+          described_class.new(Utility::NativeInteger::MAX_VALUE + 1)
+        }.to raise_error(RangeError)
       end
 
       it 'raises an exception if the initial value is too small' do
         expect {
-          described_class.new(described_class::MIN_VALUE - 1)
-        }.to raise_error
+          described_class.new(Utility::NativeInteger::MIN_VALUE - 1)
+        }.to raise_error(RangeError)
       end
     end
 

--- a/spec/concurrent/channel_spec.rb
+++ b/spec/concurrent/channel_spec.rb
@@ -595,7 +595,7 @@ module Concurrent
         it 'raises an exception when no block is given' do
           expect {
             Channel.go_loop
-          }.to raise_error(ArgumentError)
+          }.to raise_error(RejectedExecutionError)
         end
 
         it 'loops until the block returns false' do

--- a/spec/concurrent/dataflow_spec.rb
+++ b/spec/concurrent/dataflow_spec.rb
@@ -71,17 +71,16 @@ module Concurrent
       expect { Concurrent::dataflow_with(root_executor, nil, Future.execute{0}) }.to raise_error(ArgumentError)
     end
 
-    it 'doesn\'t raises exceptions from dependencies, unless called with !' do
+    it 'doesn\'t raise exceptions from dependencies, unless called with !' do
+      d1 = Concurrent::dataflow { raise 'd1 error' }
+      d2 = Concurrent::dataflow { raise 'd2 error' }
+      f = Concurrent::dataflow!(d1, d2) { |d1v, d2v| [d1v, d2v] }
+      expect { f.value! }.to raise_error(RuntimeError).with_message('d1 error')
 
-      d1 = Concurrent::dataflow(){raise}
-      d2 = Concurrent::dataflow(){raise}
-      f = Concurrent::dataflow!(d1, d2){|d1v, d2v| [d1v,d2v]}
-      expect{f.value!}.to raise_error
-
-      d1 = Concurrent::dataflow(){raise}
-      d2 = Concurrent::dataflow(){raise}
-      f = Concurrent::dataflow(d1, d2){|d1v, d2v| [d1v,d2v]}
-      expect{f.value!}.to_not raise_error
+      d1 = Concurrent::dataflow { raise 'd1 error' }
+      d2 = Concurrent::dataflow { raise 'd2 error' }
+      f = Concurrent::dataflow(d1, d2) { |d1v, d2v| [d1v, d2v] }
+      expect { f.value! }.to_not raise_error
     end
 
     it 'returns a Future' do

--- a/spec/concurrent/executor/fixed_thread_pool_spec.rb
+++ b/spec/concurrent/executor/fixed_thread_pool_spec.rb
@@ -208,7 +208,7 @@ module Concurrent
             end
           end
           latch.wait(1)
-        }.to raise_error
+        }.to raise_error(RejectedExecutionError)
       end
 
       # On discard, we'd expect no error, but also not all five results

--- a/spec/concurrent/timer_task_spec.rb
+++ b/spec/concurrent/timer_task_spec.rb
@@ -129,7 +129,7 @@ module Concurrent
       it 'raises an exception if no block given' do
         expect {
           Concurrent::TimerTask.execute
-        }.to raise_error
+        }.to raise_error(ArgumentError)
       end
 
       specify '#execution_interval is writeable' do


### PR DESCRIPTION
This PR **avoids an RSpec warning** about `raise_error` without any arguments.

While fixing this output warning, I found that one test which had been using a bare expectation to `raise_error` actually masked a NameError, just like the RSpec warning said it could.