### PR TITLE
Fix misspellings

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -56,7 +56,7 @@ There are a few very strong guidelines which we follow when adding features. Sub
 
 * **No downstream dependencies:** Concurrent Ruby is a foundational library used by major projects like [Rails](http://rubyonrails.org/). Our downstream dependencies become everyone's dependencies. Because we cannot guarantee that downstream projects meet our development standards, it's best for everyone if we simply aviod dependencies.
 * **Do not monkey patch Ruby:** Changing Ruby for our convenience affects every gem in every project that uses Concurrent Ruby. Monkey patching Ruby may change the behavior of other libraries in unexpected ways and destabilize projects which depend on us.
-* **Do not polute the global namespace:** Putting all our code within the `Concurrent` module guarantees that there will be no namespace collisions with other gems or the projects which depend on us.
+* **Do not pollute the global namespace:** Putting all our code within the `Concurrent` module guarantees that there will be no namespace collisions with other gems or the projects which depend on us.
 * **No global varaibles:** Global state should be kept to an absolute minimum. When it's necessary, add it to the global gem configuration.
 * **Minimize per-object configuration:** Ruby makes programmers happy. One of Ruby's charms is its simplicity. Concurrent Ruby aims to mirror this simplicity. Advanced configuration options are encouraged when they provide value, but every abstraction should have reasonable defaults that meet the needs of most users.
 * **Provide explicit behavior and guarantees:** Our APIs should be concrete and clearly define what they do (and don't do). Users of Concurrent Ruby should never be surprised by unexpected behavior or be given guarantees we cannot keep.

--- a/doc/actor/messaging.in.rb
+++ b/doc/actor/messaging.in.rb
@@ -25,8 +25,8 @@ end #
 
 calculator = Calculator.spawn('calculator')
 addition = calculator.ask Add[1, 2]
-substraction = calculator.ask Subtract[1, 0.5]
-results = (addition & substraction)
+subtraction = calculator.ask Subtract[1, 0.5]
+results = (addition & subtraction)
 results.value!
 
 calculator.ask! :terminate!

--- a/doc/actor/messaging.out.rb
+++ b/doc/actor/messaging.out.rb
@@ -27,9 +27,9 @@ calculator = Calculator.spawn('calculator')
     # => #<Concurrent::Actor::Reference:0x7fbedba52d90 /calculator (Calculator)>
 addition = calculator.ask Add[1, 2]
     # => <#Concurrent::Promises::Future:0x7fbedc05f7b0 pending>
-substraction = calculator.ask Subtract[1, 0.5]
+subtraction = calculator.ask Subtract[1, 0.5]
     # => <#Concurrent::Promises::Future:0x7fbedd891388 pending>
-results = (addition & substraction)
+results = (addition & subtraction)
     # => <#Concurrent::Promises::Future:0x7fbedc04eeb0 pending>
 results.value!                                     # => [3, 0.5]
 

--- a/examples/graph_atomic_bench.rb
+++ b/examples/graph_atomic_bench.rb
@@ -23,13 +23,13 @@ result = File.open("results_#{conf[:lock]}_#{conf[:vary]}.csv", "w")
 
 
 if conf[:vary] == "threads"
-  # Vary the number of concurrent threads that update the value.
+  # Varies the number of concurrent threads that update the value.
   #
   # There is a total count of 1mio updates that is distributed
   # between the number of threads.
   #
-  # A pair number of threads is used so that even add and odd substract 1.
-  # This avoid creating instances for Bignum since the number should
+  # A doubled number of threads is used so that even adds 1 and odd subtracts 1.
+  # This avoids creating instances for Bignum since the number should
   # stay in the Fixnum range.
   #
   (1..100).each do |i|

--- a/lib/concurrent/async.rb
+++ b/lib/concurrent/async.rb
@@ -159,7 +159,7 @@ module Concurrent
   #
   # To get the state *at the current* time, irrespective of an enqueued method
   # calls, a reader method must be called directly. This is inherently unsafe
-  # unless the instance variable is itself thread-safe, preferrably using one
+  # unless the instance variable is itself thread-safe, preferably using one
   # of the thread-safe classes within this library. Because the thread-safe
   # classes within this library are internally-locking or non-locking, they can
   # be safely used from within asynchronous methods without causing deadlocks.
@@ -188,7 +188,7 @@ module Concurrent
   #
   # Class variables should be avoided. Class variables represent shared state.
   # Shared state is anathema to concurrency. Should there be a need to share
-  # state using class variables they *must* be thread-safe, preferrably
+  # state using class variables they *must* be thread-safe, preferably
   # using the thread-safe classes within this library. When updating class
   # variables, never assign a new value/object to the variable itself. Assignment
   # is not thread-safe in Ruby. Instead, use the thread-safe update functions

--- a/lib/concurrent/atomic/event.rb
+++ b/lib/concurrent/atomic/event.rb
@@ -32,7 +32,7 @@ module Concurrent
   #   # prints:
   #   # t2 calling set
   #   # t1 is waiting
-  #   # event ocurred
+  #   # event occurred
   class Event < Synchronization::LockableObject
 
     # Creates a new `Event` in the unset state. Threads calling `#wait` on the

--- a/lib/concurrent/collection/map/atomic_reference_map_backend.rb
+++ b/lib/concurrent/collection/map/atomic_reference_map_backend.rb
@@ -289,7 +289,7 @@ module Concurrent
                   end
                 end
               elsif cas_hash(my_hash, my_hash | WAITING)
-                force_aquire_lock(table, i)
+                force_acquire_lock(table, i)
                 break
               end
             end
@@ -330,7 +330,7 @@ module Concurrent
         end
 
         private
-        def force_aquire_lock(table, i)
+        def force_acquire_lock(table, i)
           cheap_synchronize do
             if equal?(table.volatile_get(i)) && (hash & WAITING) == WAITING
               cheap_wait

--- a/lib/concurrent/collection/map/non_concurrent_map_backend.rb
+++ b/lib/concurrent/collection/map/non_concurrent_map_backend.rb
@@ -10,7 +10,7 @@ module Concurrent
 
       # WARNING: all public methods of the class must operate on the @backend
       # directly without calling each other. This is important because of the
-      # SynchronizedMapBackend which uses a non-reentrant mutex for perfomance
+      # SynchronizedMapBackend which uses a non-reentrant mutex for performance
       # reasons.
       def initialize(options = nil)
         @backend = {}

--- a/lib/concurrent/exchanger.rb
+++ b/lib/concurrent/exchanger.rb
@@ -218,7 +218,7 @@ module Concurrent
       # node's initial value. It never changes. It's what the fulfiller returns on
       # success. The occupier's hole is where the fulfiller put its item. It's the
       # item that the occupier returns on success. The latch is used for synchronization.
-      # Becuase a thread may act as either an occupier or fulfiller (or possibly
+      # Because a thread may act as either an occupier or fulfiller (or possibly
       # both in periods of high contention) every thread creates a node when
       # the exchange method is first called.
       #

--- a/lib/concurrent/mutable_struct.rb
+++ b/lib/concurrent/mutable_struct.rb
@@ -108,7 +108,7 @@ module Concurrent
     #
     #   Attribute Reference
     #
-    #   @param [Symbol, String, Integer] member the string or symbol name of the memeber
+    #   @param [Symbol, String, Integer] member the string or symbol name of the member
     #     for which to obtain the value or the member's index
     #
     #   @return [Object] the value of the given struct member or the member at the given index.
@@ -175,7 +175,7 @@ module Concurrent
     #
     #   Sets the value of the given struct member or the member at the given index.
     #
-    #   @param [Symbol, String, Integer] member the string or symbol name of the memeber
+    #   @param [Symbol, String, Integer] member the string or symbol name of the member
     #     for which to obtain the value or the member's index
     #
     #   @return [Object] the value of the given struct member or the member at the given index.

--- a/lib/concurrent/utility/at_exit.rb
+++ b/lib/concurrent/utility/at_exit.rb
@@ -16,7 +16,7 @@ module Concurrent
     end
 
     # Add a handler to be run at `Kernel#at_exit`
-    # @param [Object] handler_id optionally provide an id, if allready present, handler is replaced
+    # @param [Object] handler_id optionally provide an id, if already present, handler is replaced
     # @yield the handler
     # @return id of the handler
     def add(handler_id = nil, &handler)

--- a/spec/concurrent/executor/executor_service_shared.rb
+++ b/spec/concurrent/executor/executor_service_shared.rb
@@ -167,7 +167,7 @@ shared_examples :executor_service do
       expect(subject.wait_for_termination(1)).to be_truthy
     end
 
-    it 'returns true when shutdown sucessfully completes before timeout' do
+    it 'returns true when shutdown successfully completes before timeout' do
       subject.post{ sleep(0.5) }
       sleep(0.1)
       subject.shutdown

--- a/spec/concurrent/map_spec.rb
+++ b/spec/concurrent/map_spec.rb
@@ -793,7 +793,7 @@ module Concurrent
       expect(1).to eq new_cache.size
     end
 
-    it 'marshal dump doesnt work with default proc' do
+    it 'marshal dump does not work with default proc' do
       expect { Marshal.dump(Concurrent::Map.new {}) }.to raise_error(TypeError)
     end
 


### PR DESCRIPTION
This PR fixes tiny misspellings throughout the codebase.

I found them using the [`misspellings`](https://pypi.python.org/pypi/misspellings) tool.