### PR TITLE
Add 'truffleruby' to engine test per docs

### DIFF
--- a/lib/concurrent/utility/engine.rb
+++ b/lib/concurrent/utility/engine.rb
@@ -20,7 +20,7 @@ module Concurrent
       end
 
       def on_truffle?
-        ruby_engine == 'jruby+truffle'
+        ruby_engine == 'truffleruby'
       end
 
       def on_windows?


### PR DESCRIPTION
TruffleRuby now uses 'truffleruby' as the RUBY_ENGINE constant. Without this patch, the if statements fall through and no classes in the Concurrent namespace are created.

https://github.com/oracle/truffleruby/blob/40a1377/doc/user/compatibility.md#identification