### PR TITLE
Fix missing monkeypatch of #new on TruffleRuby

### DIFF
--- a/lib/concurrent/array.rb
+++ b/lib/concurrent/array.rb
@@ -40,7 +40,7 @@ module Concurrent
     class Array < ::Array
     end
 
-    ThreadSafe::Util.make_synchronized_on_rbx Array
+    ThreadSafe::Util.make_synchronized_on_rbx Concurrent::Array
   end
 end
 

--- a/lib/concurrent/hash.rb
+++ b/lib/concurrent/hash.rb
@@ -31,6 +31,6 @@ module Concurrent
     class Hash < ::Hash
     end
 
-    ThreadSafe::Util.make_synchronized_on_rbx Hash
+    ThreadSafe::Util.make_synchronized_on_rbx Concurrent::Hash
   end
 end

--- a/lib/concurrent/thread_safe/util/array_hash_rbx.rb
+++ b/lib/concurrent/thread_safe/util/array_hash_rbx.rb
@@ -10,7 +10,7 @@ module Concurrent
             @_monitor = Monitor.new unless @_monitor # avoid double initialisation
           end
 
-          def self.allocate
+          def self.new
             obj = super
             obj.send(:_mon_initialize)
             obj


### PR DESCRIPTION
After applying the patch [here](https://github.com/ruby-concurrency/concurrent-ruby/pull/696/files), a basic usage of Concurrent::Array
```rb
[1] pry(main)> require 'concurrent'
=> true
[2] pry(main)> ary = Concurrent::Array.new
=> #<Concurrent::Array:0x283a>
[3] pry(main)> ary << 1
NoMethodError: undefined method `synchronize' for nil:NilClass
from /opt/graalvm-0.31/jre/languages/ruby/lib/ruby/gems/2.3.0/gems/concurrent-ruby-1.0.5/lib/concurrent/thread_safe/util/array_hash_rbx.rb:23:in `method_missing'
```
fails.

Investigation into the code shows that this is because the `@_monitor` variable is not being assigned on [allocate](https://github.com/ruby-concurrency/concurrent-ruby/blob/91170af/lib/concurrent/thread_safe/util/array_hash_rbx.rb#L13), which is correct:
```rb
[4] pry(main)> ary.instance_variables
=> []
```

In order to get the code to work, this needs to be added at line 17 in [lib/concurrent/thread_safe/util/array_hash_rbx.rb](https://github.com/ruby-concurrency/concurrent-ruby/blob/91170af/lib/concurrent/thread_safe/util/array_hash_rbx.rb):

```rb

          def self.new
            obj = super
            obj.send(:_mon_initialize)
            obj
          end
```

After this, it works.

```rb
[1] pry(main)> require 'concurrent'
=> true
[2] pry(main)> ary = Concurrent::Array.new
=> []
[3] pry(main)> ary << 1
=> [1]
```