### PR TITLE
Travis: Add Ruby 2.5.0; promote RUBYOPT=-w to global env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 
 rvm:
   # start with the latest
+  - 2.5.0
   - 2.4.3
   - jruby-9.1.15.0
 
@@ -44,8 +45,9 @@ matrix:
 env:
   global:
     - JAVA_OPTS=-Xmx1024m
+    - RUBYOPT=-w
 
 before_install:
   - "echo JAVA_OPTS: $JAVA_OPTS"
 
-script: RUBYOPT=-w bundle exec rake ci
+script: bundle exec rake ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: ruby
 rvm:
   # start with the latest
   - 2.5.0
-  - 2.4.3
   - jruby-9.1.15.0
 
   # older versions
+  - 2.4.3
   - 2.3.4
   - 2.2.7
   - 2.1.9


### PR DESCRIPTION
This PR prepends Ruby 2.5.0 to CI matrix.

Demotes 2.4 to "older versions" section.