### PR TITLE
Update documentation for monotonic_time

### DIFF
--- a/lib/concurrent/utility/monotonic_time.rb
+++ b/lib/concurrent/utility/monotonic_time.rb
@@ -46,8 +46,8 @@ module Concurrent
   #
   #   Returns the current time a tracked by the application monotonic clock.
   #
-  #   @return [Float] The current monotonic time when `since` not given else
-  #     the elapsed monotonic time between `since` and the current time
+  #   @return [Float] The current monotonic time since some unspecified
+  #     starting point
   #
   #   @!macro monotonic_clock_warning
   def monotonic_time


### PR DESCRIPTION
The `since` argument was removed in https://github.com/ruby-concurrency/concurrent-ruby/commit/7551cc687957a4f6969d9835e31b900ce431a75b but the documentation still referred to it. The language here was patterned after the comment above `GLOBAL_MONOTONIC_CLOCK`.