### PR TITLE
Ensure memory barriers when setting/getting atomic boolean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,10 @@ tmtags
 .DS_Store
 .githubtoken
 
+# Rspec created files
+spec/examples.txt
+
+# Compiled files
+lib/concurrent_ruby_ext.jar
 lib/concurrent/extension.so
+lib/concurrent/extension.bundle

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ tmtags
 .DS_Store
 .githubtoken
 
-spec/examples.txt
+lib/concurrent/extension.so

--- a/ext/concurrent/atomic_boolean.c
+++ b/ext/concurrent/atomic_boolean.c
@@ -21,13 +21,12 @@ VALUE method_atomic_boolean_initialize(int argc, VALUE* argv, VALUE self) {
 }
 
 VALUE method_atomic_boolean_value(VALUE self) {
-  return (VALUE) DATA_PTR(self);
+  return(ir_get(self));
 }
 
 VALUE method_atomic_boolean_value_set(VALUE self, VALUE value) {
   VALUE new_value = TRUTHY(value);
-  DATA_PTR(self) = (void *) new_value;
-  return(new_value);
+  return(ir_set(self, new_value));
 }
 
 VALUE method_atomic_boolean_true_question(VALUE self) {


### PR DESCRIPTION
After reviewing the atomic boolean code a bit, I noticed the atomic boolean was not using memory barriers when getting and setting values. This PR ensures that those memory barriers are used in all places.