### PR TITLE
add concurrent-ruby.rb to make Bundler.require() work

### DIFF
--- a/lib/concurrent-ruby.rb
+++ b/lib/concurrent-ruby.rb
@@ -1,0 +1,1 @@
+require_relative "./concurrent"


### PR DESCRIPTION
`Bundler.require()`, or Rails, loads gems by the name listed in Gemfile, but cuncurrent-ruby does not provide "concurrent-ruby.rb", so the Rails application engineers have to declare it as `gem "concurrent-ruby", require: "concurrent"` even if the app does not depend on concurrent-ruby directly.

This PR add the file "concurrent-ruby.rb" as an alias to "concurrent.rb" to make `Bundle.require()` work.

Can you review it please?