### PR TITLE
Travis: jruby-9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   # start with the latest
   - 2.5.1
-  - jruby-9.1.17.0
+  - jruby-9.2.0.0
 
   # older versions
   - 2.4.4


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/05/24/jruby-9-2-0-0.html

# Test failures

- [ ] name "needs to be constant" – `NameErrors` caught and re-raised