### PR TITLE
Fixnum dep. warning in CountDownLatch

### DIFF
--- a/lib/concurrent/atomic/java_count_down_latch.rb
+++ b/lib/concurrent/atomic/java_count_down_latch.rb
@@ -9,7 +9,7 @@ if Concurrent.on_jruby?
 
       # @!macro count_down_latch_method_initialize
       def initialize(count = 1)
-        unless count.is_a?(Fixnum) && count >= 0
+        unless count.is_a?(Integer) && count >= 0
           raise ArgumentError.new('count must be in integer greater than or equal zero')
         end
         @latch = java.util.concurrent.CountDownLatch.new(count)


### PR DESCRIPTION
Resolves this warning:

gems/jruby-9.2.0.0/gems/concurrent-ruby-1.0.5-java/lib/concurrent/atomic/java_count_down_latch.rb:12: warning: constant ::Fixnum is deprecated