### PR TITLE
Update travis CI adding latest Ruby and JRuby versions; fix failure on JRuby 9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ rvm:
   - jruby-1.7.27
 
   - ruby-head
+  - ruby-2.6.0-preview2
   - jruby-head
 
   - rbx-3
@@ -42,6 +43,7 @@ matrix:
     - rvm: jruby-head
     - rvm: 1.9.3
     - rvm: rbx-3
+    - rvm: ruby-2.6.0-preview2
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   # start with the latest
   - 2.5.1
-  - jruby-9.1.17.0
+  - jruby-9.2.0.0
 
   # older versions
   - 2.4.4
@@ -13,6 +13,7 @@ rvm:
   - 2.0.0
   - 1.9.3
 
+  - jruby-9.1.17.0
   - jruby-9.0.5.0
   - jruby-1.7.27
 

--- a/lib/concurrent/synchronization/abstract_struct.rb
+++ b/lib/concurrent/synchronization/abstract_struct.rb
@@ -117,7 +117,7 @@ module Concurrent
 
       # @!visibility private
       def pr_underscore(clazz)
-        word = clazz.to_s
+        word = clazz.to_s.dup # dup string to workaround JRuby 9.2.0.0 bug https://github.com/jruby/jruby/issues/5229
         word.gsub!(/::/, '/')
         word.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
         word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')


### PR DESCRIPTION
Hello there, here's a small addition!

I also took a stab at adding truffleruby which is now available in rvm master but was not able to force an rvm upgrade before Travis attempts to install the target Ruby, so I guess we'll need to wait until the next rvm release.

Note: Tests seem to be broken with JRuby 9.2.0.0, I'll submit a separate issue for that.