### PR TITLE
Fix Array/Hash/Set construction broken on TruffleRuby

### DIFF
--- a/lib/concurrent/thread_safe/util/array_hash_rbx.rb
+++ b/lib/concurrent/thread_safe/util/array_hash_rbx.rb
@@ -41,7 +41,14 @@ module Concurrent
           else
             klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
               def #{method}(*args)
-                @_monitor.synchronize { super }
+                monitor = @_monitor
+
+                unless monitor
+                  raise("BUG: Internal monitor was not properly initialized. Please report this to the "\
+                    "concurrent-ruby developers.")
+                end
+
+                monitor.synchronize { super }
               end
             RUBY
           end

--- a/lib/concurrent/thread_safe/util/array_hash_rbx.rb
+++ b/lib/concurrent/thread_safe/util/array_hash_rbx.rb
@@ -10,10 +10,9 @@ module Concurrent
             @_monitor = Monitor.new unless @_monitor # avoid double initialisation
           end
 
-          def self.new
-            obj = super
-            obj.send(:_mon_initialize)
-            obj
+          def initialize(*args)
+            _mon_initialize
+            super
           end
         end
 

--- a/lib/concurrent/thread_safe/util/array_hash_rbx.rb
+++ b/lib/concurrent/thread_safe/util/array_hash_rbx.rb
@@ -14,6 +14,12 @@ module Concurrent
             _mon_initialize
             super
           end
+
+          def self.allocate
+            obj = super
+            obj.send(:_mon_initialize)
+            obj
+          end
         end
 
         klass.superclass.instance_methods(false).each do |method|

--- a/lib/concurrent/thread_safe/util/array_hash_rbx.rb
+++ b/lib/concurrent/thread_safe/util/array_hash_rbx.rb
@@ -20,6 +20,12 @@ module Concurrent
             obj.send(:_mon_initialize)
             obj
           end
+
+          def self.[](*args)
+            obj = super
+            obj.send(:_mon_initialize)
+            obj
+          end
         end
 
         klass.superclass.instance_methods(false).each do |method|

--- a/spec/concurrent/array_spec.rb
+++ b/spec/concurrent/array_spec.rb
@@ -2,6 +2,69 @@ module Concurrent
   RSpec.describe Array do
     let!(:ary) { described_class.new }
 
+    describe '.[]' do
+      describe 'when initializing with no arguments' do
+        it do
+          expect(described_class[]).to be_empty
+        end
+      end
+
+      describe 'when initializing with arguments' do
+        it 'creates an array with the given objects' do
+          expect(described_class[:hello, :world]).to eq [:hello, :world]
+        end
+      end
+    end
+
+    describe '.new' do
+      describe 'when initializing with no arguments' do
+        it do
+          expect(described_class.new).to be_empty
+        end
+      end
+
+      describe 'when initializing with a size argument' do
+        let(:size) { 3 }
+
+        it 'creates an array with size elements set to nil' do
+          expect(described_class.new(size)).to eq [nil, nil, nil]
+        end
+
+        describe 'when initializing with a default value argument' do
+          let(:default_value) { :ruby }
+
+          it 'creates an array with size elements set to the default value' do
+            expect(described_class.new(size, default_value)).to eq [:ruby, :ruby, :ruby]
+          end
+        end
+
+        describe 'when initializing with a block argument' do
+          let(:block_argument) { proc { |index| :"ruby#{index}" } }
+
+          it 'creates an array with size elements set to the default value' do
+            expect(described_class.new(size, &block_argument)).to eq [:ruby0, :ruby1, :ruby2]
+          end
+        end
+      end
+
+      describe 'when initializing with another array as an argument' do
+        let(:other_array) { [:hello, :world] }
+        let(:fake_other_array) { double('Fake array', to_ary: other_array) }
+
+        it 'creates a new array' do
+          expect(described_class.new(other_array)).to_not be other_array
+        end
+
+        it 'creates an array with the same contents as the other array' do
+          expect(described_class.new(other_array)).to eq [:hello, :world]
+        end
+
+        it 'creates an array with the results of calling #to_ary on the other array' do
+          expect(described_class.new(fake_other_array)).to eq [:hello, :world]
+        end
+      end
+    end
+
     context 'concurrency' do
       it do
         (1..Concurrent::ThreadSafe::Test::THREADS).map do |i|

--- a/spec/concurrent/array_spec.rb
+++ b/spec/concurrent/array_spec.rb
@@ -2,18 +2,20 @@ module Concurrent
   RSpec.describe Array do
     let!(:ary) { described_class.new }
 
-    it 'concurrency' do
-      (1..Concurrent::ThreadSafe::Test::THREADS).map do |i|
-        in_thread do
-          1000.times do
-            ary << i
-            ary.each { |x| x * 2 }
-            ary.shift
-            ary.last
+    context 'concurrency' do
+      it do
+        (1..Concurrent::ThreadSafe::Test::THREADS).map do |i|
+          in_thread do
+            1000.times do
+              ary << i
+              ary.each { |x| x * 2 }
+              ary.shift
+              ary.last
+            end
           end
-        end
-      end.map(&:join)
-      expect(ary).to be_empty
+        end.map(&:join)
+        expect(ary).to be_empty
+      end
     end
 
     describe '#slice' do

--- a/spec/concurrent/array_spec.rb
+++ b/spec/concurrent/array_spec.rb
@@ -68,7 +68,7 @@ module Concurrent
     context 'concurrency' do
       it do
         (1..Concurrent::ThreadSafe::Test::THREADS).map do |i|
-          in_thread do
+          in_thread(ary) do |ary|
             1000.times do
               ary << i
               ary.each { |x| x * 2 }
@@ -82,7 +82,7 @@ module Concurrent
     end
 
     describe '#slice' do
-      # This is mostly relevant on Rubinius and Truffle
+      # This is mostly relevant on Rubinius and TruffleRuby
       it 'correctly initializes the monitor' do
         ary.concat([0, 1, 2, 3, 4, 5, 6, 7, 8])
 

--- a/spec/concurrent/hash_spec.rb
+++ b/spec/concurrent/hash_spec.rb
@@ -2,17 +2,19 @@ module Concurrent
   RSpec.describe Hash do
     let!(:hsh) { described_class.new }
 
-    it 'concurrency' do
-      (1..Concurrent::ThreadSafe::Test::THREADS).map do |i|
-        in_thread do
-          1000.times do |j|
-            hsh[i * 1000 + j] = i
-            expect(hsh[i * 1000 + j]).to eq(i)
-            expect(hsh.delete(i * 1000 + j)).to eq(i)
+    context 'concurrency' do
+      it do
+        (1..Concurrent::ThreadSafe::Test::THREADS).map do |i|
+          in_thread do
+            1000.times do |j|
+              hsh[i * 1000 + j] = i
+              expect(hsh[i * 1000 + j]).to eq(i)
+              expect(hsh.delete(i * 1000 + j)).to eq(i)
+            end
           end
-        end
-      end.map(&:join)
-      expect(hsh).to be_empty
+        end.map(&:join)
+        expect(hsh).to be_empty
+      end
     end
   end
 end

--- a/spec/concurrent/hash_spec.rb
+++ b/spec/concurrent/hash_spec.rb
@@ -2,6 +2,90 @@ module Concurrent
   RSpec.describe Hash do
     let!(:hsh) { described_class.new }
 
+    describe '.[]' do
+      describe 'when initializing with no arguments' do
+        it do
+          expect(described_class[]).to be_empty
+        end
+      end
+
+      describe 'when initializing with an even number of arguments' do
+        it 'creates a hash using the odd position arguments as keys and even position arguments as values' do
+          expect(described_class[:hello, 'hello', :world, 'world']).to eq(hello: 'hello', world: 'world')
+        end
+      end
+
+      describe 'when initializing with an array of pairs' do
+        let(:array_of_pairs) { [[:hello, 'hello'], [:world, 'world']] }
+
+        it 'creates a hash using each pair as a (key, value) pair' do
+          expect(described_class[array_of_pairs]).to eq(hello: 'hello', world: 'world')
+        end
+      end
+
+      describe 'when initializing with another hash as an argument' do
+        let(:other_hash) { {hello: 'hello', world: 'world'} }
+        let(:fake_other_hash) { double('Fake hash', to_hash: other_hash) }
+
+        it 'creates a new hash' do
+          expect(described_class[other_hash]).to_not be other_hash
+        end
+
+        it 'creates a hash with the same contents as the other hash' do
+          expect(described_class[other_hash]).to eq(hello: 'hello', world: 'world')
+        end
+
+        it 'creates a hash with the results of calling #to_hash on the other array' do
+          expect(described_class[fake_other_hash]).to eq(hello: 'hello', world: 'world')
+        end
+      end
+    end
+
+    describe '.new' do
+      describe 'when initializing with no arguments' do
+        it do
+          expect(described_class.new).to be_empty
+        end
+      end
+
+      describe 'when initialized with a default object' do
+        let(:default_object) { :ruby }
+
+        it 'uses the default object for non-existing keys' do
+          hash = described_class.new(default_object)
+
+          expect(hash[:hello]).to be :ruby
+          expect(hash[:world]).to be :ruby
+        end
+      end
+
+      describe 'when initialized with a block' do
+        it 'calls the block for non-existing keys' do
+          block_calls = []
+
+          hash = described_class.new do |hash_instance, key|
+            block_calls << [hash_instance, key]
+          end
+
+          hash[:hello]
+          hash[:world]
+
+          expect(block_calls).to eq [[hash, :hello], [hash, :world]]
+        end
+
+        it 'returns the results of calling the block for non-existing key' do
+          block_results = ['hello', 'world']
+
+          hash = described_class.new do
+            block_results.shift
+          end
+
+          expect(hash[:hello]).to eq 'hello'
+          expect(hash[:world]).to eq 'world'
+        end
+      end
+    end
+
     context 'concurrency' do
       it do
         (1..Concurrent::ThreadSafe::Test::THREADS).map do |i|

--- a/spec/concurrent/set_spec.rb
+++ b/spec/concurrent/set_spec.rb
@@ -3,18 +3,20 @@ module Concurrent
   RSpec.describe Set do
     let!(:set) { described_class.new }
 
-    it 'concurrency' do
-      (1..Concurrent::ThreadSafe::Test::THREADS).map do |i|
-        in_thread do
-          1000.times do
-            v = i
-            set << v
-            expect(set).not_to be_empty
-            set.delete(v)
+    context 'concurrency' do
+      it do
+        (1..Concurrent::ThreadSafe::Test::THREADS).map do |i|
+          in_thread do
+            1000.times do
+              v = i
+              set << v
+              expect(set).not_to be_empty
+              set.delete(v)
+            end
           end
-        end
-      end.map(&:join)
-      expect(set).to be_empty
+        end.map(&:join)
+        expect(set).to be_empty
+      end
     end
   end
 end

--- a/spec/concurrent/set_spec.rb
+++ b/spec/concurrent/set_spec.rb
@@ -3,6 +3,44 @@ module Concurrent
   RSpec.describe Set do
     let!(:set) { described_class.new }
 
+    describe '.[]' do
+      describe 'when initializing with no arguments' do
+        it do
+          expect(described_class[]).to be_empty
+        end
+      end
+
+      describe 'when initializing with arguments' do
+        it 'creates a set with the given objects' do
+          expect(described_class[:hello, :world]).to eq ::Set.new([:hello, :world])
+        end
+      end
+    end
+
+    describe '.new' do
+      describe 'when initializing with no arguments' do
+        it do
+          expect(described_class.new).to be_empty
+        end
+      end
+
+      describe 'when initializing with an enumerable object' do
+        let(:enumerable_object) { [:hello, :world] }
+
+        it 'creates a set with the contents of the enumerable object' do
+          expect(described_class.new(enumerable_object)).to eq ::Set.new([:hello, :world])
+        end
+
+        describe 'when initializing with a block argument' do
+          let(:block_argument) { proc { |value| :"#{value}_ruby" } }
+
+          it 'creates a set with the contents of the enumerable object' do
+            expect(described_class.new(enumerable_object, &block_argument)).to eq ::Set.new([:hello_ruby, :world_ruby])
+          end
+        end
+      end
+    end
+
     context 'concurrency' do
       it do
         (1..Concurrent::ThreadSafe::Test::THREADS).map do |i|


### PR DESCRIPTION
While trying to get the [Persistent-💎](https://gitlab.com/ivoanjo/persistent-dmnd) gem specs to work on TruffleRuby, I discovered that Array/Hash/Set construction was broken in several cases.

I've added test cases for the expected behaviors of Array/Hash/Set `.[]` and `.new`, and fixed a number of broken test cases on TruffleRuby (all specs are green on MRI).

There is one remaining spec in `array_spec.rb` that was already broken and that is non-trivial to fix, so I'll create an issue for it.