### PR TITLE
Support keyword arguments on all Concurrent Struct classes

### DIFF
--- a/lib/concurrent/immutable_struct.rb
+++ b/lib/concurrent/immutable_struct.rb
@@ -71,20 +71,20 @@ module Concurrent
     end
 
     # @!macro struct_new
-    def self.new(*args, &block)
+    def self.new(*args, **kw_args, &block)
       clazz_name = nil
       if args.length == 0
         raise ArgumentError.new('wrong number of arguments (0 for 1+)')
       elsif args.length > 0 && args.first.is_a?(String)
         clazz_name = args.shift
       end
-      FACTORY.define_struct(clazz_name, args, &block)
+      FACTORY.define_struct(clazz_name, args, kw_args, &block)
     end
 
     FACTORY = Class.new(Synchronization::LockableObject) do
-      def define_struct(name, members, &block)
+      def define_struct(name, members, kw_args, &block)
         synchronize do
-          Synchronization::AbstractStruct.define_struct_class(ImmutableStruct, Synchronization::Object, name, members, &block)
+          Synchronization::AbstractStruct.define_struct_class(ImmutableStruct, Synchronization::Object, name, members, kw_args, &block)
         end
       end
     end.new

--- a/lib/concurrent/mutable_struct.rb
+++ b/lib/concurrent/mutable_struct.rb
@@ -197,20 +197,20 @@ module Concurrent
     end
 
     # @!macro struct_new
-    def self.new(*args, &block)
+    def self.new(*args, **kw_args, &block)
       clazz_name = nil
       if args.length == 0
         raise ArgumentError.new('wrong number of arguments (0 for 1+)')
       elsif args.length > 0 && args.first.is_a?(String)
         clazz_name = args.shift
       end
-      FACTORY.define_struct(clazz_name, args, &block)
+      FACTORY.define_struct(clazz_name, args, kw_args, &block)
     end
 
     FACTORY = Class.new(Synchronization::LockableObject) do
-      def define_struct(name, members, &block)
+      def define_struct(name, members, kw_args, &block)
         synchronize do
-          clazz = Synchronization::AbstractStruct.define_struct_class(MutableStruct, Synchronization::LockableObject, name, members, &block)
+          clazz = Synchronization::AbstractStruct.define_struct_class(MutableStruct, Synchronization::LockableObject, name, members, kw_args, &block)
           members.each_with_index do |member, index|
             clazz.send :remove_method, member
             clazz.send(:define_method, member) do

--- a/lib/concurrent/settable_struct.rb
+++ b/lib/concurrent/settable_struct.rb
@@ -92,20 +92,20 @@ module Concurrent
     end
 
     # @!macro struct_new
-    def self.new(*args, &block)
+    def self.new(*args, **kw_args, &block)
       clazz_name = nil
       if args.length == 0
         raise ArgumentError.new('wrong number of arguments (0 for 1+)')
       elsif args.length > 0 && args.first.is_a?(String)
         clazz_name = args.shift
       end
-      FACTORY.define_struct(clazz_name, args, &block)
+      FACTORY.define_struct(clazz_name, args, kw_args, &block)
     end
 
     FACTORY = Class.new(Synchronization::LockableObject) do
-      def define_struct(name, members, &block)
+      def define_struct(name, members, kw_args, &block)
         synchronize do
-          clazz = Synchronization::AbstractStruct.define_struct_class(SettableStruct, Synchronization::LockableObject, name, members, &block)
+          clazz = Synchronization::AbstractStruct.define_struct_class(SettableStruct, Synchronization::LockableObject, name, members, kw_args, &block)
           members.each_with_index do |member, index|
             clazz.send :remove_method, member if clazz.instance_methods.include? member
             clazz.send(:define_method, member) do

--- a/spec/concurrent/struct_shared.rb
+++ b/spec/concurrent/struct_shared.rb
@@ -101,8 +101,13 @@ RSpec.shared_examples :struct do
 
     it 'raises an exception when extra members are given' do
       classes.each do |clazz|
-        extra_values = values << 'forty two'
-        expect{ clazz.new(*extra_values) }.to raise_error(ArgumentError)
+        if clazz::KEYWORD_INIT
+          extra_values = kw_values.merge({FortyTwo: 'forty two'})
+          expect{ clazz.new(**extra_values) }.to raise_error(ArgumentError)
+        else  
+          extra_values = values << 'forty two'
+          expect{ clazz.new(*extra_values) }.to raise_error(ArgumentError)
+        end
       end
     end
   end


### PR DESCRIPTION
📓 Original issue: https://github.com/ruby-concurrency/concurrent-ruby/issues/694

⚠️ Putting this up for initial comments, there's still one tiny bit to address which I will complete shortly...

(fix #694)