### PR TITLE
Documentation fix for AtomicFixnum#compare_and_set

### DIFF
--- a/lib/concurrent/atomic/atomic_fixnum.rb
+++ b/lib/concurrent/atomic/atomic_fixnum.rb
@@ -52,7 +52,7 @@ module Concurrent
   #   @param [Fixnum] expect the expected value
   #   @param [Fixnum] update the new value
   #
-  #   @return [Fixnum] true if the value was updated else false
+  #   @return [Boolean] true if the value was updated else false
 
   # @!macro [new] atomic_fixnum_method_update
   #


### PR DESCRIPTION
The return value is a Boolean, not a number.