### PR TITLE
TimerTask: kill the execution when it exceeds the task timeout 

### DIFF
--- a/lib/concurrent/timer_task.rb
+++ b/lib/concurrent/timer_task.rb
@@ -280,7 +280,8 @@ module Concurrent
       self.execution_interval = opts[:execution] || opts[:execution_interval] || EXECUTION_INTERVAL
       self.timeout_interval = opts[:timeout] || opts[:timeout_interval] || TIMEOUT_INTERVAL
       @run_now = opts[:now] || opts[:run_now]
-      @executor = Concurrent::SafeTaskExecutor.new(task)
+      @task = task
+      @executor = Concurrent::RubySingleThreadExecutor.new()
       @running = Concurrent::AtomicBoolean.new(false)
       @value = nil
 
@@ -309,13 +310,26 @@ module Concurrent
     def execute_task(completion)
       return nil unless @running.true?
       ScheduledTask.execute(timeout_interval, args: [completion], &method(:timeout_task))
-      _success, value, reason = @executor.execute(self)
+      @thread_completed = Concurrent::Event.new
+      @value = @reason = nil
+
+      @executor.post do
+        begin
+          @value = @task.call(self)
+        rescue Exception => ex
+          @reason = ex
+        ensure
+          @thread_completed.set
+        end
+      end
+
+      @thread_completed.wait
+
       if completion.try?
-        self.value = value
         schedule_next_task
         time = Time.now
         observers.notify_observers do
-          [time, self.value, reason]
+          [time, self.value, @reason]
         end
       end
       nil
@@ -325,6 +339,10 @@ module Concurrent
     def timeout_task(completion)
       return unless @running.true?
       if completion.try?
+        @executor.kill
+        @executor.wait_for_termination
+        @executor = Concurrent::RubySingleThreadExecutor.new()
+        @thread_completed.set
         self.value = value
         schedule_next_task
         observers.notify_observers(Time.now, nil, Concurrent::TimeoutError.new)

--- a/lib/concurrent/timer_task.rb
+++ b/lib/concurrent/timer_task.rb
@@ -281,7 +281,7 @@ module Concurrent
       self.timeout_interval = opts[:timeout] || opts[:timeout_interval] || TIMEOUT_INTERVAL
       @run_now = opts[:now] || opts[:run_now]
       @task = task
-      @executor = Concurrent::RubySingleThreadExecutor.new()
+      @executor = Concurrent::RubySingleThreadExecutor.new
       @running = Concurrent::AtomicBoolean.new(false)
       @value = nil
 
@@ -341,7 +341,7 @@ module Concurrent
       if completion.try?
         @executor.kill
         @executor.wait_for_termination
-        @executor = Concurrent::RubySingleThreadExecutor.new()
+        @executor = Concurrent::RubySingleThreadExecutor.new
         @thread_completed.set
         self.value = value
         schedule_next_task

--- a/lib/concurrent/timer_task.rb
+++ b/lib/concurrent/timer_task.rb
@@ -4,7 +4,7 @@ require 'concurrent/concern/observable'
 require 'concurrent/atomic/atomic_boolean'
 require 'concurrent/executor/executor_service'
 require 'concurrent/executor/ruby_executor_service'
-require 'concurrent/executor/safe_task_executor'
+require 'concurrent/executor/ruby_single_thread_executor'
 require 'concurrent/scheduled_task'
 
 module Concurrent


### PR DESCRIPTION
Before this commit when a TimerTask task exceeded the timeout the job kept running. That could lead to thread leaking. Related to #639

This PR changes the TimerTask executor to be a SingleThreadExecutor. So whenever the task doesn't finish in time, the execution thread is killed (in this case the pool is killed).

The spec ensures that this new behavior is working correctly. It fails on master. If the main job isn't killed after the timeout, the `latch.wait(2)` would raise, since the timer task sleeps for 5 seconds.

If you want to see the leak by yourself take a look on this https://github.com/rubemz/concurrent-ruby-leak, which is pretty much a copy from https://github.com/ruby-concurrency/concurrent-ruby/issues/639#issuecomment-309792568. @shun0309 thanks for that code.

Closes #639