### PR TITLE
fix a typo on the timer_task_spec

### DIFF
--- a/spec/concurrent/timer_task_spec.rb
+++ b/spec/concurrent/timer_task_spec.rb
@@ -205,11 +205,12 @@ module Concurrent
         latch    = CountDownLatch.new(1)
         subject  = TimerTask.new(execution_interval: 1, run_now: true) do |task|
           expected = task
-          latch.sount_down
+          latch.count_down
         end
         subject.execute
         latch.wait(1)
         expect(expected).to eq subject
+        expect(latch.count).to eq(0)
         subject.kill
       end
     end


### PR DESCRIPTION
sount_down -> count_down. As the spec didn't check whether the
execution raised or not this typo went unnoticed.