### PR TITLE
fix typo in concurrent/set for rbx and truffleruby

### DIFF
--- a/lib/concurrent/set.rb
+++ b/lib/concurrent/set.rb
@@ -41,7 +41,7 @@ module Concurrent
 
                         class RbxSet < ::Set
                         end
-                        ThreadSafe::Util.make_synchronized_on_rbx Concurrent::Set
+                        ThreadSafe::Util.make_synchronized_on_rbx RbxSet
                         RbxSet
 
                       when Concurrent.on_truffleruby?
@@ -50,7 +50,7 @@ module Concurrent
                         class TruffleRubySet < ::Set
                         end
 
-                        ThreadSafe::Util.make_synchronized_on_truffleruby Concurrent::Set
+                        ThreadSafe::Util.make_synchronized_on_truffleruby TruffleRubySet
                         TruffleRubySet
 
                       else


### PR DESCRIPTION
It seems to be a typo. Rake was failing on truffleruby 1.0.0.rc6 and Rails 5.2.1 without this fix
```
rake aborted!
NameError: uninitialized constant Concurrent::Set
Did you mean?  Set
/Users/pachkovsky/.rvm/gems/truffleruby-1.0.0-rc6/gems/concurrent-ruby-1.1.0.pre1/lib/concurrent/set.rb:53:in `const_missing'
/Users/pachkovsky/.rvm/gems/truffleruby-1.0.0-rc6/gems/concurrent-ruby-1.1.0.pre1/lib/concurrent/set.rb:53:in `Concurrent'
/Users/pachkovsky/.rvm/gems/truffleruby-1.0.0-rc6/gems/concurrent-ruby-1.1.0.pre1/lib/concurrent/set.rb:5:in `<top (required)>'
/Users/pachkovsky/.rvm/gems/truffleruby-1.0.0-rc6/gems/concurrent-ruby-1.1.0.pre1/lib/concurrent.rb:16:in `require'
/Users/pachkovsky/.rvm/gems/truffleruby-1.0.0-rc6/gems/concurrent-ruby-1.1.0.pre1/lib/concurrent.rb:16:in `<top (required)>'
```