### PR TITLE
Fix NameError on defining a struct with a name

### DIFF
--- a/lib/concurrent/synchronization/abstract_struct.rb
+++ b/lib/concurrent/synchronization/abstract_struct.rb
@@ -138,7 +138,7 @@ module Concurrent
         end
         unless name.nil?
           begin
-            parent.send :remove_const, name if parent.const_defined? name
+            parent.send :remove_const, name if parent.const_defined?(name, false)
             parent.const_set(name, clazz)
             clazz
           rescue NameError

--- a/spec/concurrent/struct_shared.rb
+++ b/spec/concurrent/struct_shared.rb
@@ -10,6 +10,15 @@ RSpec.shared_examples :struct do
       expect(clazz.ancestors).to include described_class
     end
 
+    it 'registers the class when given a class name which is defined in the ancestors' do
+      class_name = 'ValidClassName2'
+      Object.const_set(class_name, class_name)
+      clazz = described_class.new(class_name)
+      expect{ described_class.const_get(class_name) }.to_not raise_error
+      expect(clazz).to be_a Class
+      expect(clazz.ancestors).to include described_class
+    end
+
     it 'creates an anonymous class when given at least one member' do
       clazz = described_class.new(:foo)
       expect{ described_class.const_get(clazz.to_s) }.to raise_error(NameError)


### PR DESCRIPTION
Fix `NameError` on defining a struct with a name when a constant with the same name already exists in the ancestors, e.g. in `Object` (global space).