### PR TITLE
Remove java_alias of 'submit' method of Runnable

### DIFF
--- a/lib/concurrent/executor/java_executor_service.rb
+++ b/lib/concurrent/executor/java_executor_service.rb
@@ -20,13 +20,12 @@ if Concurrent.on_jruby?
 
       def initialize(*args, &block)
         super
-        ns_make_executor_runnable
       end
 
       def post(*args, &task)
         raise ArgumentError.new('no block given') unless block_given?
         return handle_fallback(*args, &task) unless running?
-        @executor.submit_runnable Job.new(args, task)
+        @executor.submit Job.new(args, task)
         true
       rescue Java::JavaUtilConcurrent::RejectedExecutionException
         raise RejectedExecutionError
@@ -73,14 +72,6 @@ if Concurrent.on_jruby?
 
       def ns_shutdown?
         @executor.isShutdown || @executor.isTerminated
-      end
-
-      def ns_make_executor_runnable
-        if !defined?(@executor.submit_runnable)
-          @executor.class.class_eval do
-            java_alias :submit_runnable, :submit, [java.lang.Runnable.java_class]
-          end
-        end
       end
 
       class Job


### PR DESCRIPTION
There is an error while accessing the method of private class 'DelegatedExecutorService' in 'Executors' from 'JavaSingleThreadExecutor'. This happens for JDK-11, but works fine in JDK-8.

Fixes #758 