### PR TITLE
CI: Add Ruby 2.6.0 to matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ branches:
 matrix:
   fast_finish: true
   include:
-    - name: MRI 2.5.1 Latest
-      rvm: 2.5.1
+    - name: MRI 2.6.0 Latest
+      rvm: 2.6.0
     - name: JRuby 9.2.5.0 Latest on Java 11
       rvm: jruby-9.2.5.0
       jdk: oraclejdk11
@@ -24,7 +24,7 @@ matrix:
         - gem install bundler
         - bundle install
     - name: YARD uptodate in docs
-      rvm: 2.5.1
+      rvm: 2.6.0
       script:
       - bundle install --with documentation
       - bundle exec rake yard:master:uptodate
@@ -54,8 +54,6 @@ matrix:
 
     - name: MRI head
       rvm: ruby-head
-    - name: MRI 2.6.0-rc1
-      rvm: 2.6.0-rc1
     - name: JRuby head
       rvm: jruby-head
       jdk: oraclejdk8
@@ -68,7 +66,6 @@ matrix:
       env: COVERAGE=1
 
   allow_failures:
-    - rvm: 2.6.0-rc1
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: rbx-3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
   include:
     - name: MRI 2.6.0 Latest
       rvm: 2.6.0
+    - name: MRI 2.5
+      rvm: 2.5.3
     - name: JRuby 9.2.5.0 Latest on Java 11
       rvm: jruby-9.2.5.0
       jdk: oraclejdk11
@@ -41,7 +43,8 @@ matrix:
       rvm: 2.0.0
     - name: MRI 1.9.3
       rvm: 1.9.3
-
+      before_install:
+        - gem install bundler
     - name: JRuby 9.1.17.0
       rvm: jruby-9.1.17.0
       jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ branches:
 matrix:
   fast_finish: true
   include:
+    # Latest versions first
     - name: MRI 2.6.0 Latest
       rvm: 2.6.0
-    - name: MRI 2.5
-      rvm: 2.5.3
     - name: JRuby 9.2.5.0 Latest on Java 11
       rvm: jruby-9.2.5.0
       jdk: oraclejdk11
@@ -31,6 +30,9 @@ matrix:
       - bundle install --with documentation
       - bundle exec rake yard:master:uptodate
 
+    # Older versions follow
+    - name: MRI 2.5
+      rvm: 2.5.3
     - name: MRI 2.4.4
       rvm: 2.4.4
     - name: MRI 2.3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       - bundle exec rake yard:master:uptodate
 
     # Older versions follow
-    - name: MRI 2.5
+    - name: MRI 2.5.3
       rvm: 2.5.3
     - name: MRI 2.4.4
       rvm: 2.4.4


### PR DESCRIPTION
This PR adds latest MRI to the matrix.

  - remove 2.6.0-rc1