### PR TITLE
Fixes a code comment in Concurrent::{Hash,Array}

### DIFF
--- a/lib/concurrent/array.rb
+++ b/lib/concurrent/array.rb
@@ -21,8 +21,9 @@ module Concurrent
   # @!macro internal_implementation_note
   ArrayImplementation = case
                         when Concurrent.on_cruby?
-                          # Because MRI never runs code in parallel, the existing
-                          # non-thread-safe structures should usually work fine.
+                          # Array is thread-safe in practice because CRuby runs
+                          # threads one at a time and does not do context
+                          # switching during the execution of C functions.
                           ::Array
 
                         when Concurrent.on_jruby?
@@ -63,4 +64,3 @@ module Concurrent
   end
 
 end
-

--- a/lib/concurrent/hash.rb
+++ b/lib/concurrent/hash.rb
@@ -15,8 +15,9 @@ module Concurrent
   # @!macro internal_implementation_note
   HashImplementation = case
                        when Concurrent.on_cruby?
-                         # Because MRI never runs code in parallel, the existing
-                         # non-thread-safe structures should usually work fine.
+                         # Hash is thread-safe in practice because CRuby runs
+                         # threads one at a time and does not do context
+                         # switching during the execution of C functions.
                          ::Hash
 
                        when Concurrent.on_jruby?
@@ -56,4 +57,3 @@ module Concurrent
   end
 
 end
-


### PR DESCRIPTION
This patch is actually a question.

The reason `Hash` can be chosen in MRI as implementation for `Concurrent::Hash` cannot be that the interpreter does not run threads in parallel, because if you issue a `delete` call, say, and there is a context switch, even if only one thread runs at a time, the internal state of the hash could be left inconsistent.

What we need for `Hash` to work, really, is that their functions are _atomic_ in practice.

Not realeasing the GIL while C runs is something that I've heard, but I don't really know if my proposal is correct. Someone knowledgeable should validate it.

I could do the same in `Concurrent::Array` and others if there are more.