### PR TITLE
Remove shebang from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-#!/usr/bin/env rake
-
 require_relative 'lib/concurrent/version'
 require_relative 'lib/concurrent/utility/engine'
 


### PR DESCRIPTION
as the file is not executable anyway.

_FYI:_
It causes linter errors on our Fedora (rpm) packages:
```
E: non-executable-script /usr/share/gems/gems/concurrent-ruby-1.1.4/Rakefile 644 /usr/bin/env rake
E: wrong-script-interpreter /usr/share/gems/gems/concurrent-ruby-1.1.4/Rakefile /usr/bin/env rake
```