### PR TITLE
CI: update matrix versions, drop unused directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 branches:
   only:
     - master
@@ -8,18 +7,18 @@ matrix:
   fast_finish: true
   include:
     # Latest versions first
-    - name: MRI 2.6.0 Latest
-      rvm: 2.6.0
-    - name: JRuby 9.2.5.0 Latest on Java 11
-      rvm: jruby-9.2.5.0
+    - name: MRI 2.6.1 Latest
+      rvm: 2.6.1
+    - name: JRuby 9.2.6.0 Latest on Java 11
+      rvm: jruby-9.2.6.0
       jdk: oraclejdk11
-    - name: JRuby 9.2.5.0 Latest on Java 8
-      rvm: jruby-9.2.5.0
+    - name: JRuby 9.2.6.0 Latest on Java 8
+      rvm: jruby-9.2.6.0
       jdk: oraclejdk8
     - name: TruffleRuby Latest
       rvm: truffleruby
     - name: YARD uptodate in docs
-      rvm: 2.6.0
+      rvm: 2.6.1
       script:
       - bundle install --with documentation
       - bundle exec rake yard:master:uptodate
@@ -27,10 +26,10 @@ matrix:
     # Older versions follow
     - name: MRI 2.5.3
       rvm: 2.5.3
-    - name: MRI 2.4.4
-      rvm: 2.4.4
-    - name: MRI 2.3.7
-      rvm: 2.3.7
+    - name: MRI 2.4.5
+      rvm: 2.4.5
+    - name: MRI 2.3.8
+      rvm: 2.3.8
     - name: MRI 2.2.10
       rvm: 2.2.10
     - name: MRI 2.1.10
@@ -58,8 +57,8 @@ matrix:
     - name: Rubinius
       rvm: rbx-3
 
-    - name: Coverage on MRI 2.3.7
-      rvm: 2.3.7
+    - name: Coverage on MRI 2.3.8
+      rvm: 2.3.8
       env: COVERAGE=1
 
   allow_failures:


### PR DESCRIPTION
  - drop sudo: false - a directive which now does nothing
  - update MRI patch levels
  - update JRuby 9.2

---

This PR updates the CI matrix to use latest JRuby, 9.2.6.0.

[JRuby 9.2.6.0 release blog post](https://www.jruby.org/2019/02/11/jruby-9-2-6-0.html)