### PR TITLE
link to soure-code from gemspec

### DIFF
--- a/concurrent-ruby.gemspec
+++ b/concurrent-ruby.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
     Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more.
     Inspired by Erlang, Clojure, Go, JavaScript, actors, and classic concurrency patterns.
   TXT
-
+  s.metadata["source_code_uri"] = "https://github.com/ruby-concurrency/concurrent-ruby"
   s.required_ruby_version = '>= 1.9.3'
 end


### PR DESCRIPTION
 - rubygems removed the edit UI, so it should be in the gemspec now
 - makes it easy for automated tools to link to github for comparisons