### PR TITLE
CI: Use 2.4.6, 2.5.5, 2.6.2, jruby-9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     # Latest versions first
     - name: MRI 2.6.2 Latest
       rvm: 2.6.2
-    - name: JRuby 9.2.6.0 Latest on Java 11
-      rvm: jruby-9.2.6.0
+    - name: JRuby 9.2.7.0 Latest on Java 11
+      rvm: jruby-9.2.7.0
       jdk: oraclejdk11
-    - name: JRuby 9.2.6.0 Latest on Java 8
-      rvm: jruby-9.2.6.0
+    - name: JRuby 9.2.7.0 Latest on Java 8
+      rvm: jruby-9.2.7.0
       jdk: oraclejdk8
     - name: TruffleRuby Latest
       rvm: truffleruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ matrix:
     # Older versions follow
     - name: MRI 2.5.5
       rvm: 2.5.5
-    - name: MRI 2.4.5
-      rvm: 2.4.5
+    - name: MRI 2.4.6
+      rvm: 2.4.6
     - name: MRI 2.3.8
       rvm: 2.3.8
     - name: MRI 2.2.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
   fast_finish: true
   include:
     # Latest versions first
-    - name: MRI 2.6.1 Latest
-      rvm: 2.6.1
+    - name: MRI 2.6.2 Latest
+      rvm: 2.6.2
     - name: JRuby 9.2.6.0 Latest on Java 11
       rvm: jruby-9.2.6.0
       jdk: oraclejdk11
@@ -18,14 +18,14 @@ matrix:
     - name: TruffleRuby Latest
       rvm: truffleruby
     - name: YARD uptodate in docs
-      rvm: 2.6.1
+      rvm: 2.6.2
       script:
       - bundle install --with documentation
       - bundle exec rake yard:master:uptodate
 
     # Older versions follow
-    - name: MRI 2.5.3
-      rvm: 2.5.3
+    - name: MRI 2.5.5
+      rvm: 2.5.5
     - name: MRI 2.4.5
       rvm: 2.4.5
     - name: MRI 2.3.8


### PR DESCRIPTION
This PR updates the CI matrix to latest Rubies.