### PR TITLE
Use Ruby's Etc.nprocessors for processor_count if available

### DIFF
--- a/lib/concurrent/utility/processor_counter.rb
+++ b/lib/concurrent/utility/processor_counter.rb
@@ -1,3 +1,4 @@
+require 'etc'
 require 'rbconfig'
 require 'concurrent/delay'
 
@@ -78,7 +79,7 @@ module Concurrent
       def compute_processor_count
         if Concurrent.on_jruby?
           java.lang.Runtime.getRuntime.availableProcessors
-        elsif defined?(Etc) && Etc.respond_to?(:nprocessors) && (nprocessor = Etc.nprocessors rescue nil)
+        elsif Etc.respond_to?(:nprocessors) && (nprocessor = Etc.nprocessors rescue nil)
           nprocessor
         else
           os_name = RbConfig::CONFIG["target_os"]

--- a/lib/concurrent/utility/processor_counter.rb
+++ b/lib/concurrent/utility/processor_counter.rb
@@ -22,6 +22,8 @@ module Concurrent
       # occasionally poll this property." Subsequently the result will NOT be
       # memoized under JRuby.
       #
+      # Ruby's Etc.nprocessors will be used if available (MRI 2.2+).
+      #
       # On Windows the Win32 API will be queried for the
       # `NumberOfLogicalProcessors from Win32_Processor`. This will return the
       # total number "logical processors for the current instance of the
@@ -76,6 +78,8 @@ module Concurrent
       def compute_processor_count
         if Concurrent.on_jruby?
           java.lang.Runtime.getRuntime.availableProcessors
+        elsif defined?(Etc) && Etc.respond_to?(:nprocessors) && (nprocessor = Etc.nprocessors rescue nil)
+          nprocessor
         else
           os_name = RbConfig::CONFIG["target_os"]
           if os_name =~ /mingw|mswin/


### PR DESCRIPTION
In 0371ed4ad5c910fdcf569c8e85d7de96abf5903e from the discussions in #576, we switched the default method of detecting processor count from `/usr/bin/nproc` to reading `/proc/cpuinfo`. This avoids a fork, but means that we no longer respect CPU affinity, which we should want if using this value to control parallelism. I imagine it should work on Alpha too.

MRI has had `Etc.nprocessors` since Ruby 2.2, which uses:
- sched_getaffinity(): Linux
- sysconf(_SC_NPROCESSORS_ONLN): GNU/Linux, NetBSD, FreeBSD, OpenBSD, DragonFly BSD, OpenIndiana, Mac OS X, AIX
- GetSystemInfo(): Win32

This should be faster than the alternatives of reading from `/proc/cpuinfo`, using WIN32OLE, or spawning a new process (though all should be plenty fast since this is memoized). It also will take into account CPU affinity.

**Before:**
```
$ taskset 0x3 ruby -Ilib -rconcurrent-ruby -e 'puts Concurrent.processor_count'
12
$ be ruby -Ilib benchmark_processor_count.rb
compute_processor_count
                          5.581k (± 0.9%) i/s -     27.999k in   5.017628s
```

**After:**
```
$ taskset 0x3 bundle exec ruby -Ilib -rconcurrent-ruby -e 'puts Concurrent.processor_count'
2
$ be ruby -Ilib benchmark_processor_count.rb
compute_processor_count
                          1.685M (± 1.0%) i/s -      8.442M in   5.010886s
```

cc @pitr-ch @matthewd @graaff