### PR TITLE
CI: Use jruby-9.2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     # Latest versions first
     - name: MRI 2.6.2 Latest
       rvm: 2.6.2
-    - name: JRuby 9.2.7.0 Latest on Java 11
-      rvm: jruby-9.2.7.0
+    - name: JRuby 9.2.8.0 Latest on Java 11
+      rvm: jruby-9.2.8.0
       jdk: oraclejdk11
-    - name: JRuby 9.2.7.0 Latest on Java 8
-      rvm: jruby-9.2.7.0
+    - name: JRuby 9.2.8.0 Latest on Java 8
+      rvm: jruby-9.2.8.0
       jdk: oraclejdk8
     - name: TruffleRuby Latest
       rvm: truffleruby


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.8.0**.

[JRuby 9.2.8.0 release blog post](https://www.jruby.org/2019/08/12/jruby-9-2-8-0.html)