### PR TITLE
CI: Use Ruby 2.4.9, 2.5.7, 2.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
   fast_finish: true
   include:
     # Latest versions first
-    - name: MRI 2.6.2 Latest
-      rvm: 2.6.2
+    - name: MRI 2.6.4 Latest
+      rvm: 2.6.4
     - name: JRuby 9.2.8.0 Latest on Java 11
       rvm: jruby-9.2.8.0
       jdk: oraclejdk11
@@ -18,16 +18,16 @@ matrix:
     - name: TruffleRuby Latest
       rvm: truffleruby
     - name: YARD uptodate in docs
-      rvm: 2.6.2
+      rvm: 2.6.4
       script:
       - bundle install --with documentation
       - bundle exec rake yard:master:uptodate
 
     # Older versions follow
-    - name: MRI 2.5.5
-      rvm: 2.5.5
-    - name: MRI 2.4.6
-      rvm: 2.4.6
+    - name: MRI 2.5.6
+      rvm: 2.5.6
+    - name: MRI 2.4.7
+      rvm: 2.4.7
     - name: MRI 2.3.8
       rvm: 2.3.8
     - name: MRI 2.2.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
   fast_finish: true
   include:
     # Latest versions first
-    - name: MRI 2.6.4 Latest
-      rvm: 2.6.4
+    - name: MRI 2.6.5 Latest
+      rvm: 2.6.5
     - name: JRuby 9.2.8.0 Latest on Java 11
       rvm: jruby-9.2.8.0
       jdk: oraclejdk11
@@ -18,16 +18,16 @@ matrix:
     - name: TruffleRuby Latest
       rvm: truffleruby
     - name: YARD uptodate in docs
-      rvm: 2.6.4
+      rvm: 2.6.5
       script:
       - bundle install --with documentation
       - bundle exec rake yard:master:uptodate
 
     # Older versions follow
-    - name: MRI 2.5.6
-      rvm: 2.5.6
-    - name: MRI 2.4.7
-      rvm: 2.4.7
+    - name: MRI 2.5.7
+      rvm: 2.5.7
+    - name: MRI 2.4.9
+      rvm: 2.4.9
     - name: MRI 2.3.8
       rvm: 2.3.8
     - name: MRI 2.2.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       jdk: oraclejdk11
     - name: JRuby 9.2.8.0 Latest on Java 8
       rvm: jruby-9.2.8.0
-      jdk: oraclejdk8
+      jdk: openjdk8
     - name: TruffleRuby Latest
       rvm: truffleruby
     - name: YARD uptodate in docs
@@ -40,19 +40,19 @@ matrix:
       rvm: 1.9.3
     - name: JRuby 9.1.17.0
       rvm: jruby-9.1.17.0
-      jdk: oraclejdk8
+      jdk: openjdk8
     - name: JRuby 9.0.5.0
       rvm: jruby-9.0.5.0
-      jdk: oraclejdk8
+      jdk: openjdk8
     - name: JRuby 1.7.27
       rvm: jruby-1.7.27
-      jdk: oraclejdk8
+      jdk: openjdk8
 
     - name: MRI head
       rvm: ruby-head
     - name: JRuby head
       rvm: jruby-head
-      jdk: oraclejdk8
+      jdk: openjdk8
 
     - name: Rubinius
       rvm: rbx-3


### PR DESCRIPTION
This PR updates the Ruby used to latest releases.

Update: CI: Use 2.4.9, 2.5.7, 2.6.5