### PR TITLE
Doc Fixes

### DIFF
--- a/lib-edge/concurrent/actor/reference.rb
+++ b/lib-edge/concurrent/actor/reference.rb
@@ -35,12 +35,7 @@ module Concurrent
 
       alias_method :<<, :tell
 
-      # @note it's a good practice to use tell whenever possible. Ask should be used only for
-      # testing and when it returns very shortly. It can lead to deadlock if all threads in
-      # global_io_executor will block on while asking. It's fine to use it form outside of actors and
-      # global_io_executor.
-      #
-      # @note it's a good practice to use {#tell} whenever possible. Results can be send back with other messages.
+      # @note it's a good practice to use {#tell} whenever possible. Results can be sent back with other messages.
       #   Ask should be used only for testing and when it returns very shortly. It can lead to deadlock if all threads in
       #   global_io_executor will block on while asking. It's fine to use it form outside of actors and
       #   global_io_executor.
@@ -61,7 +56,7 @@ module Concurrent
       # Sends the message synchronously and blocks until the message
       # is processed. Raises on error.
       #
-      # @note it's a good practice to use {#tell} whenever possible. Results can be send back with other messages.
+      # @note it's a good practice to use {#tell} whenever possible. Results can be sent back with other messages.
       #   Ask should be used only for testing and when it returns very shortly. It can lead to deadlock if all threads in
       #   global_io_executor will block on while asking. It's fine to use it form outside of actors and
       #   global_io_executor.

--- a/lib/concurrent/array.rb
+++ b/lib/concurrent/array.rb
@@ -10,11 +10,11 @@ module Concurrent
   #   or writing at a time. This includes iteration methods like `#each`.
   #
   #   @note `a += b` is **not** a **thread-safe** operation on
-  #   `Concurrent::Array`. It reads array `a`, then it creates new `Concurrent::Array`
-  #   which is concatenation of `a` and `b`, then it writes the concatenation to `a`.
-  #   The read and write are independent operations they do not form a single atomic
-  #   operation therefore when two `+=` operations are executed concurrently updates
-  #   may be lost. Use `#concat` instead.
+  #     `Concurrent::Array`. It reads array `a`, then it creates new `Concurrent::Array`
+  #     which is concatenation of `a` and `b`, then it writes the concatenation to `a`.
+  #     The read and write are independent operations they do not form a single atomic
+  #     operation therefore when two `+=` operations are executed concurrently updates
+  #     may be lost. Use `#concat` instead.
   #
   #   @see http://ruby-doc.org/core-2.2.0/Array.html Ruby standard library `Array`
 

--- a/lib/concurrent/concern/dereferenceable.rb
+++ b/lib/concurrent/concern/dereferenceable.rb
@@ -37,8 +37,8 @@ module Concurrent
       #   returning data to the caller (dereferencing).
       #
       #   @note Most classes that include this module will call `#set_deref_options`
-      #   from within the constructor, thus allowing these options to be set at
-      #   object creation.
+      #     from within the constructor, thus allowing these options to be set at
+      #     object creation.
       #
       #   @param [Hash] opts the options defining dereference behavior.
       #   @option opts [String] :dup_on_deref (false) call `#dup` before returning the data

--- a/lib/concurrent/set.rb
+++ b/lib/concurrent/set.rb
@@ -11,11 +11,11 @@ module Concurrent
   #   or writing at a time. This includes iteration methods like `#each`.
   #
   #   @note `a += b` is **not** a **thread-safe** operation on
-  #   `Concurrent::Set`. It reads Set `a`, then it creates new `Concurrent::Set`
-  #   which is union of `a` and `b`, then it writes the union to `a`.
-  #   The read and write are independent operations they do not form a single atomic
-  #   operation therefore when two `+=` operations are executed concurrently updates
-  #   may be lost. Use `#merge` instead.
+  #     `Concurrent::Set`. It reads Set `a`, then it creates new `Concurrent::Set`
+  #     which is union of `a` and `b`, then it writes the union to `a`.
+  #     The read and write are independent operations they do not form a single atomic
+  #     operation therefore when two `+=` operations are executed concurrently updates
+  #     may be lost. Use `#merge` instead.
   #
   #   @see http://ruby-doc.org/stdlib-2.4.0/libdoc/set/rdoc/Set.html Ruby standard library `Set`
 


### PR DESCRIPTION
I was reading the [`Array` docs](http://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/Array.html) recently and noticed the note displayed incorrectly. Apparently Yard doc notes require indentations for multi lines.

I fixed this instance and a couple more. I also found some duplicated docs in actor/reference and tried to clean that up as well.
