### PR TITLE
Allow semaphore permit acquisition with blocks

### DIFF
--- a/lib/concurrent-ruby/concurrent/atomic/mutex_semaphore.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/mutex_semaphore.rb
@@ -23,8 +23,9 @@ module Concurrent
 
       synchronize do
         try_acquire_timed(permits, nil)
-        nil
       end
+
+      nil
     end
 
     # @!macro semaphore_method_available_permits

--- a/lib/concurrent-ruby/concurrent/atomic/semaphore.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/semaphore.rb
@@ -16,14 +16,16 @@ module Concurrent
   # @!macro semaphore_method_acquire
   #
   #   Acquires the given number of permits from this semaphore,
-  #     blocking until all are available.
+  #     blocking until all are available. If a block is given,
+  #     yields to it and releases the permits afterwards.
   #
   #   @param [Fixnum] permits Number of permits to acquire
   #
   #   @raise [ArgumentError] if `permits` is not an integer or is less than
   #     one
   #
-  #   @return [nil]
+  #   @return [nil, BasicObject] Without a block, `nil` is returned. If a block
+  #   is given, its return value is returned.
 
   # @!macro semaphore_method_available_permits
   #
@@ -41,7 +43,9 @@ module Concurrent
   #
   #   Acquires the given number of permits from this semaphore,
   #     only if all are available at the time of invocation or within
-  #     `timeout` interval
+  #     `timeout` interval. If a block is given, yields to it if the permits
+  #     were successfully acquired, and releases them afterward, returning the
+  #     block's return value.
   #
   #   @param [Fixnum] permits the number of permits to acquire
   #
@@ -51,8 +55,10 @@ module Concurrent
   #   @raise [ArgumentError] if `permits` is not an integer or is less than
   #     one
   #
-  #   @return [Boolean] `false` if no permits are available, `true` when
-  #     acquired a permit
+  #   @return [true, false, nil, BasicObject] `false` if no permits are
+  #     available, `true` when acquired a permit. If a block is given, the
+  #     block's return value is returned if the permits were acquired; if not,
+  #     `nil` is returned.
 
   # @!macro semaphore_method_release
   #
@@ -106,6 +112,8 @@ module Concurrent
   #   releasing a blocking acquirer.
   #   However, no actual permit objects are used; the Semaphore just keeps a
   #   count of the number available and acts accordingly.
+  #   Alternatively, permits may be acquired within a block, and automatically
+  #   released after the block finishes executing.
   #
   # @!macro semaphore_public_api
   # @example
@@ -140,6 +148,19 @@ module Concurrent
   #   # Thread 4 releasing semaphore
   #   # Thread 1 acquired semaphore
   #
+  # @example
+  #   semaphore = Concurrent::Semaphore.new(1)
+  #
+  #   puts semaphore.available_permits
+  #   semaphore.acquire do
+  #     puts semaphore.available_permits
+  #   end
+  #   puts semaphore.available_permits
+  #
+  #   # prints:
+  #   # 1
+  #   # 0
+  #   # 1
   class Semaphore < SemaphoreImplementation
   end
 end

--- a/spec/concurrent/atomic/semaphore_spec.rb
+++ b/spec/concurrent/atomic/semaphore_spec.rb
@@ -27,29 +27,91 @@ RSpec.shared_examples :semaphore do
   end
 
   describe '#acquire' do
-    context 'permits available' do
-      it 'should return true immediately' do
-        result = semaphore.acquire
-        expect(result).to be_nil
+    context 'without block' do
+      context 'permits available' do
+        it 'should return nil immediately' do
+          result = semaphore.acquire
+          expect(result).to be_nil
+        end
+      end
+
+      context 'not enough permits available' do
+        it 'should block thread until permits are available' do
+          semaphore.drain_permits
+          in_thread { sleep(0.2); semaphore.release }
+
+          result = semaphore.acquire
+          expect(result).to be_nil
+          expect(semaphore.available_permits).to eq 0
+        end
+      end
+
+      context 'when acquiring negative permits' do
+        it 'raises ArgumentError' do
+          expect {
+            semaphore.acquire(-1)
+          }.to raise_error(ArgumentError)
+        end
       end
     end
 
-    context 'not enough permits available' do
-      it 'should block thread until permits are available' do
-        semaphore.drain_permits
-        in_thread { sleep(0.2); semaphore.release }
+    context 'with block' do
+      context 'permits available' do
+        it 'should acquire permits, run the block, release permits, and return block return value' do
+          available_permits = semaphore.available_permits
+          yielded = false
+          expected_result = Object.new
 
-        result = semaphore.acquire
-        expect(result).to be_nil
-        expect(semaphore.available_permits).to eq 0
+          actual_result = semaphore.acquire do
+            expect(semaphore.available_permits).to eq(available_permits - 1)
+            yielded = true
+            expected_result
+          end
+
+          expect(semaphore.available_permits).to eq(available_permits)
+          expect(yielded).to be true
+          expect(actual_result).to be(expected_result)
+        end
+
+        it 'if the block raises, the permit is still released' do
+          expect {
+            expect {
+              semaphore.acquire do
+                raise 'boom'
+              end
+            }.to raise_error('boom')
+          }.to_not change { semaphore.available_permits }
+        end
       end
-    end
 
-    context 'when acquiring negative permits' do
-      it do
-        expect {
-          semaphore.acquire(-1)
-        }.to raise_error(ArgumentError)
+      context 'not enough permits available' do
+        it 'should block thread until permits are available' do
+          yielded = false
+          semaphore.drain_permits
+          in_thread { sleep(0.2); semaphore.release }
+          expected_result = Object.new
+
+          actual_result = semaphore.acquire do
+            yielded = true
+            expected_result
+          end
+
+          expect(actual_result).to be(expected_result)
+          expect(yielded).to be true
+          expect(semaphore.available_permits).to eq 1
+        end
+      end
+
+      context 'when acquiring negative permits' do
+        it 'raises ArgumentError' do
+          expect {
+            expect {
+              semaphore.acquire(-1) do
+                raise 'block should never run'
+              end
+            }.to raise_error(ArgumentError)
+          }.not_to change { semaphore.available_permits }
+        end
       end
     end
   end
@@ -69,43 +131,151 @@ RSpec.shared_examples :semaphore do
   end
 
   describe '#try_acquire' do
-    context 'without timeout' do
-      it 'acquires immediately if permits are available' do
-        result = semaphore.try_acquire(1)
-        expect(result).to be_truthy
+    context 'without block' do
+      context 'without timeout' do
+        it 'acquires immediately if permits are available' do
+          result = semaphore.try_acquire(1)
+          expect(result).to be_truthy
+        end
+
+        it 'returns false immediately in no permits are available' do
+          result = semaphore.try_acquire(20)
+          expect(result).to be_falsey
+        end
+
+        context 'when trying to acquire negative permits' do
+          it do
+            expect {
+              semaphore.try_acquire(-1)
+            }.to raise_error(ArgumentError)
+          end
+        end
       end
 
-      it 'returns false immediately in no permits are available' do
-        result = semaphore.try_acquire(20)
-        expect(result).to be_falsey
-      end
+      context 'with timeout' do
+        it 'acquires immediately if permits are available' do
+          result = semaphore.try_acquire(1, 5)
+          expect(result).to be_truthy
+        end
 
-      context 'when trying to acquire negative permits' do
-        it do
-          expect {
-            semaphore.try_acquire(-1)
-          }.to raise_error(ArgumentError)
+        it 'acquires when permits are available within timeout' do
+          semaphore.drain_permits
+          in_thread { sleep 0.1; semaphore.release }
+          result = semaphore.try_acquire(1, 1)
+          expect(result).to be_truthy
+        end
+
+        it 'returns false on timeout' do
+          semaphore.drain_permits
+          result = semaphore.try_acquire(1, 0.1)
+          expect(result).to be_falsey
         end
       end
     end
 
-    context 'with timeout' do
-      it 'acquires immediately if permits are available' do
-        result = semaphore.try_acquire(1, 5)
-        expect(result).to be_truthy
+    context 'with block' do
+      context 'without timeout' do
+        it 'acquires immediately if permits are available and returns block return value' do
+          yielded = false
+          available_permits = semaphore.available_permits
+          expected_result = Object.new
+
+          actual_result = semaphore.try_acquire(1) do
+            yielded = true
+            expect(semaphore.available_permits).to eq(available_permits - 1)
+            expected_result
+          end
+
+          expect(actual_result).to be(expected_result)
+          expect(yielded).to be true
+          expect(semaphore.available_permits).to eq available_permits
+        end
+
+        it 'releases permit if block raises' do
+          expect {
+            expect {
+              semaphore.try_acquire(1) do
+                raise 'boom'
+              end
+            }.to raise_error('boom')
+          }.not_to change { semaphore.available_permits }
+        end
+
+        it 'returns false immediately in no permits are available' do
+          expect {
+            result = semaphore.try_acquire(20) do
+              raise 'block should never run'
+            end
+
+            expect(result).to be_falsey
+          }.not_to change { semaphore.available_permits }
+        end
+
+        context 'when trying to acquire negative permits' do
+          it do
+            expect {
+              expect {
+                semaphore.try_acquire(-1) do
+                  raise 'block should never run'
+                end
+              }.to raise_error(ArgumentError)
+            }.not_to change { semaphore.available_permits }
+          end
+        end
       end
 
-      it 'acquires when permits are available within timeout' do
-        semaphore.drain_permits
-        in_thread { sleep 0.1; semaphore.release }
-        result = semaphore.try_acquire(1, 1)
-        expect(result).to be_truthy
-      end
+      context 'with timeout' do
+        it 'acquires immediately if permits are available, and returns block return value' do
+          expect {
+            yielded = false
+            expected_result = Object.new
 
-      it 'returns false on timeout' do
-        semaphore.drain_permits
-        result = semaphore.try_acquire(1, 0.1)
-        expect(result).to be_falsey
+            actual_result = semaphore.try_acquire(1, 5) do
+              yielded = true
+              expected_result
+            end
+
+            expect(actual_result).to be(expected_result)
+            expect(yielded).to be true
+          }.not_to change { semaphore.available_permits }
+        end
+
+        it 'releases permits if block raises' do
+          expect {
+            expect {
+              semaphore.try_acquire(1, 5) do
+                raise 'boom'
+              end
+            }.to raise_error('boom')
+          }.not_to change { semaphore.available_permits }
+        end
+
+        it 'acquires when permits are available within timeout, and returns block return value' do
+          yielded = false
+          semaphore.drain_permits
+          in_thread { sleep 0.1; semaphore.release }
+          expected_result = Object.new
+
+          actual_result = semaphore.try_acquire(1, 1) do
+            yielded = true
+            expected_result
+          end
+
+          expect(actual_result).to be(expected_result)
+          expect(yielded).to be true
+          expect(semaphore.available_permits).to be 1
+        end
+
+        it 'returns false on timeout' do
+          semaphore.drain_permits
+
+          result = semaphore.try_acquire(1, 0.1) do
+            raise 'block should never run'
+          end
+
+          expect(result).to be_falsey
+          expect(semaphore.available_permits).to be 0
+        end
       end
     end
   end


### PR DESCRIPTION
Ruby often idiomatically uses blocks to open a resource and close it again automatically.

For example:

```ruby
file = File.open('file', 'r')
# do work with file
file.close

# vs

File.open('file', 'r') do |file|
  # do work with file
end
# file closed automatically
```

**This teaches semaphores a similar technique:**

```ruby
semaphore = Concurrent::Semaphore.new(1)

semaphore.acquire
# do work
semaphore.release

# vs

semaphore.acquire do
  # do work
end
# permit automatically released
```