### PR TITLE
require 'concurrent/utility/engine' first

### DIFF
--- a/lib/concurrent/atomic/count_down_latch.rb
+++ b/lib/concurrent/atomic/count_down_latch.rb
@@ -1,6 +1,6 @@
+require 'concurrent/utility/engine'
 require 'concurrent/atomic/mutex_count_down_latch'
 require 'concurrent/atomic/java_count_down_latch'
-require 'concurrent/utility/engine'
 
 module Concurrent
 

--- a/lib/concurrent/atomic/thread_local_var.rb
+++ b/lib/concurrent/atomic/thread_local_var.rb
@@ -1,6 +1,6 @@
+require 'concurrent/utility/engine'
 require 'concurrent/atomic/ruby_thread_local_var'
 require 'concurrent/atomic/java_thread_local_var'
-require 'concurrent/utility/engine'
 
 module Concurrent
 

--- a/lib/concurrent/collection/non_concurrent_priority_queue.rb
+++ b/lib/concurrent/collection/non_concurrent_priority_queue.rb
@@ -1,6 +1,6 @@
+require 'concurrent/utility/engine'
 require 'concurrent/collection/java_non_concurrent_priority_queue'
 require 'concurrent/collection/ruby_non_concurrent_priority_queue'
-require 'concurrent/utility/engine'
 
 module Concurrent
   module Collection

--- a/lib/concurrent/executor/single_thread_executor.rb
+++ b/lib/concurrent/executor/single_thread_executor.rb
@@ -1,3 +1,4 @@
+require 'concurrent/utility/engine'
 require 'concurrent/executor/ruby_single_thread_executor'
 
 module Concurrent


### PR DESCRIPTION
Without this reordering require, require a specific file will raise
"undefined method `on_jruby?' for Concurrent:Module (NoMethodError)".

Steps to reproduce:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "concurrent-ruby", require: false
end

begin
  require "concurrent/atomic/thread_local_var"
rescue
  puts $!.full_message
end

begin
  require "concurrent/collection/non_concurrent_priority_queue"
rescue
  puts $!.full_message
end
```

Result:

```
$ ruby a.rb
Fetching gem metadata from https://rubygems.org/..
Resolving dependencies...
Using bundler 1.17.2
Using concurrent-ruby 1.1.5
Traceback (most recent call last):
        4: from a.rb:14:in `<main>'
        3: from a.rb:14:in `require'
        2: from /Users/kamipo/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/atomic/thread_local_var.rb:2:in `<top (required)>'
        1: from /Users/kamipo/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/atomic/thread_local_var.rb:2:in `require'
/Users/kamipo/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/atomic/java_thread_local_var.rb:3:in `<top (required)>': undefined method `on_jruby?' for Concurrent:Module (NoMethodError)
Traceback (most recent call last):
        4: from a.rb:20:in `<main>'
        3: from a.rb:20:in `require'
        2: from /Users/kamipo/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/collection/non_concurrent_priority_queue.rb:1:in `<top (required)>'
        1: from /Users/kamipo/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/collection/non_concurrent_priority_queue.rb:1:in `require'
/Users/kamipo/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.5/lib/concurrent/collection/java_non_concurrent_priority_queue.rb:1:in `<top (required)>': undefined method `on_jruby?' for Concurrent:Module (NoMethodError)
```