### PR TITLE
Fix the docs for Concurrent::Map#put_if_absent

### DIFF
--- a/lib/concurrent/map.rb
+++ b/lib/concurrent/map.rb
@@ -197,7 +197,7 @@ module Concurrent
     # Insert value into map with key if key is absent in one atomic step.
     # @param [Object] key
     # @param [Object] value
-    # @return [Object, nil] the value or nil when key was present
+    # @return [Object, nil] the previous value when key was present or nil when there was no key
     def put_if_absent(key, value)
       computed = false
       result   = compute_if_absent(key) do


### PR DESCRIPTION
This is a fix to address [Issue #798](https://github.com/ruby-concurrency/concurrent-ruby/issues/798)

Change the documentation to state the correct behavior:
* Return nil if the key is not present
* Return the previous value when the key is present