### PR TITLE
Fix typo in Concurrent::AtomicBoolean docs

### DIFF
--- a/docs/1.0.5/Concurrent/AtomicBoolean.html
+++ b/docs/1.0.5/Concurrent/AtomicBoolean.html
@@ -513,7 +513,7 @@ Testing with Concurrent::JavaAtomicBoolean...
       
       
         &mdash;
-        <div class='inline'><p>true is value has changed, otherwise false</p>
+        <div class='inline'><p>true if value has changed, otherwise false</p>
 </div>
       
     </li>
@@ -580,7 +580,7 @@ Testing with Concurrent::JavaAtomicBoolean...
       
       
         &mdash;
-        <div class='inline'><p>true is value has changed, otherwise false</p>
+        <div class='inline'><p>true if value has changed, otherwise false</p>
 </div>
       
     </li>

--- a/docs/1.1.4/Concurrent/AtomicBoolean.html
+++ b/docs/1.1.4/Concurrent/AtomicBoolean.html
@@ -549,7 +549,7 @@ Testing with Concurrent::JavaAtomicBoolean...
       
       
         &mdash;
-        <div class='inline'><p>true is value has changed, otherwise false</p>
+        <div class='inline'><p>true if value has changed, otherwise false</p>
 </div>
       
     </li>
@@ -616,7 +616,7 @@ Testing with Concurrent::JavaAtomicBoolean...
       
       
         &mdash;
-        <div class='inline'><p>true is value has changed, otherwise false</p>
+        <div class='inline'><p>true if value has changed, otherwise false</p>
 </div>
       
     </li>

--- a/docs/1.1.5/Concurrent/AtomicBoolean.html
+++ b/docs/1.1.5/Concurrent/AtomicBoolean.html
@@ -549,7 +549,7 @@ Testing with Concurrent::JavaAtomicBoolean...
       
       
         &mdash;
-        <div class='inline'><p>true is value has changed, otherwise false</p>
+        <div class='inline'><p>true if value has changed, otherwise false</p>
 </div>
       
     </li>
@@ -616,7 +616,7 @@ Testing with Concurrent::JavaAtomicBoolean...
       
       
         &mdash;
-        <div class='inline'><p>true is value has changed, otherwise false</p>
+        <div class='inline'><p>true if value has changed, otherwise false</p>
 </div>
       
     </li>

--- a/docs/master/Concurrent/AtomicBoolean.html
+++ b/docs/master/Concurrent/AtomicBoolean.html
@@ -549,7 +549,7 @@ Testing with Concurrent::JavaAtomicBoolean...
       
       
         &mdash;
-        <div class='inline'><p>true is value has changed, otherwise false</p>
+        <div class='inline'><p>true if value has changed, otherwise false</p>
 </div>
       
     </li>
@@ -616,7 +616,7 @@ Testing with Concurrent::JavaAtomicBoolean...
       
       
         &mdash;
-        <div class='inline'><p>true is value has changed, otherwise false</p>
+        <div class='inline'><p>true if value has changed, otherwise false</p>
 </div>
       
     </li>

--- a/lib/concurrent/atomic/atomic_boolean.rb
+++ b/lib/concurrent/atomic/atomic_boolean.rb
@@ -41,13 +41,13 @@ module Concurrent
   #
   #   Explicitly sets the value to true.
   #
-  #   @return [Boolean] true is value has changed, otherwise false
+  #   @return [Boolean] true if value has changed, otherwise false
 
   # @!macro atomic_boolean_method_make_false
   #
   #   Explicitly sets the value to false.
   #
-  #   @return [Boolean] true is value has changed, otherwise false
+  #   @return [Boolean] true if value has changed, otherwise false
 
   ###################################################################
 


### PR DESCRIPTION
`true _is_ value has changed, otherwise false` should have been
`true _if_ value has changed, otherwise false`.