### PR TITLE
Implement #dup and #clone for Structs

### DIFF
--- a/lib/concurrent/immutable_struct.rb
+++ b/lib/concurrent/immutable_struct.rb
@@ -70,11 +70,11 @@ module Concurrent
       ns_select(&block)
     end
 
-    # @!macro struct_initialize_copy
-    #
+    private
+
     # @!visibility private
     def initialize_copy(original)
-      super
+      super(original)
       ns_initialize_copy
     end
 

--- a/lib/concurrent/immutable_struct.rb
+++ b/lib/concurrent/immutable_struct.rb
@@ -70,6 +70,14 @@ module Concurrent
       ns_select(&block)
     end
 
+    # @!macro struct_initialize_copy
+    #
+    # @!visibility private
+    def initialize_copy(original)
+      super
+      ns_initialize_copy
+    end
+
     # @!macro struct_new
     def self.new(*args, &block)
       clazz_name = nil

--- a/lib/concurrent/mutable_struct.rb
+++ b/lib/concurrent/mutable_struct.rb
@@ -169,16 +169,6 @@ module Concurrent
       synchronize { ns_select(&block) }
     end
 
-    # @!macro struct_initialize_copy
-    #
-    # @!visibility private
-    def initialize_copy(original)
-      synchronize do
-        super
-        ns_initialize_copy
-      end
-    end
-
     # @!macro struct_set
     #
     #   Attribute Assignment
@@ -204,6 +194,16 @@ module Concurrent
       end
     rescue NoMethodError
       raise NameError.new("no member '#{member}' in struct")
+    end
+
+    private
+
+    # @!visibility private
+    def initialize_copy(original)
+      synchronize do
+        super(original)
+        ns_initialize_copy
+      end
     end
 
     # @!macro struct_new

--- a/lib/concurrent/mutable_struct.rb
+++ b/lib/concurrent/mutable_struct.rb
@@ -169,6 +169,16 @@ module Concurrent
       synchronize { ns_select(&block) }
     end
 
+    # @!macro struct_initialize_copy
+    #
+    # @!visibility private
+    def initialize_copy(original)
+      synchronize do
+        super
+        ns_initialize_copy
+      end
+    end
+
     # @!macro struct_set
     #
     #   Attribute Assignment

--- a/lib/concurrent/settable_struct.rb
+++ b/lib/concurrent/settable_struct.rb
@@ -69,16 +69,6 @@ module Concurrent
       synchronize { ns_select(&block) }
     end
 
-    # @!macro struct_initialize_copy
-    #
-    # @!visibility private
-    def initialize_copy(original)
-      synchronize do
-        super
-        ns_initialize_copy
-      end
-    end
-
     # @!macro struct_set
     #
     # @raise [Concurrent::ImmutabilityError] if the given member has already been set
@@ -99,6 +89,16 @@ module Concurrent
       end
     rescue NoMethodError
       raise NameError.new("no member '#{member}' in struct")
+    end
+
+    private
+
+    # @!visibility private
+    def initialize_copy(original)
+      synchronize do
+        super(original)
+        ns_initialize_copy
+      end
     end
 
     # @!macro struct_new

--- a/lib/concurrent/settable_struct.rb
+++ b/lib/concurrent/settable_struct.rb
@@ -69,6 +69,16 @@ module Concurrent
       synchronize { ns_select(&block) }
     end
 
+    # @!macro struct_initialize_copy
+    #
+    # @!visibility private
+    def initialize_copy(original)
+      synchronize do
+        super
+        ns_initialize_copy
+      end
+    end
+
     # @!macro struct_set
     #
     # @raise [Concurrent::ImmutabilityError] if the given member has already been set

--- a/lib/concurrent/synchronization/abstract_struct.rb
+++ b/lib/concurrent/synchronization/abstract_struct.rb
@@ -115,8 +115,6 @@ module Concurrent
         self.class.new(*self.to_h.merge(other, &block).values)
       end
 
-      # @!macro struct_initialize_copy
-      #
       # @!visibility private
       def ns_initialize_copy
         @values = @values.map(&:clone)

--- a/lib/concurrent/synchronization/abstract_struct.rb
+++ b/lib/concurrent/synchronization/abstract_struct.rb
@@ -115,6 +115,13 @@ module Concurrent
         self.class.new(*self.to_h.merge(other, &block).values)
       end
 
+      # @!macro struct_initialize_copy
+      #
+      # @!visibility private
+      def ns_initialize_copy
+        @values = @values.map(&:clone)
+      end
+
       # @!visibility private
       def pr_underscore(clazz)
         word = clazz.to_s.dup # dup string to workaround JRuby 9.2.0.0 bug https://github.com/jruby/jruby/issues/5229

--- a/lib/concurrent/synchronization/abstract_struct.rb
+++ b/lib/concurrent/synchronization/abstract_struct.rb
@@ -117,7 +117,13 @@ module Concurrent
 
       # @!visibility private
       def ns_initialize_copy
-        @values = @values.map(&:clone)
+        @values = @values.map do |val|
+          begin
+            val.clone
+          rescue TypeError
+            val
+          end
+        end
       end
 
       # @!visibility private

--- a/spec/concurrent/mutable_struct_spec.rb
+++ b/spec/concurrent/mutable_struct_spec.rb
@@ -149,6 +149,25 @@ module Concurrent
         expect(subject).to receive(:synchronize).at_least(:once).with(no_args).and_call_original
         subject.select{|value| false }
       end
+
+      it 'protects #initialize_copy' do
+        expect(subject).to receive(:synchronize).at_least(:once).with(no_args).and_call_original
+        subject.clone
+      end
+    end
+
+    context 'copy' do
+      context '#dup' do
+        it 'mutates only the copy' do
+          expect(subject.dup.name = 'Jane').not_to eq(subject.name)
+        end
+      end
+
+      context '#clone' do
+        it 'mutates only the copy' do
+          expect(subject.clone.name = 'Jane').not_to eq(subject.name)
+        end
+      end
     end
   end
 end

--- a/spec/concurrent/settable_struct_spec.rb
+++ b/spec/concurrent/settable_struct_spec.rb
@@ -171,6 +171,31 @@ module Concurrent
         expect(subject).to receive(:synchronize).at_least(:once).with(no_args).and_call_original
         subject.select{|value| false }
       end
+
+      it 'protects #initialize_copy' do
+        expect(subject).to receive(:synchronize).at_least(:once).with(no_args).and_call_original
+        subject.clone
+      end
+    end
+
+    context 'copy' do
+      context '#dup' do
+        it 'retains settability of members' do
+          subject['name'] = 'John'
+          expect { subject.dup['name'] = 'Jane' }
+            .to raise_error(ImmutabilityError)
+          expect(subject['address'] = 'Earth').to eq('Earth')
+        end
+      end
+
+      context '#clone' do
+        it 'retains settability of members' do
+          subject['name'] = 'John'
+          expect { subject.clone['name'] = 'Jane' }
+            .to raise_error(ImmutabilityError)
+          expect(subject['address'] = 'Earth').to eq('Earth')
+        end
+      end
     end
   end
 end

--- a/spec/concurrent/struct_shared.rb
+++ b/spec/concurrent/struct_shared.rb
@@ -437,6 +437,69 @@ RSpec.shared_examples :struct do
       end
     end
   end
+
+  context 'copy' do
+    let(:this) do
+      described_class.new(:foo, :bar, :baz).new('foo'.freeze, ['bar'], 42)
+    end
+
+    context '#dup' do
+      it 'shallowly duplicates all members along with the struct' do
+        copy = this.dup
+        expect(copy.foo).not_to be this.foo
+        expect(copy.bar).not_to be this.bar
+        expect(copy.bar.first).to be this.bar.first
+        expect(copy.baz).to be this.baz
+      end
+
+      it 'discards frozen state of the struct' do
+        expect(this.freeze.dup).not_to be_frozen
+      end
+
+      it 'retains frozen state of members' do
+        expect(this.dup.foo).to be_frozen
+      end
+
+      it 'discards singleton class' do
+        this.define_singleton_method(:qux) { 'qux' }
+        expect(this.qux).to eq('qux')
+        expect{this.dup.qux}.to raise_error(NoMethodError)
+      end
+
+      it 'copies the singleton class of members' do
+        this.bar.define_singleton_method(:qux) { 'qux' }
+        expect(this.bar.qux).to eq('qux')
+        expect(this.dup.bar.qux).to eq('qux')
+      end
+    end
+
+    context '#clone' do
+      it 'shallowly clones all members along with the struct' do
+        copy = this.clone
+        expect(copy.foo).not_to be this.foo
+        expect(copy.bar).not_to be this.bar
+        expect(copy.bar.first).to be this.bar.first
+        expect(copy.baz).to be this.baz
+      end
+
+      it 'retains frozen state' do
+        expect(this.freeze.clone).to be_frozen
+        expect(this.clone.foo).to be_frozen
+      end
+
+      it 'copies the singleton class' do
+        this.define_singleton_method(:qux) { 'qux' }
+        expect(this.qux).to eq('qux')
+        expect(this.clone.qux).to eq('qux')
+      end
+
+      it 'copies the singleton class of members' do
+        this.bar.define_singleton_method(:qux) { 'qux' }
+        expect(this.bar.qux).to eq('qux')
+        expect(this.clone.bar.qux).to eq('qux')
+      end
+    end
+  end
 end
 
 RSpec.shared_examples :mergeable_struct do


### PR DESCRIPTION
This fixes #836 

### Why are the changes necessary?

When calling `#dup` or `#clone` on a plain old Ruby Struct the member values
are copied along with the Struct's instance. This is not true for MutableStruct,
SettableStruct or ImmutableStruct.

This is especially troublesome for MutableStruct since mutating a member value
of a copy would also mutate the original. It is also a problem when any of
Concurrent Ruby's Struct classes has a mutable member value, e.g., an array.
Changes to that array would be reflected in the original and the copy since they
essentially share the same array.

### What does this pull request cover?

* Implement `initialize_copy` for Concurrent Ruby's Struct classes to copy the
  member values when `dup` or `clone` are called.
* Add tests to ensure Struct classes behave just like plain old Ruby Structs:
  * dup does not preserve taints (singleton class, frozen state)
  * clone does preserve taints
  * clone and dup both preserve taints of member values
  * copies are shallow
* Add tests to ensure dup and clone of `MutableStruct` and `SettableStruct`
  are protected (synchronization)