### PR TITLE
CI: Use 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
   fast_finish: true
   include:
     # Latest versions first
-    - name: MRI 2.6.5 Latest
-      rvm: 2.6.5
+    - name: MRI 2.7.0 Latest
+      rvm: 2.7.0
     - name: JRuby 9.2.9.0 Latest on Java 11
       rvm: jruby-9.2.9.0
       jdk: oraclejdk11
@@ -18,12 +18,14 @@ matrix:
     - name: TruffleRuby Latest
       rvm: truffleruby
     - name: YARD uptodate in docs
-      rvm: 2.6.5
+      rvm: 2.7.0
       script:
       - bundle install --with documentation
       - bundle exec rake yard:master:uptodate
 
     # Older versions follow
+    - name: MRI 2.6.5
+      rvm: 2.6.5
     - name: MRI 2.5.7
       rvm: 2.5.7
     - name: MRI 2.4.9


### PR DESCRIPTION
This PR adds Ruby 2.7.0 to the CI matrix