### PR TITLE
Ruby 2.7+: delegate kwags explicitely

### DIFF
--- a/lib/concurrent-ruby-edge/concurrent/edge/erlang_actor.rb
+++ b/lib/concurrent-ruby-edge/concurrent/edge/erlang_actor.rb
@@ -531,8 +531,8 @@ module Concurrent
     module FunctionShortcuts
       # Optionally included shortcut method for {Functions#spawn_actor}
       # @return [Pid]
-      def spawn(*args, &body)
-        spawn_actor(*args, &body)
+      def spawn(*args, **kwargs, &body)
+        spawn_actor(*args, **kwargs, &body)
       end
 
       # Optionally included shortcut method for {Functions#terminate_actor}


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

fixes
<code>
/home/travis/build/ruby-concurrency/concurrent-ruby/lib/concurrent-ruby-edge/concurrent/edge/erlang_actor.rb:535: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
</code>
<code>
/home/travis/build/ruby-concurrency/concurrent-ruby/lib/concurrent-ruby-edge/concurrent/edge/erlang_actor.rb:492: warning: The called method `spawn_actor' is defined here
</code>
