### PR TITLE
Make CRuby Set thread safe

### DIFF
--- a/lib/concurrent-ruby/concurrent/thread_safe/util/data_structures.rb
+++ b/lib/concurrent-ruby/concurrent/thread_safe/util/data_structures.rb
@@ -17,7 +17,7 @@ module Concurrent
           private
 
           def _mon_initialize
-            @_monitor = Monitor.new unless @_monitor # avoid double initialisation
+            @_monitor ||= Monitor.new # avoid double initialisation
           end
 
           def self.new(*args)


### PR DESCRIPTION
Follow similar pattern for Rbx to wrap every superclass (::Set) instance
method with a Monitor (which is re-entrant).

Included is a test that I believe *would* occasionally fail
if Set was not thread safe.

fixes #796