### PR TITLE
Remove un-needed line in TimerTask

### DIFF
--- a/lib/concurrent-ruby/concurrent/timer_task.rb
+++ b/lib/concurrent-ruby/concurrent/timer_task.rb
@@ -325,7 +325,6 @@ module Concurrent
     def timeout_task(completion)
       return unless @running.true?
       if completion.try?
-        self.value = value
         schedule_next_task
         observers.notify_observers(Time.now, nil, Concurrent::TimeoutError.new)
       end


### PR DESCRIPTION
Removed `self.value = value` in TimerTask#timeout_task

This line was probably added as a copy-mistake from the above
method (execute_task).

I ran `brake spec SPEC=spec/concurrent/timer_task_spec.rb` and the tests pass.
I can't see why the need to self-assign the variable here.

co-author: @kalenp