### PR TITLE
Introduce ThreadPoolExecutor without a Queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Current
 
+concurrent-ruby:
+
+* (#853) Introduce ThreadPoolExecutor without a Queue
+
 ## Release v1.1.6, edge v0.6.0 (10 Feb 2020)
 
 concurrent-ruby:

--- a/lib/concurrent-ruby/concurrent/executor/fixed_thread_pool.rb
+++ b/lib/concurrent-ruby/concurrent/executor/fixed_thread_pool.rb
@@ -16,6 +16,9 @@ module Concurrent
   #   Default maximum number of seconds a thread in the pool may remain idle
   #   before being reclaimed.
 
+  # @!macro thread_pool_executor_constant_default_synchronous
+  #   Default value of the :synchronous option.
+
   # @!macro thread_pool_executor_attr_reader_max_length
   #   The maximum number of threads that may be created in the pool.
   #   @return [Integer] The maximum number of threads that may be created in the pool.
@@ -39,6 +42,10 @@ module Concurrent
   # @!macro thread_pool_executor_attr_reader_idletime
   #   The number of seconds that a thread may be idle before being reclaimed.
   #   @return [Integer] The number of seconds that a thread may be idle before being reclaimed.
+
+  # @!macro thread_pool_executor_attr_reader_synchronous
+  #   Whether or not a value of 0 for :max_queue option means the queue must perform direct hand-off or rather unbounded queue.
+  #   @return [true, false]
 
   # @!macro thread_pool_executor_attr_reader_max_queue
   #   The maximum number of tasks that may be waiting in the work queue at any one time.

--- a/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb
@@ -3,7 +3,6 @@ require 'concurrent/atomic/event'
 require 'concurrent/concern/logging'
 require 'concurrent/executor/ruby_executor_service'
 require 'concurrent/utility/monotonic_time'
-require 'concurrent/mvar'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb
@@ -209,9 +209,7 @@ module Concurrent
     #
     # @!visibility private
     def ns_enqueue(*args, &task)
-      if @synchronous
-        return false
-      end
+      return false if @synchronous
       
       if !ns_limited_queue? || @queue.size < @max_queue
         @queue << [task, args]

--- a/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb
@@ -246,7 +246,7 @@ module Concurrent
     #
     # @!visibility private
     def ns_ready_worker(worker, success = true)
-        task_and_args = @queue.shift
+      task_and_args = @queue.shift
       if task_and_args
         worker << task_and_args
       else

--- a/lib/concurrent-ruby/concurrent/executor/thread_pool_executor.rb
+++ b/lib/concurrent-ruby/concurrent/executor/thread_pool_executor.rb
@@ -73,7 +73,8 @@ module Concurrent
     #   @option opts [Symbol] :fallback_policy (:abort) the policy for handling new
     #     tasks that are received when the queue size has reached
     #     `max_queue` or the executor has shut down
-    #
+    #   @options opts [Boolean] :synchronous (DEFAULT_SYNCHRONOUS) whether or not a value of 0
+    #     for :max_queue means the queue must perform direct hand-off rather than unbounded.
     #   @raise [ArgumentError] if `:max_threads` is less than one
     #   @raise [ArgumentError] if `:min_threads` is less than zero
     #   @raise [ArgumentError] if `:fallback_policy` is not one of the values specified

--- a/lib/concurrent-ruby/concurrent/executor/thread_pool_executor.rb
+++ b/lib/concurrent-ruby/concurrent/executor/thread_pool_executor.rb
@@ -73,7 +73,7 @@ module Concurrent
     #   @option opts [Symbol] :fallback_policy (:abort) the policy for handling new
     #     tasks that are received when the queue size has reached
     #     `max_queue` or the executor has shut down
-    #   @options opts [Boolean] :synchronous (DEFAULT_SYNCHRONOUS) whether or not a value of 0
+    #   @option opts [Boolean] :synchronous (DEFAULT_SYNCHRONOUS) whether or not a value of 0
     #     for :max_queue means the queue must perform direct hand-off rather than unbounded.
     #   @raise [ArgumentError] if `:max_threads` is less than one
     #   @raise [ArgumentError] if `:min_threads` is less than zero


### PR DESCRIPTION
This adds the ability for a ThreadPoolExecutor to have a queue
depth of 0.

This is useful if you'd like to perform the rejection handler if no
available threads are availabile.

This is analogous to Java's use of SynchronousQueue in
ThreadPoolExecutor.

See https://stackoverflow.com/a/10186825/143733 for more details