### PR TITLE
CI: add jruby-9.2.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     # Latest versions first
     - name: MRI 2.7.0 Latest
       rvm: 2.7.0
-    - name: JRuby 9.2.10.0 Latest on Java 11
-      rvm: jruby-9.2.10.0
+    - name: JRuby 9.2.11.0 Latest on Java 11
+      rvm: jruby-9.2.11.0
       jdk: oraclejdk11
-    - name: JRuby 9.2.10.0 Latest on Java 8
-      rvm: jruby-9.2.10.0
+    - name: JRuby 9.2.11.0 Latest on Java 8
+      rvm: jruby-9.2.11.0
       jdk: openjdk8
     - name: TruffleRuby Latest
       rvm: truffleruby


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.11.0**.

[JRuby 9.2.11.0 release blog post](https://www.jruby.org/2020/03/02/jruby-9-2-11-0.html)