### PR TITLE
CI: Rubinius as rbx-3.107, on Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,8 @@ matrix:
       jdk: openjdk8
 
     - name: Rubinius
-      rvm: rbx-3
+      rvm: rbx-3.107
+      dist: trusty
 
     - name: Coverage on MRI 2.3.8
       rvm: 2.3.8
@@ -66,7 +67,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: rbx-3
+    - name: Rubinius
     - name: TruffleRuby Latest
     - name: YARD uptodate in docs
 


### PR DESCRIPTION
This PR tries to make Rubinius CI builds work.

# Solution

Travis config for Rubinius:

  - use the `rbx-3.107` moniker seen in https://github.com/rubinius/travis-canary/pull/3
  - in `allowed_failures`: Use the `name` property to find the matrix member (to reduce churn if trying new versions)
  - ~point out macOS and which [osx image to use](https://docs.travis-ci.com/user/reference/osx/)~
  - use Trusty

(The macOS attempts failed. llvm missing c++ libraries. `Libraries missing for rbx-3.107: /usr/local/opt/llvm/lib/libc++.1.dylib. Refer to your system manual for installing libraries`)

# Background

Our Travis file's Rubinius build config is set with `rbx-3` which does not resolve in rvm to anything installable.

Compared to a 2019 working build, in Rubinius's canary repo at https://travis-ci.org/rubinius/travis-canary/builds/488215948/config


Travis has information:

- http://rubies.travis-ci.org/rubinius

