### PR TITLE
CI: Use jruby-9.2.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     # Latest versions first
     - name: MRI 2.7.0 Latest
       rvm: 2.7.0
-    - name: JRuby 9.2.11.0 Latest on Java 11
-      rvm: jruby-9.2.11.0
+    - name: JRuby 9.2.11.1 Latest on Java 11
+      rvm: jruby-9.2.11.1
       jdk: oraclejdk11
-    - name: JRuby 9.2.11.0 Latest on Java 8
-      rvm: jruby-9.2.11.0
+    - name: JRuby 9.2.11.1 Latest on Java 8
+      rvm: jruby-9.2.11.1
       jdk: openjdk8
     - name: TruffleRuby Latest
       rvm: truffleruby


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.11.1**.

[JRuby 9.2.11.1 release blog post](https://www.jruby.org/2020/03/25/jruby-9-2-11-1.html)