### PR TITLE
Child promise state not set to :pending immediately after #execute when parent has completed

### DIFF
--- a/lib/concurrent-ruby/concurrent/promise.rb
+++ b/lib/concurrent-ruby/concurrent/promise.rb
@@ -250,6 +250,7 @@ module Concurrent
           realize(@promise_body)
         end
       else
+        compare_and_set_state(:pending, :unscheduled)
         @parent.execute
       end
       self

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -195,6 +195,14 @@ module Concurrent
             end_latch.count_down
           end
         end
+
+        context "when called on child after parent completes" do
+          let(:parent_promise) { Concurrent::Promise.execute { 1 + 1 }.tap { |p| p.wait } }
+          it 'sets state to :pending immediately' do
+            child_promise = parent_promise.then { |two| two + 2 }.execute
+            expect(child_promise.state).to eq(:pending)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
1. Create a parent promise and wait for it to complete
2. Create a child promise chain off the parent (via a call to `then`, `on_success`, etc)
3. Call `execute` on the child promise
4. Immediately check the state of the child promise
5. This state will be `:unscheduled`.

Expectation: It should be `:pending`.
