### PR TITLE
Removes references to static Ruby versions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ We also have a [IRC (gitter)](https://gitter.im/ruby-concurrency/concurrent-ruby
 Collection classes that were originally part of the (deprecated) `thread_safe` gem:
 
 *   [Array](http://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/Array.html) A thread-safe
-    subclass of Ruby's standard [Array](http://ruby-doc.org/core-2.2.0/Array.html).
+    subclass of Ruby's standard [Array](http://ruby-doc.org/core/Array.html).
 *   [Hash](http://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/Hash.html) A thread-safe
-    subclass of Ruby's standard [Hash](http://ruby-doc.org/core-2.2.0/Hash.html).
+    subclass of Ruby's standard [Hash](http://ruby-doc.org/core/Hash.html).
 *   [Set](http://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/Set.html) A thread-safe
     subclass of Ruby's standard [Set](http://ruby-doc.org/stdlib-2.4.0/libdoc/set/rdoc/Set.html).
 *   [Map](http://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/Map.html) A hash-like object
@@ -122,7 +122,7 @@ Value objects inspired by other languages:
     immutable object representing an optional value, based on 
     [Haskell Data.Maybe](https://hackage.haskell.org/package/base-4.2.0.1/docs/Data-Maybe.html).
 
-Structure classes derived from Ruby's [Struct](http://ruby-doc.org/core-2.2.0/Struct.html):
+Structure classes derived from Ruby's [Struct](http://ruby-doc.org/core/Struct.html):
 
 *   [ImmutableStruct](http://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/ImmutableStruct.html)
     Immutable struct where values are set at construction and cannot be changed later.

--- a/lib/concurrent-ruby/concurrent/array.rb
+++ b/lib/concurrent-ruby/concurrent/array.rb
@@ -16,7 +16,7 @@ module Concurrent
   #     operation therefore when two `+=` operations are executed concurrently updates
   #     may be lost. Use `#concat` instead.
   #
-  #   @see http://ruby-doc.org/core-2.2.0/Array.html Ruby standard library `Array`
+  #   @see http://ruby-doc.org/core/Array.html Ruby standard library `Array`
 
   # @!macro internal_implementation_note
   ArrayImplementation = case

--- a/lib/concurrent-ruby/concurrent/hash.rb
+++ b/lib/concurrent-ruby/concurrent/hash.rb
@@ -10,7 +10,7 @@ module Concurrent
   #   or writing at a time. This includes iteration methods like `#each`,
   #   which takes the lock repeatedly when reading an item.
   #
-  #   @see http://ruby-doc.org/core-2.2.0/Hash.html Ruby standard library `Hash`
+  #   @see http://ruby-doc.org/core/Hash.html Ruby standard library `Hash`
 
   # @!macro internal_implementation_note
   HashImplementation = case

--- a/lib/concurrent-ruby/concurrent/immutable_struct.rb
+++ b/lib/concurrent-ruby/concurrent/immutable_struct.rb
@@ -5,7 +5,7 @@ module Concurrent
 
   # A thread-safe, immutable variation of Ruby's standard `Struct`.
   #
-  # @see http://ruby-doc.org/core-2.2.0/Struct.html Ruby standard library `Struct`
+  # @see http://ruby-doc.org/core/Struct.html Ruby standard library `Struct`
   module ImmutableStruct
     include Synchronization::AbstractStruct
 

--- a/lib/concurrent-ruby/concurrent/mutable_struct.rb
+++ b/lib/concurrent-ruby/concurrent/mutable_struct.rb
@@ -6,7 +6,7 @@ module Concurrent
   # An thread-safe variation of Ruby's standard `Struct`. Values can be set at
   # construction or safely changed at any time during the object's lifecycle.
   #
-  # @see http://ruby-doc.org/core-2.2.0/Struct.html Ruby standard library `Struct`
+  # @see http://ruby-doc.org/core/Struct.html Ruby standard library `Struct`
   module MutableStruct
     include Synchronization::AbstractStruct
 
@@ -40,7 +40,7 @@ module Concurrent
     #   struct. Unset parameters default to nil. Passing more parameters than number of attributes
     #   will raise an `ArgumentError`.
     #
-    #   @see http://ruby-doc.org/core-2.2.0/Struct.html#method-c-new Ruby standard library `Struct#new`
+    #   @see http://ruby-doc.org/core/Struct.html#method-c-new Ruby standard library `Struct#new`
 
     # @!macro struct_values
     #

--- a/lib/concurrent-ruby/concurrent/settable_struct.rb
+++ b/lib/concurrent-ruby/concurrent/settable_struct.rb
@@ -9,7 +9,7 @@ module Concurrent
   # or any time thereafter. Attempting to assign a value to a member
   # that has already been set will result in a `Concurrent::ImmutabilityError`.
   #
-  # @see http://ruby-doc.org/core-2.2.0/Struct.html Ruby standard library `Struct`
+  # @see http://ruby-doc.org/core/Struct.html Ruby standard library `Struct`
   # @see http://en.wikipedia.org/wiki/Final_(Java) Java `final` keyword
   module SettableStruct
     include Synchronization::AbstractStruct

--- a/lib/concurrent-ruby/concurrent/synchronization/lockable_object.rb
+++ b/lib/concurrent-ruby/concurrent/synchronization/lockable_object.rb
@@ -26,8 +26,8 @@ module Concurrent
     #   the classes using it. Use {Synchronization::Object} not this abstract class.
     #
     #   @note this object does not support usage together with
-    #     [`Thread#wakeup`](http://ruby-doc.org/core-2.2.0/Thread.html#method-i-wakeup)
-    #     and [`Thread#raise`](http://ruby-doc.org/core-2.2.0/Thread.html#method-i-raise).
+    #     [`Thread#wakeup`](http://ruby-doc.org/core/Thread.html#method-i-wakeup)
+    #     and [`Thread#raise`](http://ruby-doc.org/core/Thread.html#method-i-raise).
     #     `Thread#sleep` and `Thread#wakeup` will work as expected but mixing `Synchronization::Object#wait` and
     #     `Thread#wakeup` will not work on all platforms.
     #


### PR DESCRIPTION
This change removes references to Ruby 2.2.0 in favor of referencing the
latest version of Ruby. By referencing just `core` rather than
`core-x.y.z` the Ruby docs site will forward to the latest applicable
version.