### PR TITLE
CI: Update latest JRuby to 9.2.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     # Latest versions first
     - name: MRI 2.7.0 Latest
       rvm: 2.7.0
-    - name: JRuby 9.2.14.0 Latest on Java 11
-      rvm: jruby-9.2.14.0
+    - name: JRuby 9.2.15.0 Latest on Java 11
+      rvm: jruby-9.2.15.0
       jdk: oraclejdk11
-    - name: JRuby 9.2.14.0 Latest on Java 8
-      rvm: jruby-9.2.14.0
+    - name: JRuby 9.2.15.0 Latest on Java 8
+      rvm: jruby-9.2.15.0
       jdk: openjdk8
     - name: TruffleRuby Latest
       rvm: truffleruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     # Latest versions first
     - name: MRI 2.7.0 Latest
       rvm: 2.7.0
-    - name: JRuby 9.2.15.0 Latest on Java 11
-      rvm: jruby-9.2.15.0
+    - name: JRuby 9.2.16.0 Latest on Java 11
+      rvm: jruby-9.2.16.0
       jdk: oraclejdk11
-    - name: JRuby 9.2.15.0 Latest on Java 8
-      rvm: jruby-9.2.15.0
+    - name: JRuby 9.2.16.0 Latest on Java 8
+      rvm: jruby-9.2.16.0
       jdk: openjdk8
     - name: TruffleRuby Latest
       rvm: truffleruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     # Latest versions first
     - name: MRI 2.7.0 Latest
       rvm: 2.7.0
-    - name: JRuby 9.2.11.1 Latest on Java 11
-      rvm: jruby-9.2.11.1
+    - name: JRuby 9.2.14.0 Latest on Java 11
+      rvm: jruby-9.2.14.0
       jdk: oraclejdk11
-    - name: JRuby 9.2.11.1 Latest on Java 8
-      rvm: jruby-9.2.11.1
+    - name: JRuby 9.2.14.0 Latest on Java 8
+      rvm: jruby-9.2.14.0
       jdk: openjdk8
     - name: TruffleRuby Latest
       rvm: truffleruby


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.16.0**.

[JRuby 9.2.16.0 release blog post](https://www.jruby.org/2021/03/03/jruby-9-2-16-0.html)