### PR TITLE
Fixed documentation for Concurrent::Map

### DIFF
--- a/docs/master/Concurrent/Map.html
+++ b/docs/master/Concurrent/Map.html
@@ -157,6 +157,31 @@ does. For most uses it should do fine though, and we recommend you consider
         <li class="public ">
   <span class="summary_signature">
     
+      <a href="#[]=-instance_method" title="#[]= (instance method)">#<strong>[]=</strong>(key, value)  &#x21d2; Object </a>
+    
+
+    
+      (also: #put)
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'><p>Set a value with key.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
       <a href="#compute-instance_method" title="#compute (instance method)">#<strong>compute</strong>(key) {|old_value| ... } &#x21d2; Object, nil </a>
     
 
@@ -830,6 +855,93 @@ does. For most uses it should do fine though, and we recommend you consider
 </div>
     
       <div class="method_details ">
+  <h3 class="signature " id="[]=-instance_method">
+  
+    #<strong>[]=</strong>(key, value)  &#x21d2; <tt>Object</tt> 
+  
+
+  
+    <span class="aliases">Also known as:
+    <span class="names"><span id='put-instance_method'>put</span></span>
+    </span>
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    <p>Set a value with key</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>key</span>
+      
+      
+        <span class='type'>(<tt>Object</tt>)</span>
+      
+      
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>value</span>
+      
+      
+        <span class='type'>(<tt>Object</tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Object</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>the new value</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+150
+151
+152</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 150</span>
+
+<span class='kw'>def</span> <span class='op'>[]=</span><span class='lparen'>(</span><span class='id identifier rubyid_key'>key</span><span class='comma'>,</span> <span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
+  <span class='kw'>super</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
   <h3 class="signature " id="compute-instance_method">
   
     #<strong>compute</strong>(key) {|old_value| ... } &#x21d2; <tt>Object</tt>, <tt>nil</tt> 
@@ -1424,12 +1536,12 @@ This method is atomic.</p>
       <pre class="lines">
 
 
-241
-242
-243</pre>
+248
+249
+250</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 241</span>
+      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 248</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_each_key'>each_key</span>
   <span class='id identifier rubyid_each_pair'>each_pair</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_k'>k</span><span class='comma'>,</span> <span class='id identifier rubyid_v'>v</span><span class='op'>|</span> <span class='kw'>yield</span> <span class='id identifier rubyid_k'>k</span> <span class='rbrace'>}</span>
@@ -1533,13 +1645,13 @@ This method is atomic.</p>
       <pre class="lines">
 
 
-260
-261
-262
-263</pre>
+267
+268
+269
+270</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 260</span>
+      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 267</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_each_pair'>each_pair</span>
   <span class='kw'>return</span> <span class='id identifier rubyid_enum_for'>enum_for</span> <span class='symbol'>:each_pair</span> <span class='kw'>unless</span> <span class='id identifier rubyid_block_given?'>block_given?</span>
@@ -1629,12 +1741,12 @@ This method is atomic.</p>
       <pre class="lines">
 
 
-250
-251
-252</pre>
+257
+258
+259</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 250</span>
+      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 257</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_each_value'>each_value</span>
   <span class='id identifier rubyid_each_pair'>each_pair</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_k'>k</span><span class='comma'>,</span> <span class='id identifier rubyid_v'>v</span><span class='op'>|</span> <span class='kw'>yield</span> <span class='id identifier rubyid_v'>v</span> <span class='rbrace'>}</span>
@@ -1682,13 +1794,13 @@ This method is atomic.</p>
       <pre class="lines">
 
 
-278
-279
-280
-281</pre>
+285
+286
+287
+288</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 278</span>
+      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 285</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_empty?'>empty?</span>
   <span class='id identifier rubyid_each_pair'>each_pair</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_k'>k</span><span class='comma'>,</span> <span class='id identifier rubyid_v'>v</span><span class='op'>|</span> <span class='kw'>return</span> <span class='kw'>false</span> <span class='rbrace'>}</span>
@@ -1850,20 +1962,20 @@ or fail when no default_value is given.</p>
       <pre class="lines">
 
 
-168
-169
-170
-171
-172
-173
-174
 175
 176
 177
-178</pre>
+178
+179
+180
+181
+182
+183
+184
+185</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 168</span>
+      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 175</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='id identifier rubyid_key'>key</span><span class='comma'>,</span> <span class='id identifier rubyid_default_value'>default_value</span> <span class='op'>=</span> <span class='const'>NULL</span><span class='rparen'>)</span>
   <span class='kw'>if</span> <span class='const'>NULL</span> <span class='op'>!=</span> <span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span> <span class='op'>=</span> <span class='id identifier rubyid_get_or_default'>get_or_default</span><span class='lparen'>(</span><span class='id identifier rubyid_key'>key</span><span class='comma'>,</span> <span class='const'>NULL</span><span class='rparen'>)</span><span class='rparen'>)</span>
@@ -2012,14 +2124,14 @@ This method is atomic.</p>
       <pre class="lines">
 
 
-191
-192
-193
-194
-195</pre>
+198
+199
+200
+201
+202</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 191</span>
+      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 198</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_fetch_or_store'>fetch_or_store</span><span class='lparen'>(</span><span class='id identifier rubyid_key'>key</span><span class='comma'>,</span> <span class='id identifier rubyid_default_value'>default_value</span> <span class='op'>=</span> <span class='const'>NULL</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='id identifier rubyid_key'>key</span><span class='rparen'>)</span> <span class='kw'>do</span>
@@ -2172,13 +2284,13 @@ This method is atomic.</p>
       <pre class="lines">
 
 
-270
-271
-272
-273</pre>
+277
+278
+279
+280</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 270</span>
+      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 277</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_key'>key</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_each_pair'>each_pair</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_k'>k</span><span class='comma'>,</span> <span class='id identifier rubyid_v'>v</span><span class='op'>|</span> <span class='kw'>return</span> <span class='id identifier rubyid_k'>k</span> <span class='kw'>if</span> <span class='id identifier rubyid_v'>v</span> <span class='op'>==</span> <span class='id identifier rubyid_value'>value</span> <span class='rbrace'>}</span>
@@ -2231,14 +2343,14 @@ This method is atomic.</p>
       <pre class="lines">
 
 
-222
-223
-224
-225
-226</pre>
+229
+230
+231
+232
+233</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 222</span>
+      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 229</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_keys'>keys</span>
   <span class='id identifier rubyid_arr'>arr</span> <span class='op'>=</span> <span class='lbracket'>[</span><span class='rbracket'>]</span>
@@ -2460,17 +2572,17 @@ This method is atomic.</p>
       <pre class="lines">
 
 
-201
-202
-203
-204
-205
-206
-207
-208</pre>
+208
+209
+210
+211
+212
+213
+214
+215</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 201</span>
+      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 208</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_put_if_absent'>put_if_absent</span><span class='lparen'>(</span><span class='id identifier rubyid_key'>key</span><span class='comma'>,</span> <span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_computed'>computed</span> <span class='op'>=</span> <span class='kw'>false</span>
@@ -2699,14 +2811,14 @@ This method is atomic.</p>
       <pre class="lines">
 
 
-285
-286
-287
-288
-289</pre>
+292
+293
+294
+295
+296</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 285</span>
+      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 292</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_size'>size</span>
   <span class='id identifier rubyid_count'>count</span> <span class='op'>=</span> <span class='int'>0</span>
@@ -2771,15 +2883,15 @@ This method is atomic.</p>
       <pre class="lines">
 
 
-213
-214
-215
-216
-217
-218</pre>
+220
+221
+222
+223
+224
+225</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 213</span>
+      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 220</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_value?'>value?</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_each_value'>each_value</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_v'>v</span><span class='op'>|</span>
@@ -2834,14 +2946,14 @@ This method is atomic.</p>
       <pre class="lines">
 
 
-230
-231
-232
-233
-234</pre>
+237
+238
+239
+240
+241</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 230</span>
+      <pre class="code"><span class="info file"># File 'lib/concurrent-ruby/concurrent/map.rb', line 237</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_values'>values</span>
   <span class='id identifier rubyid_arr'>arr</span> <span class='op'>=</span> <span class='lbracket'>[</span><span class='rbracket'>]</span>

--- a/docs/master/method_list.html
+++ b/docs/master/method_list.html
@@ -46,16 +46,32 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Agent.html#<<-instance_method" title="Concurrent::Agent#&lt;&lt; (method)">#&lt;&lt;</a></span>
-      <small>Concurrent::Agent</small>
+      <span class='object_link'><a href="Concurrent/ImmediateExecutor.html#<<-instance_method" title="Concurrent::ImmediateExecutor#&lt;&lt; (method)">#&lt;&lt;</a></span>
+      <small>Concurrent::ImmediateExecutor</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/SimpleExecutorService.html#<<-instance_method" title="Concurrent::SimpleExecutorService#&lt;&lt; (method)">#&lt;&lt;</a></span>
+      <span class='object_link'><a href="Concurrent/SimpleExecutorService.html#<<-class_method" title="Concurrent::SimpleExecutorService.&lt;&lt; (method)">&lt;&lt;</a></span>
       <small>Concurrent::SimpleExecutorService</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#<<-instance_method" title="Concurrent::ThreadPoolExecutor#&lt;&lt; (method)">#&lt;&lt;</a></span>
+      <small>Concurrent::ThreadPoolExecutor</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Agent.html#<<-instance_method" title="Concurrent::Agent#&lt;&lt; (method)">#&lt;&lt;</a></span>
+      <small>Concurrent::Agent</small>
     </div>
   </li>
   
@@ -70,22 +86,6 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#<<-instance_method" title="Concurrent::ThreadPoolExecutor#&lt;&lt; (method)">#&lt;&lt;</a></span>
-      <small>Concurrent::ThreadPoolExecutor</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/ImmediateExecutor.html#<<-instance_method" title="Concurrent::ImmediateExecutor#&lt;&lt; (method)">#&lt;&lt;</a></span>
-      <small>Concurrent::ImmediateExecutor</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#<<-instance_method" title="Concurrent::SingleThreadExecutor#&lt;&lt; (method)">#&lt;&lt;</a></span>
       <small>Concurrent::SingleThreadExecutor</small>
     </div>
@@ -94,24 +94,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/SimpleExecutorService.html#<<-class_method" title="Concurrent::SimpleExecutorService.&lt;&lt; (method)">&lt;&lt;</a></span>
+      <span class='object_link'><a href="Concurrent/SimpleExecutorService.html#<<-instance_method" title="Concurrent::SimpleExecutorService#&lt;&lt; (method)">#&lt;&lt;</a></span>
       <small>Concurrent::SimpleExecutorService</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Node.html#<=>-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Node#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
-      <small>Concurrent::Edge::LockFreeLinkedSet::Node</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Head.html#<=>-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Head#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
-      <small>Concurrent::Edge::LockFreeLinkedSet::Head</small>
     </div>
   </li>
   
@@ -134,16 +118,32 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Tail.html#<=>-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Tail#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
-      <small>Concurrent::Edge::LockFreeLinkedSet::Tail</small>
+      <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Node.html#<=>-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Node#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
+      <small>Concurrent::Edge::LockFreeLinkedSet::Node</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/ErlangActor/Terminated.html#==-instance_method" title="Concurrent::ErlangActor::Terminated#== (method)">#==</a></span>
-      <small>Concurrent::ErlangActor::Terminated</small>
+      <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Tail.html#<=>-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Tail#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
+      <small>Concurrent::Edge::LockFreeLinkedSet::Tail</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Head.html#<=>-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Head#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
+      <small>Concurrent::Edge::LockFreeLinkedSet::Head</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/ErlangActor/Down.html#==-instance_method" title="Concurrent::ErlangActor::Down#== (method)">#==</a></span>
+      <small>Concurrent::ErlangActor::Down</small>
     </div>
   </li>
   
@@ -166,8 +166,24 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/ErlangActor/Down.html#==-instance_method" title="Concurrent::ErlangActor::Down#== (method)">#==</a></span>
-      <small>Concurrent::ErlangActor::Down</small>
+      <span class='object_link'><a href="Concurrent/ErlangActor/Terminated.html#==-instance_method" title="Concurrent::ErlangActor::Terminated#== (method)">#==</a></span>
+      <small>Concurrent::ErlangActor::Terminated</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/ErlangActor/NoActor.html#==-instance_method" title="Concurrent::ErlangActor::NoActor#== (method)">#==</a></span>
+      <small>Concurrent::ErlangActor::NoActor</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/SettableStruct.html#==-instance_method" title="Concurrent::SettableStruct#== (method)">#==</a></span>
+      <small>Concurrent::SettableStruct</small>
     </div>
   </li>
   
@@ -182,32 +198,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/ErlangActor/NoActor.html#==-instance_method" title="Concurrent::ErlangActor::NoActor#== (method)">#==</a></span>
-      <small>Concurrent::ErlangActor::NoActor</small>
+      <span class='object_link'><a href="Concurrent/ErlangActor/EnvironmentConstants/Or.html#===-instance_method" title="Concurrent::ErlangActor::EnvironmentConstants::Or#=== (method)">#===</a></span>
+      <small>Concurrent::ErlangActor::EnvironmentConstants::Or</small>
     </div>
   </li>
   
 
   <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/SettableStruct.html#==-instance_method" title="Concurrent::SettableStruct#== (method)">#==</a></span>
-      <small>Concurrent::SettableStruct</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/EnvironmentConstants/And.html#===-instance_method" title="Concurrent::ErlangActor::EnvironmentConstants::And#=== (method)">#===</a></span>
       <small>Concurrent::ErlangActor::EnvironmentConstants::And</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/ErlangActor/EnvironmentConstants/Or.html#===-instance_method" title="Concurrent::ErlangActor::EnvironmentConstants::Or#=== (method)">#===</a></span>
-      <small>Concurrent::ErlangActor::EnvironmentConstants::Or</small>
     </div>
   </li>
   
@@ -262,8 +262,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/LazyRegister.html#[]-instance_method" title="Concurrent::LazyRegister#[] (method)">#[]</a></span>
-      <small>Concurrent::LazyRegister</small>
+      <span class='object_link'><a href="Concurrent/ImmutableStruct.html#[]-instance_method" title="Concurrent::ImmutableStruct#[] (method)">#[]</a></span>
+      <small>Concurrent::ImmutableStruct</small>
     </div>
   </li>
   
@@ -278,16 +278,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/MutableStruct.html#[]-instance_method" title="Concurrent::MutableStruct#[] (method)">#[]</a></span>
-      <small>Concurrent::MutableStruct</small>
+      <span class='object_link'><a href="Concurrent/SettableStruct.html#[]-instance_method" title="Concurrent::SettableStruct#[] (method)">#[]</a></span>
+      <small>Concurrent::SettableStruct</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/SettableStruct.html#[]-instance_method" title="Concurrent::SettableStruct#[] (method)">#[]</a></span>
-      <small>Concurrent::SettableStruct</small>
+      <span class='object_link'><a href="Concurrent/MutableStruct.html#[]-instance_method" title="Concurrent::MutableStruct#[] (method)">#[]</a></span>
+      <small>Concurrent::MutableStruct</small>
     </div>
   </li>
   
@@ -302,13 +302,21 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/ImmutableStruct.html#[]-instance_method" title="Concurrent::ImmutableStruct#[] (method)">#[]</a></span>
-      <small>Concurrent::ImmutableStruct</small>
+      <span class='object_link'><a href="Concurrent/LazyRegister.html#[]-instance_method" title="Concurrent::LazyRegister#[] (method)">#[]</a></span>
+      <small>Concurrent::LazyRegister</small>
     </div>
   </li>
   
 
   <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Map.html#[]=-instance_method" title="Concurrent::Map#[]= (method)">#[]=</a></span>
+      <small>Concurrent::Map</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SettableStruct.html#[]=-instance_method" title="Concurrent::SettableStruct#[]= (method)">#[]=</a></span>
       <small>Concurrent::SettableStruct</small>
@@ -316,7 +324,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MutableStruct.html#[]=-instance_method" title="Concurrent::MutableStruct#[]= (method)">#[]=</a></span>
       <small>Concurrent::MutableStruct</small>
@@ -324,7 +332,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Transaction.html#abort-instance_method" title="Concurrent::Transaction#abort (method)">#abort</a></span>
       <small>Concurrent::Transaction</small>
@@ -332,7 +340,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#abort_transaction-class_method" title="Concurrent.abort_transaction (method)">abort_transaction</a></span>
       <small>Concurrent</small>
@@ -340,7 +348,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Throttle.html#acquire-instance_method" title="Concurrent::Throttle#acquire (method)">#acquire</a></span>
       <small>Concurrent::Throttle</small>
@@ -348,7 +356,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Semaphore.html#acquire-instance_method" title="Concurrent::Semaphore#acquire (method)">#acquire</a></span>
       <small>Concurrent::Semaphore</small>
@@ -356,7 +364,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReadWriteLock.html#acquire_read_lock-instance_method" title="Concurrent::ReadWriteLock#acquire_read_lock (method)">#acquire_read_lock</a></span>
       <small>Concurrent::ReadWriteLock</small>
@@ -364,17 +372,9 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/ReentrantReadWriteLock.html#acquire_read_lock-instance_method" title="Concurrent::ReentrantReadWriteLock#acquire_read_lock (method)">#acquire_read_lock</a></span>
-      <small>Concurrent::ReentrantReadWriteLock</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/ReentrantReadWriteLock.html#acquire_write_lock-instance_method" title="Concurrent::ReentrantReadWriteLock#acquire_write_lock (method)">#acquire_write_lock</a></span>
+      <span class='object_link'><a href="Concurrent/ReentrantReadWriteLock.html#acquire_read_lock-instance_method" title="Concurrent::ReentrantReadWriteLock#acquire_read_lock (method)">#acquire_read_lock</a></span>
       <small>Concurrent::ReentrantReadWriteLock</small>
     </div>
   </li>
@@ -390,13 +390,21 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/ReentrantReadWriteLock.html#acquire_write_lock-instance_method" title="Concurrent::ReentrantReadWriteLock#acquire_write_lock (method)">#acquire_write_lock</a></span>
+      <small>Concurrent::ReentrantReadWriteLock</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/ProcessingActor.html#act-class_method" title="Concurrent::ProcessingActor.act (method)">act</a></span>
       <small>Concurrent::ProcessingActor</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ProcessingActor.html#act_listening-class_method" title="Concurrent::ProcessingActor.act_listening (method)">act_listening</a></span>
       <small>Concurrent::ProcessingActor</small>
@@ -404,7 +412,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#actor_class-instance_method" title="Concurrent::Actor::Core#actor_class (method)">#actor_class</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -412,7 +420,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet.html#add-instance_method" title="Concurrent::Edge::LockFreeLinkedSet#add (method)">#add</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet</small>
@@ -420,7 +428,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#add_child-instance_method" title="Concurrent::Actor::Core#add_child (method)">#add_child</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -428,10 +436,18 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/IVar.html#add_observer-instance_method" title="Concurrent::IVar#add_observer (method)">#add_observer</a></span>
       <small>Concurrent::IVar</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Concern/Observable.html#add_observer-instance_method" title="Concurrent::Concern::Observable#add_observer (method)">#add_observer</a></span>
+      <small>Concurrent::Concern::Observable</small>
     </div>
   </li>
   
@@ -454,21 +470,13 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Concern/Observable.html#add_observer-instance_method" title="Concurrent::Concern::Observable#add_observer (method)">#add_observer</a></span>
-      <small>Concurrent::Concern::Observable</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Envelope.html#address-instance_method" title="Concurrent::Actor::Envelope#address (method)">#address</a></span>
       <small>Concurrent::Actor::Envelope</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Envelope.html#address_path-instance_method" title="Concurrent::Actor::Envelope#address_path (method)">#address_path</a></span>
       <small>Concurrent::Actor::Envelope</small>
@@ -476,7 +484,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promise.html#all%3F-class_method" title="Concurrent::Promise.all? (method)">all?</a></span>
       <small>Concurrent::Promise</small>
@@ -484,18 +492,10 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#allocate_context-instance_method" title="Concurrent::Actor::Core#allocate_context (method)">#allocate_context</a></span>
       <small>Concurrent::Actor::Core</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Promises/Future.html#any-instance_method" title="Concurrent::Promises::Future#any (method)">#any</a></span>
-      <small>Concurrent::Promises::Future</small>
     </div>
   </li>
   
@@ -510,13 +510,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/Promises/Future.html#any-instance_method" title="Concurrent::Promises::Future#any (method)">#any</a></span>
+      <small>Concurrent::Promises::Future</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/Promise.html#any%3F-class_method" title="Concurrent::Promise.any? (method)">any?</a></span>
       <small>Concurrent::Promise</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#any_event-instance_method" title="Concurrent::Promises::FactoryMethods#any_event (method)">#any_event</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -524,7 +532,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#any_event_on-instance_method" title="Concurrent::Promises::FactoryMethods#any_event_on (method)">#any_event_on</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -532,7 +540,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#any_fulfilled_future-instance_method" title="Concurrent::Promises::FactoryMethods#any_fulfilled_future (method)">#any_fulfilled_future</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -540,7 +548,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#any_fulfilled_future_on-instance_method" title="Concurrent::Promises::FactoryMethods#any_fulfilled_future_on (method)">#any_fulfilled_future_on</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -548,7 +556,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#any_resolved_future-instance_method" title="Concurrent::Promises::FactoryMethods#any_resolved_future (method)">#any_resolved_future</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -556,7 +564,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#any_resolved_future_on-instance_method" title="Concurrent::Promises::FactoryMethods#any_resolved_future_on (method)">#any_resolved_future_on</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -564,18 +572,10 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SerializedExecution/Job.html#args-instance_method" title="Concurrent::SerializedExecution::Job#args (method)">#args</a></span>
       <small>Concurrent::SerializedExecution::Job</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/ErlangActor/Pid.html#ask-instance_method" title="Concurrent::ErlangActor::Pid#ask (method)">#ask</a></span>
-      <small>Concurrent::ErlangActor::Pid</small>
     </div>
   </li>
   
@@ -590,23 +590,7 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#ask-instance_method" title="Concurrent::Actor::AbstractContext#ask (method)">#ask</a></span>
-      <small>Concurrent::Actor::AbstractContext</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Actor/Reference.html#ask!-instance_method" title="Concurrent::Actor::Reference#ask! (method)">#ask!</a></span>
-      <small>Concurrent::Actor::Reference</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/ErlangActor/Pid.html#ask_op-instance_method" title="Concurrent::ErlangActor::Pid#ask_op (method)">#ask_op</a></span>
+      <span class='object_link'><a href="Concurrent/ErlangActor/Pid.html#ask-instance_method" title="Concurrent::ErlangActor::Pid#ask (method)">#ask</a></span>
       <small>Concurrent::ErlangActor::Pid</small>
     </div>
   </li>
@@ -614,13 +598,37 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#ask-instance_method" title="Concurrent::Actor::AbstractContext#ask (method)">#ask</a></span>
+      <small>Concurrent::Actor::AbstractContext</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Actor/Reference.html#ask!-instance_method" title="Concurrent::Actor::Reference#ask! (method)">#ask!</a></span>
+      <small>Concurrent::Actor::Reference</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/ErlangActor/Pid.html#ask_op-instance_method" title="Concurrent::ErlangActor::Pid#ask_op (method)">#ask_op</a></span>
+      <small>Concurrent::ErlangActor::Pid</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/ProcessingActor.html#ask_op-instance_method" title="Concurrent::ProcessingActor#ask_op (method)">#ask_op</a></span>
       <small>Concurrent::ProcessingActor</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Async.html#async-instance_method" title="Concurrent::Async#async (method)">#async</a></span>
       <small>Concurrent::Async</small>
@@ -628,7 +636,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization/Object.html#atomic_attribute%3F-class_method" title="Concurrent::Synchronization::Object.atomic_attribute? (method)">atomic_attribute?</a></span>
       <small>Concurrent::Synchronization::Object</small>
@@ -636,7 +644,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization/Object.html#atomic_attributes-class_method" title="Concurrent::Synchronization::Object.atomic_attributes (method)">atomic_attributes</a></span>
       <small>Concurrent::Synchronization::Object</small>
@@ -644,7 +652,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Resolvable.html#atomic_resolution-class_method" title="Concurrent::Promises::Resolvable.atomic_resolution (method)">atomic_resolution</a></span>
       <small>Concurrent::Promises::Resolvable</small>
@@ -652,7 +660,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#atomically-class_method" title="Concurrent.atomically (method)">atomically</a></span>
       <small>Concurrent</small>
@@ -660,7 +668,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization/Object.html#attr_atomic-class_method" title="Concurrent::Synchronization::Object.attr_atomic (method)">attr_atomic</a></span>
       <small>Concurrent::Synchronization::Object</small>
@@ -668,39 +676,7 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Synchronization/RbxAttrVolatile/ClassMethods.html#attr_volatile-instance_method" title="Concurrent::Synchronization::RbxAttrVolatile::ClassMethods#attr_volatile (method)">#attr_volatile</a></span>
-      <small>Concurrent::Synchronization::RbxAttrVolatile::ClassMethods</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Synchronization/TruffleRubyAttrVolatile/ClassMethods.html#attr_volatile-instance_method" title="Concurrent::Synchronization::TruffleRubyAttrVolatile::ClassMethods#attr_volatile (method)">#attr_volatile</a></span>
-      <small>Concurrent::Synchronization::TruffleRubyAttrVolatile::ClassMethods</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Synchronization/MriAttrVolatile/ClassMethods.html#attr_volatile-instance_method" title="Concurrent::Synchronization::MriAttrVolatile::ClassMethods#attr_volatile (method)">#attr_volatile</a></span>
-      <small>Concurrent::Synchronization::MriAttrVolatile::ClassMethods</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Synchronization/JRubyAttrVolatile/ClassMethods.html#attr_volatile-instance_method" title="Concurrent::Synchronization::JRubyAttrVolatile::ClassMethods#attr_volatile (method)">#attr_volatile</a></span>
-      <small>Concurrent::Synchronization::JRubyAttrVolatile::ClassMethods</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization/Object.html#attr_volatile-class_method" title="Concurrent::Synchronization::Object.attr_volatile (method)">attr_volatile</a></span>
       <small>Concurrent::Synchronization::Object</small>
@@ -708,10 +684,34 @@
   </li>
   
 
-  <li class="even deprecated">
+  <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#auto_terminate=-instance_method" title="Concurrent::SingleThreadExecutor#auto_terminate= (method)">#auto_terminate=</a></span>
-      <small>Concurrent::SingleThreadExecutor</small>
+      <span class='object_link'><a href="Concurrent/Synchronization/JRubyAttrVolatile/ClassMethods.html#attr_volatile-instance_method" title="Concurrent::Synchronization::JRubyAttrVolatile::ClassMethods#attr_volatile (method)">#attr_volatile</a></span>
+      <small>Concurrent::Synchronization::JRubyAttrVolatile::ClassMethods</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Synchronization/RbxAttrVolatile/ClassMethods.html#attr_volatile-instance_method" title="Concurrent::Synchronization::RbxAttrVolatile::ClassMethods#attr_volatile (method)">#attr_volatile</a></span>
+      <small>Concurrent::Synchronization::RbxAttrVolatile::ClassMethods</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Synchronization/TruffleRubyAttrVolatile/ClassMethods.html#attr_volatile-instance_method" title="Concurrent::Synchronization::TruffleRubyAttrVolatile::ClassMethods#attr_volatile (method)">#attr_volatile</a></span>
+      <small>Concurrent::Synchronization::TruffleRubyAttrVolatile::ClassMethods</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Synchronization/MriAttrVolatile/ClassMethods.html#attr_volatile-instance_method" title="Concurrent::Synchronization::MriAttrVolatile::ClassMethods#attr_volatile (method)">#attr_volatile</a></span>
+      <small>Concurrent::Synchronization::MriAttrVolatile::ClassMethods</small>
     </div>
   </li>
   
@@ -724,9 +724,9 @@
   </li>
   
 
-  <li class="even ">
+  <li class="even deprecated">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#auto_terminate%3F-instance_method" title="Concurrent::SingleThreadExecutor#auto_terminate? (method)">#auto_terminate?</a></span>
+      <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#auto_terminate=-instance_method" title="Concurrent::SingleThreadExecutor#auto_terminate= (method)">#auto_terminate=</a></span>
       <small>Concurrent::SingleThreadExecutor</small>
     </div>
   </li>
@@ -742,13 +742,21 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#auto_terminate%3F-instance_method" title="Concurrent::SingleThreadExecutor#auto_terminate? (method)">#auto_terminate?</a></span>
+      <small>Concurrent::SingleThreadExecutor</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/Throttle.html#available_capacity-instance_method" title="Concurrent::Throttle#available_capacity (method)">#available_capacity</a></span>
       <small>Concurrent::Throttle</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Semaphore.html#available_permits-instance_method" title="Concurrent::Semaphore#available_permits (method)">#available_permits</a></span>
       <small>Concurrent::Semaphore</small>
@@ -756,7 +764,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#await-instance_method" title="Concurrent::Agent#await (method)">#await</a></span>
       <small>Concurrent::Agent</small>
@@ -764,7 +772,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#await-class_method" title="Concurrent::Agent.await (method)">await</a></span>
       <small>Concurrent::Agent</small>
@@ -772,7 +780,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Async.html#await-instance_method" title="Concurrent::Async#await (method)">#await</a></span>
       <small>Concurrent::Async</small>
@@ -780,7 +788,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#await_for-instance_method" title="Concurrent::Agent#await_for (method)">#await_for</a></span>
       <small>Concurrent::Agent</small>
@@ -788,7 +796,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#await_for-class_method" title="Concurrent::Agent.await_for (method)">await_for</a></span>
       <small>Concurrent::Agent</small>
@@ -796,7 +804,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#await_for!-class_method" title="Concurrent::Agent.await_for! (method)">await_for!</a></span>
       <small>Concurrent::Agent</small>
@@ -804,7 +812,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#await_for!-instance_method" title="Concurrent::Agent#await_for! (method)">#await_for!</a></span>
       <small>Concurrent::Agent</small>
@@ -812,7 +820,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour.html#base-class_method" title="Concurrent::Actor::Behaviour.base (method)">base</a></span>
       <small>Concurrent::Actor::Behaviour</small>
@@ -820,18 +828,10 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour.html#basic_behaviour_definition-class_method" title="Concurrent::Actor::Behaviour.basic_behaviour_definition (method)">basic_behaviour_definition</a></span>
       <small>Concurrent::Actor::Behaviour</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Actor/InternalDelegations.html#behaviour-instance_method" title="Concurrent::Actor::InternalDelegations#behaviour (method)">#behaviour</a></span>
-      <small>Concurrent::Actor::InternalDelegations</small>
     </div>
   </li>
   
@@ -846,7 +846,7 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Actor/InternalDelegations.html#behaviour!-instance_method" title="Concurrent::Actor::InternalDelegations#behaviour! (method)">#behaviour!</a></span>
+      <span class='object_link'><a href="Concurrent/Actor/InternalDelegations.html#behaviour-instance_method" title="Concurrent::Actor::InternalDelegations#behaviour (method)">#behaviour</a></span>
       <small>Concurrent::Actor::InternalDelegations</small>
     </div>
   </li>
@@ -854,40 +854,24 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/Actor/InternalDelegations.html#behaviour!-instance_method" title="Concurrent::Actor::InternalDelegations#behaviour! (method)">#behaviour!</a></span>
+      <small>Concurrent::Actor::InternalDelegations</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#behaviour!-instance_method" title="Concurrent::Actor::Core#behaviour! (method)">#behaviour!</a></span>
       <small>Concurrent::Actor::Core</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Context.html#behaviour_definition-instance_method" title="Concurrent::Actor::Context#behaviour_definition (method)">#behaviour_definition</a></span>
       <small>Concurrent::Actor::Context</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Actor/Root.html#behaviour_definition-instance_method" title="Concurrent::Actor::Root#behaviour_definition (method)">#behaviour_definition</a></span>
-      <small>Concurrent::Actor::Root</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Actor/Core.html#behaviour_definition-instance_method" title="Concurrent::Actor::Core#behaviour_definition (method)">#behaviour_definition</a></span>
-      <small>Concurrent::Actor::Core</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#behaviour_definition-instance_method" title="Concurrent::Actor::AbstractContext#behaviour_definition (method)">#behaviour_definition</a></span>
-      <small>Concurrent::Actor::AbstractContext</small>
     </div>
   </li>
   
@@ -902,16 +886,48 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/ThreadLocalVar.html#bind-instance_method" title="Concurrent::ThreadLocalVar#bind (method)">#bind</a></span>
-      <small>Concurrent::ThreadLocalVar</small>
+      <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#behaviour_definition-instance_method" title="Concurrent::Actor::AbstractContext#behaviour_definition (method)">#behaviour_definition</a></span>
+      <small>Concurrent::Actor::AbstractContext</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/Actor/Root.html#behaviour_definition-instance_method" title="Concurrent::Actor::Root#behaviour_definition (method)">#behaviour_definition</a></span>
+      <small>Concurrent::Actor::Root</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Actor/Core.html#behaviour_definition-instance_method" title="Concurrent::Actor::Core#behaviour_definition (method)">#behaviour_definition</a></span>
+      <small>Concurrent::Actor::Core</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/ThreadLocalVar.html#bind-instance_method" title="Concurrent::ThreadLocalVar#bind (method)">#bind</a></span>
+      <small>Concurrent::ThreadLocalVar</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/SerializedExecution/Job.html#block-instance_method" title="Concurrent::SerializedExecution::Job#block (method)">#block</a></span>
       <small>Concurrent::SerializedExecution::Job</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Channel/Buffer/Sliding.html#blocking%3F-instance_method" title="Concurrent::Channel::Buffer::Sliding#blocking? (method)">#blocking?</a></span>
+      <small>Concurrent::Channel::Buffer::Sliding</small>
     </div>
   </li>
   
@@ -934,32 +950,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Channel/Buffer/Sliding.html#blocking%3F-instance_method" title="Concurrent::Channel::Buffer::Sliding#blocking? (method)">#blocking?</a></span>
-      <small>Concurrent::Channel::Buffer::Sliding</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Concurrent/MVar.html#borrow-instance_method" title="Concurrent::MVar#borrow (method)">#borrow</a></span>
       <small>Concurrent::MVar</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization.html#broadcast-instance_method" title="Concurrent::Synchronization#broadcast (method)">#broadcast</a></span>
       <small>Concurrent::Synchronization</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Actor/Behaviour/Abstract.html#broadcast-instance_method" title="Concurrent::Actor::Behaviour::Abstract#broadcast (method)">#broadcast</a></span>
-      <small>Concurrent::Actor::Behaviour::Abstract</small>
     </div>
   </li>
   
@@ -974,13 +974,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/Actor/Behaviour/Abstract.html#broadcast-instance_method" title="Concurrent::Actor::Behaviour::Abstract#broadcast (method)">#broadcast</a></span>
+      <small>Concurrent::Actor::Behaviour::Abstract</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/CyclicBarrier.html#broken%3F-instance_method" title="Concurrent::CyclicBarrier#broken? (method)">#broken?</a></span>
       <small>Concurrent::CyclicBarrier</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#build_context-instance_method" title="Concurrent::Actor::Core#build_context (method)">#build_context</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -988,7 +996,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SerializedExecution/Job.html#call-instance_method" title="Concurrent::SerializedExecution::Job#call (method)">#call</a></span>
       <small>Concurrent::SerializedExecution::Job</small>
@@ -996,7 +1004,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#call_dataflow-class_method" title="Concurrent.call_dataflow (method)">call_dataflow</a></span>
       <small>Concurrent</small>
@@ -1004,23 +1012,7 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#can_overflow%3F-instance_method" title="Concurrent::ThreadPoolExecutor#can_overflow? (method)">#can_overflow?</a></span>
-      <small>Concurrent::ThreadPoolExecutor</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/WrappingExecutor.html#can_overflow%3F-instance_method" title="Concurrent::WrappingExecutor#can_overflow? (method)">#can_overflow?</a></span>
-      <small>Concurrent::WrappingExecutor</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#can_overflow%3F-instance_method" title="Concurrent::SingleThreadExecutor#can_overflow? (method)">#can_overflow?</a></span>
       <small>Concurrent::SingleThreadExecutor</small>
@@ -1028,10 +1020,18 @@
   </li>
   
 
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/WrappingExecutor.html#can_overflow%3F-instance_method" title="Concurrent::WrappingExecutor#can_overflow? (method)">#can_overflow?</a></span>
+      <small>Concurrent::WrappingExecutor</small>
+    </div>
+  </li>
+  
+
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/ScheduledTask.html#cancel-instance_method" title="Concurrent::ScheduledTask#cancel (method)">#cancel</a></span>
-      <small>Concurrent::ScheduledTask</small>
+      <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#can_overflow%3F-instance_method" title="Concurrent::ThreadPoolExecutor#can_overflow? (method)">#can_overflow?</a></span>
+      <small>Concurrent::ThreadPoolExecutor</small>
     </div>
   </li>
   
@@ -1046,16 +1046,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Cancellation.html#canceled%3F-instance_method" title="Concurrent::Cancellation#canceled? (method)">#canceled?</a></span>
-      <small>Concurrent::Cancellation</small>
+      <span class='object_link'><a href="Concurrent/ScheduledTask.html#cancel-instance_method" title="Concurrent::ScheduledTask#cancel (method)">#cancel</a></span>
+      <small>Concurrent::ScheduledTask</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Future.html#cancelled%3F-instance_method" title="Concurrent::Future#cancelled? (method)">#cancelled?</a></span>
-      <small>Concurrent::Future</small>
+      <span class='object_link'><a href="Concurrent/Cancellation.html#canceled%3F-instance_method" title="Concurrent::Cancellation#canceled? (method)">#canceled?</a></span>
+      <small>Concurrent::Cancellation</small>
     </div>
   </li>
   
@@ -1070,8 +1070,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Channel/Buffer/Base.html#capacity-instance_method" title="Concurrent::Channel::Buffer::Base#capacity (method)">#capacity</a></span>
-      <small>Concurrent::Channel::Buffer::Base</small>
+      <span class='object_link'><a href="Concurrent/Future.html#cancelled%3F-instance_method" title="Concurrent::Future#cancelled? (method)">#cancelled?</a></span>
+      <small>Concurrent::Future</small>
     </div>
   </li>
   
@@ -1086,13 +1086,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/Channel/Buffer/Base.html#capacity-instance_method" title="Concurrent::Channel::Buffer::Base#capacity (method)">#capacity</a></span>
+      <small>Concurrent::Channel::Buffer::Base</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#chain-instance_method" title="Concurrent::Promises::AbstractEventFuture#chain (method)">#chain</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#chain_on-instance_method" title="Concurrent::Promises::AbstractEventFuture#chain_on (method)">#chain_on</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
@@ -1100,7 +1108,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#chain_resolvable-instance_method" title="Concurrent::Promises::AbstractEventFuture#chain_resolvable (method)">#chain_resolvable</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
@@ -1108,7 +1116,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Cancellation.html#check!-instance_method" title="Concurrent::Cancellation#check! (method)">#check!</a></span>
       <small>Concurrent::Cancellation</small>
@@ -1116,7 +1124,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/InternalDelegations.html#children-instance_method" title="Concurrent::Actor::InternalDelegations#children (method)">#children</a></span>
       <small>Concurrent::Actor::InternalDelegations</small>
@@ -1124,7 +1132,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#children-instance_method" title="Concurrent::Actor::Core#children (method)">#children</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -1132,7 +1140,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack.html#clear-instance_method" title="Concurrent::LockFreeStack#clear (method)">#clear</a></span>
       <small>Concurrent::LockFreeStack</small>
@@ -1140,7 +1148,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack.html#clear_each-instance_method" title="Concurrent::LockFreeStack#clear_each (method)">#clear_each</a></span>
       <small>Concurrent::LockFreeStack</small>
@@ -1148,7 +1156,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack.html#clear_if-instance_method" title="Concurrent::LockFreeStack#clear_if (method)">#clear_if</a></span>
       <small>Concurrent::LockFreeStack</small>
@@ -1156,7 +1164,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Base.html#close-instance_method" title="Concurrent::Channel::Buffer::Base#close (method)">#close</a></span>
       <small>Concurrent::Channel::Buffer::Base</small>
@@ -1164,7 +1172,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Base.html#closed%3F-instance_method" title="Concurrent::Channel::Buffer::Base#closed? (method)">#closed?</a></span>
       <small>Concurrent::Channel::Buffer::Base</small>
@@ -1172,7 +1180,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Transaction.html#commit-instance_method" title="Concurrent::Transaction#commit (method)">#commit</a></span>
       <small>Concurrent::Transaction</small>
@@ -1180,7 +1188,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack.html#compare_and_clear-instance_method" title="Concurrent::LockFreeStack#compare_and_clear (method)">#compare_and_clear</a></span>
       <small>Concurrent::LockFreeStack</small>
@@ -1188,7 +1196,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack.html#compare_and_pop-instance_method" title="Concurrent::LockFreeStack#compare_and_pop (method)">#compare_and_pop</a></span>
       <small>Concurrent::LockFreeStack</small>
@@ -1196,10 +1204,18 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack.html#compare_and_push-instance_method" title="Concurrent::LockFreeStack#compare_and_push (method)">#compare_and_push</a></span>
       <small>Concurrent::LockFreeStack</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Tuple.html#compare_and_set-instance_method" title="Concurrent::Tuple#compare_and_set (method)">#compare_and_set</a></span>
+      <small>Concurrent::Tuple</small>
     </div>
   </li>
   
@@ -1222,22 +1238,6 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/AtomicFixnum.html#compare_and_set-instance_method" title="Concurrent::AtomicFixnum#compare_and_set (method)">#compare_and_set</a></span>
-      <small>Concurrent::AtomicFixnum</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Tuple.html#compare_and_set-instance_method" title="Concurrent::Tuple#compare_and_set (method)">#compare_and_set</a></span>
-      <small>Concurrent::Tuple</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Concurrent/Atom.html#compare_and_set-instance_method" title="Concurrent::Atom#compare_and_set (method)">#compare_and_set</a></span>
       <small>Concurrent::Atom</small>
     </div>
@@ -1246,13 +1246,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/AtomicFixnum.html#compare_and_set-instance_method" title="Concurrent::AtomicFixnum#compare_and_set (method)">#compare_and_set</a></span>
+      <small>Concurrent::AtomicFixnum</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeQueue/Node.html#compare_and_set_successor-instance_method" title="Concurrent::LockFreeQueue::Node#compare_and_set_successor (method)">#compare_and_set_successor</a></span>
       <small>Concurrent::LockFreeQueue::Node</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Concern/Obligation.html#complete%3F-instance_method" title="Concurrent::Concern::Obligation#complete? (method)">#complete?</a></span>
       <small>Concurrent::Concern::Obligation</small>
@@ -1260,7 +1268,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#completed_task_count-instance_method" title="Concurrent::ThreadPoolExecutor#completed_task_count (method)">#completed_task_count</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -1268,7 +1276,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#compute-instance_method" title="Concurrent::Map#compute (method)">#compute</a></span>
       <small>Concurrent::Map</small>
@@ -1276,7 +1284,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#compute_if_absent-instance_method" title="Concurrent::Map#compute_if_absent (method)">#compute_if_absent</a></span>
       <small>Concurrent::Map</small>
@@ -1284,7 +1292,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#compute_if_present-instance_method" title="Concurrent::Map#compute_if_present (method)">#compute_if_present</a></span>
       <small>Concurrent::Map</small>
@@ -1292,7 +1300,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet.html#contains%3F-instance_method" title="Concurrent::Edge::LockFreeLinkedSet#contains? (method)">#contains?</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet</small>
@@ -1300,7 +1308,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#context-instance_method" title="Concurrent::Actor::Core#context (method)">#context</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -1308,18 +1316,10 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/InternalDelegations.html#context-instance_method" title="Concurrent::Actor::InternalDelegations#context (method)">#context</a></span>
       <small>Concurrent::Actor::InternalDelegations</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Actor/Core.html#context_class-instance_method" title="Concurrent::Actor::Core#context_class (method)">#context_class</a></span>
-      <small>Concurrent::Actor::Core</small>
     </div>
   </li>
   
@@ -1334,13 +1334,21 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/Actor/Core.html#context_class-instance_method" title="Concurrent::Actor::Core#context_class (method)">#context_class</a></span>
+      <small>Concurrent::Actor::Core</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#core-instance_method" title="Concurrent::Actor::AbstractContext#core (method)">#core</a></span>
       <small>Concurrent::Actor::AbstractContext</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Abstract.html#core-instance_method" title="Concurrent::Actor::Behaviour::Abstract#core (method)">#core</a></span>
       <small>Concurrent::Actor::Behaviour::Abstract</small>
@@ -1348,7 +1356,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/CountDownLatch.html#count-instance_method" title="Concurrent::CountDownLatch#count (method)">#count</a></span>
       <small>Concurrent::CountDownLatch</small>
@@ -1356,10 +1364,18 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/CountDownLatch.html#count_down-instance_method" title="Concurrent::CountDownLatch#count_down (method)">#count_down</a></span>
       <small>Concurrent::CountDownLatch</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Concern/Observable.html#count_observers-instance_method" title="Concurrent::Concern::Observable#count_observers (method)">#count_observers</a></span>
+      <small>Concurrent::Concern::Observable</small>
     </div>
   </li>
   
@@ -1382,21 +1398,13 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Concern/Observable.html#count_observers-instance_method" title="Concurrent::Concern::Observable#count_observers (method)">#count_observers</a></span>
-      <small>Concurrent::Concern::Observable</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Concurrent.html#create_simple_logger-class_method" title="Concurrent.create_simple_logger (method)">create_simple_logger</a></span>
       <small>Concurrent</small>
     </div>
   </li>
   
 
-  <li class="even deprecated">
+  <li class="odd deprecated">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#create_stdlib_logger-class_method" title="Concurrent.create_stdlib_logger (method)">create_stdlib_logger</a></span>
       <small>Concurrent</small>
@@ -1404,18 +1412,10 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Window.html#curr-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Window#curr (method)">#curr</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet::Window</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Transaction.html#current-class_method" title="Concurrent::Transaction.current (method)">current</a></span>
-      <small>Concurrent::Transaction</small>
     </div>
   </li>
   
@@ -1430,7 +1430,7 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Transaction.html#current=-class_method" title="Concurrent::Transaction.current= (method)">current=</a></span>
+      <span class='object_link'><a href="Concurrent/Transaction.html#current-class_method" title="Concurrent::Transaction.current (method)">current</a></span>
       <small>Concurrent::Transaction</small>
     </div>
   </li>
@@ -1438,13 +1438,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/Transaction.html#current=-class_method" title="Concurrent::Transaction.current= (method)">current=</a></span>
+      <small>Concurrent::Transaction</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Node.html#data-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Node#data (method)">#data</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet::Node</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#dataflow-class_method" title="Concurrent.dataflow (method)">dataflow</a></span>
       <small>Concurrent</small>
@@ -1452,7 +1460,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#dataflow!-class_method" title="Concurrent.dataflow! (method)">dataflow!</a></span>
       <small>Concurrent</small>
@@ -1460,7 +1468,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#dataflow_with-class_method" title="Concurrent.dataflow_with (method)">dataflow_with</a></span>
       <small>Concurrent</small>
@@ -1468,18 +1476,10 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#dataflow_with!-class_method" title="Concurrent.dataflow_with! (method)">dataflow_with!</a></span>
       <small>Concurrent</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Actor/Reference.html#dead_letter_routing-instance_method" title="Concurrent::Actor::Reference#dead_letter_routing (method)">#dead_letter_routing</a></span>
-      <small>Concurrent::Actor::Reference</small>
     </div>
   </li>
   
@@ -1502,13 +1502,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/Actor/Reference.html#dead_letter_routing-instance_method" title="Concurrent::Actor::Reference#dead_letter_routing (method)">#dead_letter_routing</a></span>
+      <small>Concurrent::Actor::Reference</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Root.html#dead_letter_routing-instance_method" title="Concurrent::Actor::Root#dead_letter_routing (method)">#dead_letter_routing</a></span>
       <small>Concurrent::Actor::Root</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#dead_letter_routing-instance_method" title="Concurrent::Actor::Core#dead_letter_routing (method)">#dead_letter_routing</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -1516,7 +1524,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicFixnum.html#decrement-instance_method" title="Concurrent::AtomicFixnum#decrement (method)">#decrement</a></span>
       <small>Concurrent::AtomicFixnum</small>
@@ -1524,7 +1532,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Functions.html#default_actor_executor-instance_method" title="Concurrent::ErlangActor::Functions#default_actor_executor (method)">#default_actor_executor</a></span>
       <small>Concurrent::ErlangActor::Functions</small>
@@ -1532,26 +1540,18 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#default_executor-instance_method" title="Concurrent::Actor::AbstractContext#default_executor (method)">#default_executor</a></span>
-      <small>Concurrent::Actor::AbstractContext</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Throttle.html#default_executor-instance_method" title="Concurrent::Throttle#default_executor (method)">#default_executor</a></span>
-      <small>Concurrent::Throttle</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Functions.html#default_executor-instance_method" title="Concurrent::ErlangActor::Functions#default_executor (method)">#default_executor</a></span>
       <small>Concurrent::ErlangActor::Functions</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#default_executor-instance_method" title="Concurrent::ErlangActor::Environment#default_executor (method)">#default_executor</a></span>
+      <small>Concurrent::ErlangActor::Environment</small>
     </div>
   </li>
   
@@ -1574,16 +1574,32 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#default_executor-instance_method" title="Concurrent::ErlangActor::Environment#default_executor (method)">#default_executor</a></span>
-      <small>Concurrent::ErlangActor::Environment</small>
+      <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#default_executor-instance_method" title="Concurrent::Actor::AbstractContext#default_executor (method)">#default_executor</a></span>
+      <small>Concurrent::Actor::AbstractContext</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/Throttle.html#default_executor-instance_method" title="Concurrent::Throttle#default_executor (method)">#default_executor</a></span>
+      <small>Concurrent::Throttle</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#default_reference_class-instance_method" title="Concurrent::Actor::AbstractContext#default_reference_class (method)">#default_reference_class</a></span>
       <small>Concurrent::Actor::AbstractContext</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#delay-instance_method" title="Concurrent::Promises::FactoryMethods#delay (method)">#delay</a></span>
+      <small>Concurrent::Promises::FactoryMethods</small>
     </div>
   </li>
   
@@ -1606,21 +1622,13 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#delay-instance_method" title="Concurrent::Promises::FactoryMethods#delay (method)">#delay</a></span>
-      <small>Concurrent::Promises::FactoryMethods</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#delay_on-instance_method" title="Concurrent::Promises::FactoryMethods#delay_on (method)">#delay_on</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#delete-instance_method" title="Concurrent::Map#delete (method)">#delete</a></span>
       <small>Concurrent::Map</small>
@@ -1628,10 +1636,18 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Collection/CopyOnNotifyObserverSet.html#delete_observer-instance_method" title="Concurrent::Collection::CopyOnNotifyObserverSet#delete_observer (method)">#delete_observer</a></span>
       <small>Concurrent::Collection::CopyOnNotifyObserverSet</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Concern/Observable.html#delete_observer-instance_method" title="Concurrent::Concern::Observable#delete_observer (method)">#delete_observer</a></span>
+      <small>Concurrent::Concern::Observable</small>
     </div>
   </li>
   
@@ -1646,7 +1662,7 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Concern/Observable.html#delete_observer-instance_method" title="Concurrent::Concern::Observable#delete_observer (method)">#delete_observer</a></span>
+      <span class='object_link'><a href="Concurrent/Concern/Observable.html#delete_observers-instance_method" title="Concurrent::Concern::Observable#delete_observers (method)">#delete_observers</a></span>
       <small>Concurrent::Concern::Observable</small>
     </div>
   </li>
@@ -1670,21 +1686,13 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Concern/Observable.html#delete_observers-instance_method" title="Concurrent::Concern::Observable#delete_observers (method)">#delete_observers</a></span>
-      <small>Concurrent::Concern::Observable</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#delete_pair-instance_method" title="Concurrent::Map#delete_pair (method)">#delete_pair</a></span>
       <small>Concurrent::Map</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#demonitor-instance_method" title="Concurrent::ErlangActor::Environment#demonitor (method)">#demonitor</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -1692,7 +1700,7 @@
   </li>
   
 
-  <li class="odd deprecated">
+  <li class="even deprecated">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#disable_at_exit_handlers!-class_method" title="Concurrent.disable_at_exit_handlers! (method)">disable_at_exit_handlers!</a></span>
       <small>Concurrent</small>
@@ -1700,7 +1708,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Utils/Balancer.html#distribute-instance_method" title="Concurrent::Actor::Utils::Balancer#distribute (method)">#distribute</a></span>
       <small>Concurrent::Actor::Utils::Balancer</small>
@@ -1708,50 +1716,10 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Semaphore.html#drain_permits-instance_method" title="Concurrent::Semaphore#drain_permits (method)">#drain_permits</a></span>
       <small>Concurrent::Semaphore</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/LockFreeStack.html#each-instance_method" title="Concurrent::LockFreeStack#each (method)">#each</a></span>
-      <small>Concurrent::LockFreeStack</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Channel.html#each-instance_method" title="Concurrent::Channel#each (method)">#each</a></span>
-      <small>Concurrent::Channel</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/ImmutableStruct.html#each-instance_method" title="Concurrent::ImmutableStruct#each (method)">#each</a></span>
-      <small>Concurrent::ImmutableStruct</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/MutableStruct.html#each-instance_method" title="Concurrent::MutableStruct#each (method)">#each</a></span>
-      <small>Concurrent::MutableStruct</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet.html#each-instance_method" title="Concurrent::Edge::LockFreeLinkedSet#each (method)">#each</a></span>
-      <small>Concurrent::Edge::LockFreeLinkedSet</small>
     </div>
   </li>
   
@@ -1766,6 +1734,22 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/MutableStruct.html#each-instance_method" title="Concurrent::MutableStruct#each (method)">#each</a></span>
+      <small>Concurrent::MutableStruct</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet.html#each-instance_method" title="Concurrent::Edge::LockFreeLinkedSet#each (method)">#each</a></span>
+      <small>Concurrent::Edge::LockFreeLinkedSet</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/SettableStruct.html#each-instance_method" title="Concurrent::SettableStruct#each (method)">#each</a></span>
       <small>Concurrent::SettableStruct</small>
     </div>
@@ -1774,24 +1758,40 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Map.html#each_key-instance_method" title="Concurrent::Map#each_key (method)">#each_key</a></span>
-      <small>Concurrent::Map</small>
+      <span class='object_link'><a href="Concurrent/ImmutableStruct.html#each-instance_method" title="Concurrent::ImmutableStruct#each (method)">#each</a></span>
+      <small>Concurrent::ImmutableStruct</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/ImmutableStruct.html#each_pair-instance_method" title="Concurrent::ImmutableStruct#each_pair (method)">#each_pair</a></span>
-      <small>Concurrent::ImmutableStruct</small>
+      <span class='object_link'><a href="Concurrent/Channel.html#each-instance_method" title="Concurrent::Channel#each (method)">#each</a></span>
+      <small>Concurrent::Channel</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/MutableStruct.html#each_pair-instance_method" title="Concurrent::MutableStruct#each_pair (method)">#each_pair</a></span>
-      <small>Concurrent::MutableStruct</small>
+      <span class='object_link'><a href="Concurrent/LockFreeStack.html#each-instance_method" title="Concurrent::LockFreeStack#each (method)">#each</a></span>
+      <small>Concurrent::LockFreeStack</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Map.html#each_key-instance_method" title="Concurrent::Map#each_key (method)">#each_key</a></span>
+      <small>Concurrent::Map</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/ImmutableStruct.html#each_pair-instance_method" title="Concurrent::ImmutableStruct#each_pair (method)">#each_pair</a></span>
+      <small>Concurrent::ImmutableStruct</small>
     </div>
   </li>
   
@@ -1806,40 +1806,24 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/MutableStruct.html#each_pair-instance_method" title="Concurrent::MutableStruct#each_pair (method)">#each_pair</a></span>
+      <small>Concurrent::MutableStruct</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/SettableStruct.html#each_pair-instance_method" title="Concurrent::SettableStruct#each_pair (method)">#each_pair</a></span>
       <small>Concurrent::SettableStruct</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#each_value-instance_method" title="Concurrent::Map#each_value (method)">#each_value</a></span>
       <small>Concurrent::Map</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Channel/Buffer/Base.html#empty%3F-instance_method" title="Concurrent::Channel::Buffer::Base#empty? (method)">#empty?</a></span>
-      <small>Concurrent::Channel::Buffer::Base</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Map.html#empty%3F-instance_method" title="Concurrent::Map#empty? (method)">#empty?</a></span>
-      <small>Concurrent::Map</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/MVar.html#empty%3F-instance_method" title="Concurrent::MVar#empty? (method)">#empty?</a></span>
-      <small>Concurrent::MVar</small>
     </div>
   </li>
   
@@ -1854,13 +1838,37 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/MVar.html#empty%3F-instance_method" title="Concurrent::MVar#empty? (method)">#empty?</a></span>
+      <small>Concurrent::MVar</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Unbuffered.html#empty%3F-instance_method" title="Concurrent::Channel::Buffer::Unbuffered#empty? (method)">#empty?</a></span>
       <small>Concurrent::Channel::Buffer::Unbuffered</small>
     </div>
   </li>
   
 
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Map.html#empty%3F-instance_method" title="Concurrent::Map#empty? (method)">#empty?</a></span>
+      <small>Concurrent::Map</small>
+    </div>
+  </li>
+  
+
   <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Channel/Buffer/Base.html#empty%3F-instance_method" title="Concurrent::Channel::Buffer::Base#empty? (method)">#empty?</a></span>
+      <small>Concurrent::Channel::Buffer::Base</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization/Object.html#ensure_safe_initialization_when_final_fields_are_present-class_method" title="Concurrent::Synchronization::Object.ensure_safe_initialization_when_final_fields_are_present (method)">ensure_safe_initialization_when_final_fields_are_present</a></span>
       <small>Concurrent::Synchronization::Object</small>
@@ -1868,7 +1876,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#envelope-instance_method" title="Concurrent::Actor::AbstractContext#envelope (method)">#envelope</a></span>
       <small>Concurrent::Actor::AbstractContext</small>
@@ -1876,7 +1884,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/UnknownMessage.html#envelope-instance_method" title="Concurrent::Actor::UnknownMessage#envelope (method)">#envelope</a></span>
       <small>Concurrent::Actor::UnknownMessage</small>
@@ -1884,7 +1892,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Tick.html#epoch-instance_method" title="Concurrent::Channel::Tick#epoch (method)">#epoch</a></span>
       <small>Concurrent::Channel::Tick</small>
@@ -1892,7 +1900,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#error-instance_method" title="Concurrent::Agent#error (method)">#error</a></span>
       <small>Concurrent::Agent</small>
@@ -1900,7 +1908,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#error_mode-instance_method" title="Concurrent::Agent#error_mode (method)">#error_mode</a></span>
       <small>Concurrent::Agent</small>
@@ -1908,7 +1916,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/SetResults.html#error_strategy-instance_method" title="Concurrent::Actor::Behaviour::SetResults#error_strategy (method)">#error_strategy</a></span>
       <small>Concurrent::Actor::Behaviour::SetResults</small>
@@ -1916,7 +1924,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MultipleErrors.html#errors-instance_method" title="Concurrent::MultipleErrors#errors (method)">#errors</a></span>
       <small>Concurrent::MultipleErrors</small>
@@ -1924,7 +1932,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableFuture.html#evaluate_to-instance_method" title="Concurrent::Promises::ResolvableFuture#evaluate_to (method)">#evaluate_to</a></span>
       <small>Concurrent::Promises::ResolvableFuture</small>
@@ -1932,18 +1940,10 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableFuture.html#evaluate_to!-instance_method" title="Concurrent::Promises::ResolvableFuture#evaluate_to! (method)">#evaluate_to!</a></span>
       <small>Concurrent::Promises::ResolvableFuture</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Concern/Obligation.html#exception-instance_method" title="Concurrent::Concern::Obligation#exception (method)">#exception</a></span>
-      <small>Concurrent::Concern::Obligation</small>
     </div>
   </li>
   
@@ -1958,15 +1958,15 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent.html#exchange-instance_method" title="Concurrent#exchange (method)">#exchange</a></span>
-      <small>Concurrent</small>
+      <span class='object_link'><a href="Concurrent/Concern/Obligation.html#exception-instance_method" title="Concurrent::Concern::Obligation#exception (method)">#exception</a></span>
+      <small>Concurrent::Concern::Obligation</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent.html#exchange!-instance_method" title="Concurrent#exchange! (method)">#exchange!</a></span>
+      <span class='object_link'><a href="Concurrent.html#exchange-instance_method" title="Concurrent#exchange (method)">#exchange</a></span>
       <small>Concurrent</small>
     </div>
   </li>
@@ -1974,8 +1974,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Channel/Selector/DefaultClause.html#execute-instance_method" title="Concurrent::Channel::Selector::DefaultClause#execute (method)">#execute</a></span>
-      <small>Concurrent::Channel::Selector::DefaultClause</small>
+      <span class='object_link'><a href="Concurrent.html#exchange!-instance_method" title="Concurrent#exchange! (method)">#exchange!</a></span>
+      <small>Concurrent</small>
     </div>
   </li>
   
@@ -1990,21 +1990,13 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/TimerTask.html#execute-class_method" title="Concurrent::TimerTask.execute (method)">execute</a></span>
-      <small>Concurrent::TimerTask</small>
+      <span class='object_link'><a href="Concurrent/SafeTaskExecutor.html#execute-instance_method" title="Concurrent::SafeTaskExecutor#execute (method)">#execute</a></span>
+      <small>Concurrent::SafeTaskExecutor</small>
     </div>
   </li>
   
 
   <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/ScheduledTask.html#execute-class_method" title="Concurrent::ScheduledTask.execute (method)">execute</a></span>
-      <small>Concurrent::ScheduledTask</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Selector/PutClause.html#execute-instance_method" title="Concurrent::Channel::Selector::PutClause#execute (method)">#execute</a></span>
       <small>Concurrent::Channel::Selector::PutClause</small>
@@ -2012,34 +2004,10 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/ScheduledTask.html#execute-instance_method" title="Concurrent::ScheduledTask#execute (method)">#execute</a></span>
-      <small>Concurrent::ScheduledTask</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Future.html#execute-instance_method" title="Concurrent::Future#execute (method)">#execute</a></span>
-      <small>Concurrent::Future</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Selector/TakeClause.html#execute-instance_method" title="Concurrent::Channel::Selector::TakeClause#execute (method)">#execute</a></span>
       <small>Concurrent::Channel::Selector::TakeClause</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Future.html#execute-class_method" title="Concurrent::Future.execute (method)">execute</a></span>
-      <small>Concurrent::Future</small>
     </div>
   </li>
   
@@ -2054,16 +2022,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Channel/Selector/ErrorClause.html#execute-instance_method" title="Concurrent::Channel::Selector::ErrorClause#execute (method)">#execute</a></span>
-      <small>Concurrent::Channel::Selector::ErrorClause</small>
+      <span class='object_link'><a href="Concurrent/Promise.html#execute-instance_method" title="Concurrent::Promise#execute (method)">#execute</a></span>
+      <small>Concurrent::Promise</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Promise.html#execute-instance_method" title="Concurrent::Promise#execute (method)">#execute</a></span>
-      <small>Concurrent::Promise</small>
+      <span class='object_link'><a href="Concurrent/Channel/Selector/ErrorClause.html#execute-instance_method" title="Concurrent::Channel::Selector::ErrorClause#execute (method)">#execute</a></span>
+      <small>Concurrent::Channel::Selector::ErrorClause</small>
     </div>
   </li>
   
@@ -2078,13 +2046,53 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/SafeTaskExecutor.html#execute-instance_method" title="Concurrent::SafeTaskExecutor#execute (method)">#execute</a></span>
-      <small>Concurrent::SafeTaskExecutor</small>
+      <span class='object_link'><a href="Concurrent/TimerTask.html#execute-class_method" title="Concurrent::TimerTask.execute (method)">execute</a></span>
+      <small>Concurrent::TimerTask</small>
     </div>
   </li>
   
 
   <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Channel/Selector/DefaultClause.html#execute-instance_method" title="Concurrent::Channel::Selector::DefaultClause#execute (method)">#execute</a></span>
+      <small>Concurrent::Channel::Selector::DefaultClause</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Future.html#execute-instance_method" title="Concurrent::Future#execute (method)">#execute</a></span>
+      <small>Concurrent::Future</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Future.html#execute-class_method" title="Concurrent::Future.execute (method)">execute</a></span>
+      <small>Concurrent::Future</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/ScheduledTask.html#execute-instance_method" title="Concurrent::ScheduledTask#execute (method)">#execute</a></span>
+      <small>Concurrent::ScheduledTask</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/ScheduledTask.html#execute-class_method" title="Concurrent::ScheduledTask.execute (method)">execute</a></span>
+      <small>Concurrent::ScheduledTask</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/TimerTask.html#execution_interval-instance_method" title="Concurrent::TimerTask#execution_interval (method)">#execution_interval</a></span>
       <small>Concurrent::TimerTask</small>
@@ -2092,7 +2100,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/PublicDelegations.html#executor-instance_method" title="Concurrent::Actor::PublicDelegations#executor (method)">#executor</a></span>
       <small>Concurrent::Actor::PublicDelegations</small>
@@ -2100,23 +2108,7 @@
   </li>
   
 
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Actor/Core.html#executor-instance_method" title="Concurrent::Actor::Core#executor (method)">#executor</a></span>
-      <small>Concurrent::Actor::Core</small>
-    </div>
-  </li>
-  
-
   <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/SerializedExecution/Job.html#executor-instance_method" title="Concurrent::SerializedExecution::Job#executor (method)">#executor</a></span>
-      <small>Concurrent::SerializedExecution::Job</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#executor-class_method" title="Concurrent.executor (method)">executor</a></span>
       <small>Concurrent</small>
@@ -2124,10 +2116,18 @@
   </li>
   
 
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/SerializedExecution/Job.html#executor-instance_method" title="Concurrent::SerializedExecution::Job#executor (method)">#executor</a></span>
+      <small>Concurrent::SerializedExecution::Job</small>
+    </div>
+  </li>
+  
+
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Promise.html#fail-instance_method" title="Concurrent::Promise#fail (method)">#fail</a></span>
-      <small>Concurrent::Promise</small>
+      <span class='object_link'><a href="Concurrent/Actor/Core.html#executor-instance_method" title="Concurrent::Actor::Core#executor (method)">#executor</a></span>
+      <small>Concurrent::Actor::Core</small>
     </div>
   </li>
   
@@ -2142,16 +2142,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Agent.html#failed%3F-instance_method" title="Concurrent::Agent#failed? (method)">#failed?</a></span>
-      <small>Concurrent::Agent</small>
+      <span class='object_link'><a href="Concurrent/Promise.html#fail-instance_method" title="Concurrent::Promise#fail (method)">#fail</a></span>
+      <small>Concurrent::Promise</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#fallback_policy-instance_method" title="Concurrent::ThreadPoolExecutor#fallback_policy (method)">#fallback_policy</a></span>
-      <small>Concurrent::ThreadPoolExecutor</small>
+      <span class='object_link'><a href="Concurrent/Agent.html#failed%3F-instance_method" title="Concurrent::Agent#failed? (method)">#failed?</a></span>
+      <small>Concurrent::Agent</small>
     </div>
   </li>
   
@@ -2166,13 +2166,21 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#fallback_policy-instance_method" title="Concurrent::ThreadPoolExecutor#fallback_policy (method)">#fallback_policy</a></span>
+      <small>Concurrent::ThreadPoolExecutor</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicBoolean.html#false%3F-instance_method" title="Concurrent::AtomicBoolean#false? (method)">#false?</a></span>
       <small>Concurrent::AtomicBoolean</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#fetch-instance_method" title="Concurrent::Map#fetch (method)">#fetch</a></span>
       <small>Concurrent::Map</small>
@@ -2180,7 +2188,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#fetch_or_store-instance_method" title="Concurrent::Map#fetch_or_store (method)">#fetch_or_store</a></span>
       <small>Concurrent::Map</small>
@@ -2188,7 +2196,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Utils/Broadcast.html#filtered_receivers-instance_method" title="Concurrent::Actor::Utils::Broadcast#filtered_receivers (method)">#filtered_receivers</a></span>
       <small>Concurrent::Actor::Utils::Broadcast</small>
@@ -2196,7 +2204,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Window.html#find-class_method" title="Concurrent::Edge::LockFreeLinkedSet::Window.find (method)">find</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet::Window</small>
@@ -2204,7 +2212,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#flat_event-instance_method" title="Concurrent::Promises::Future#flat_event (method)">#flat_event</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -2212,7 +2220,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#flat_future-instance_method" title="Concurrent::Promises::Future#flat_future (method)">#flat_future</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -2220,7 +2228,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promise.html#flat_map-instance_method" title="Concurrent::Promise#flat_map (method)">#flat_map</a></span>
       <small>Concurrent::Promise</small>
@@ -2228,7 +2236,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Terminated.html#from-instance_method" title="Concurrent::ErlangActor::Terminated#from (method)">#from</a></span>
       <small>Concurrent::ErlangActor::Terminated</small>
@@ -2236,7 +2244,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Maybe.html#from-class_method" title="Concurrent::Maybe.from (method)">from</a></span>
       <small>Concurrent::Maybe</small>
@@ -2244,7 +2252,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Down.html#from-instance_method" title="Concurrent::ErlangActor::Down#from (method)">#from</a></span>
       <small>Concurrent::ErlangActor::Down</small>
@@ -2252,7 +2260,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promise.html#fulfill-class_method" title="Concurrent::Promise.fulfill (method)">fulfill</a></span>
       <small>Concurrent::Promise</small>
@@ -2260,18 +2268,10 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableFuture.html#fulfill-instance_method" title="Concurrent::Promises::ResolvableFuture#fulfill (method)">#fulfill</a></span>
       <small>Concurrent::Promises::ResolvableFuture</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Promises/Future.html#fulfilled%3F-instance_method" title="Concurrent::Promises::Future#fulfilled? (method)">#fulfilled?</a></span>
-      <small>Concurrent::Promises::Future</small>
     </div>
   </li>
   
@@ -2286,8 +2286,24 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/Promises/Future.html#fulfilled%3F-instance_method" title="Concurrent::Promises::Future#fulfilled? (method)">#fulfilled?</a></span>
+      <small>Concurrent::Promises::Future</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#fulfilled_future-instance_method" title="Concurrent::Promises::FactoryMethods#fulfilled_future (method)">#fulfilled_future</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Concurrent/Channel/Buffer/Unbuffered.html#full%3F-instance_method" title="Concurrent::Channel::Buffer::Unbuffered#full? (method)">#full?</a></span>
+      <small>Concurrent::Channel::Buffer::Unbuffered</small>
     </div>
   </li>
   
@@ -2310,32 +2326,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Channel/Buffer/Unbuffered.html#full%3F-instance_method" title="Concurrent::Channel::Buffer::Unbuffered#full? (method)">#full?</a></span>
-      <small>Concurrent::Channel::Buffer::Unbuffered</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Dropping.html#full%3F-instance_method" title="Concurrent::Channel::Buffer::Dropping#full? (method)">#full?</a></span>
       <small>Concurrent::Channel::Buffer::Dropping</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MVar.html#full%3F-instance_method" title="Concurrent::MVar#full? (method)">#full?</a></span>
       <small>Concurrent::MVar</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#future-instance_method" title="Concurrent::Promises::FactoryMethods#future (method)">#future</a></span>
-      <small>Concurrent::Promises::FactoryMethods</small>
     </div>
   </li>
   
@@ -2350,7 +2350,7 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#future_on-instance_method" title="Concurrent::Promises::FactoryMethods#future_on (method)">#future_on</a></span>
+      <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#future-instance_method" title="Concurrent::Promises::FactoryMethods#future (method)">#future</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
     </div>
   </li>
@@ -2358,24 +2358,24 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/AtomicMarkableReference.html#get-instance_method" title="Concurrent::AtomicMarkableReference#get (method)">#get</a></span>
-      <small>Concurrent::AtomicMarkableReference</small>
+      <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#future_on-instance_method" title="Concurrent::Promises::FactoryMethods#future_on (method)">#future_on</a></span>
+      <small>Concurrent::Promises::FactoryMethods</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/Tuple.html#get-instance_method" title="Concurrent::Tuple#get (method)">#get</a></span>
-      <small>Concurrent::Tuple</small>
+      <span class='object_link'><a href="Concurrent/ThreadSafe/Util/XorShiftRandom.html#get-instance_method" title="Concurrent::ThreadSafe::Util::XorShiftRandom#get (method)">#get</a></span>
+      <small>Concurrent::ThreadSafe::Util::XorShiftRandom</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Concurrent/ThreadSafe/Util/XorShiftRandom.html#get-instance_method" title="Concurrent::ThreadSafe::Util::XorShiftRandom#get (method)">#get</a></span>
-      <small>Concurrent::ThreadSafe::Util::XorShiftRandom</small>
+      <span class='object_link'><a href="Concurrent/Tuple.html#get-instance_method" title="Concurrent::Tuple#get (method)">#get</a></span>
+      <small>Concurrent::Tuple</small>
     </div>
   </li>
   
@@ -2390,13 +2390,21 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/AtomicMarkableReference.html#get-instance_method" title="Concurrent::AtomicMarkableReference#get (method)">#get</a></span>
+      <small>Concurrent::AtomicMarkableReference</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#get_and_set-instance_method" title="Concurrent::Map#get_and_set (method)">#get_and_set</a></span>
       <small>Concurrent::Map</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicReference.html#get_and_set-instance_method" title="Concurrent::AtomicReference#get_and_set (method)">#get_and_set</a></span>
       <small>Concurrent::AtomicReference</small>
@@ -2404,7 +2412,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#global_fast_executor-class_method" title="Concurrent.global_fast_executor (method)">global_fast_executor</a></span>
       <small>Concurrent</small>
@@ -2412,7 +2420,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#global_immediate_executor-class_method" title="Concurrent.global_immediate_executor (method)">global_immediate_executor</a></span>
       <small>Concurrent</small>
@@ -2420,7 +2428,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#global_io_executor-class_method" title="Concurrent.global_io_executor (method)">global_io_executor</a></span>
       <small>Concurrent</small>
@@ -2428,7 +2436,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#global_logger-class_method" title="Concurrent.global_logger (method)">global_logger</a></span>
       <small>Concurrent</small>
@@ -2436,7 +2444,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#global_logger=-class_method" title="Concurrent.global_logger= (method)">global_logger=</a></span>
       <small>Concurrent</small>
@@ -2444,7 +2452,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#global_timer_set-class_method" title="Concurrent.global_timer_set (method)">global_timer_set</a></span>
       <small>Concurrent</small>
@@ -2452,7 +2460,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#go-class_method" title="Concurrent::Channel.go (method)">go</a></span>
       <small>Concurrent::Channel</small>
@@ -2460,7 +2468,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#go_loop-class_method" title="Concurrent::Channel.go_loop (method)">go_loop</a></span>
       <small>Concurrent::Channel</small>
@@ -2468,7 +2476,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#go_loop_via-class_method" title="Concurrent::Channel.go_loop_via (method)">go_loop_via</a></span>
       <small>Concurrent::Channel</small>
@@ -2476,7 +2484,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#go_via-class_method" title="Concurrent::Channel.go_via (method)">go_via</a></span>
       <small>Concurrent::Channel</small>
@@ -2484,7 +2492,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#guard!-instance_method" title="Concurrent::Actor::Core#guard! (method)">#guard!</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -2492,18 +2500,10 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReadWriteLock.html#has_waiters%3F-instance_method" title="Concurrent::ReadWriteLock#has_waiters? (method)">#has_waiters?</a></span>
       <small>Concurrent::ReadWriteLock</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Concurrent/ErlangActor/Terminated.html#hash-instance_method" title="Concurrent::ErlangActor::Terminated#hash (method)">#hash</a></span>
-      <small>Concurrent::ErlangActor::Terminated</small>
     </div>
   </li>
   
@@ -2526,13 +2526,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Concurrent/ErlangActor/Terminated.html#hash-instance_method" title="Concurrent::ErlangActor::Terminated#hash (method)">#hash</a></span>
+      <small>Concurrent::ErlangActor::Terminated</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#idletime-instance_method" title="Concurrent::ThreadPoolExecutor#idletime (method)">#idletime</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Concern/Obligation.html#incomplete%3F-instance_method" title="Concurrent::Concern::Obligation#incomplete? (method)">#incomplete?</a></span>
       <small>Concurrent::Concern::Obligation</small>
@@ -2540,7 +2548,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicFixnum.html#increment-instance_method" title="Concurrent::AtomicFixnum#increment (method)">#increment</a></span>
       <small>Concurrent::AtomicFixnum</small>
@@ -2548,7 +2556,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Down.html#info-instance_method" title="Concurrent::ErlangActor::Down#info (method)">#info</a></span>
       <small>Concurrent::ErlangActor::Down</small>
@@ -2556,7 +2564,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ScheduledTask.html#initial_delay-instance_method" title="Concurrent::ScheduledTask#initial_delay (method)">#initial_delay</a></span>
       <small>Concurrent::ScheduledTask</small>
@@ -2564,7 +2572,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Selector/PutClause.html#initialize-instance_method" title="Concurrent::Channel::Selector::PutClause#initialize (method)">#initialize</a></span>
       <small>Concurrent::Channel::Selector::PutClause</small>
@@ -2572,7 +2580,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#initialize-instance_method" title="Concurrent::Map#initialize (method)">#initialize</a></span>
       <small>Concurrent::Map</small>
@@ -2580,7 +2588,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Atom.html#initialize-instance_method" title="Concurrent::Atom#initialize (method)">#initialize</a></span>
       <small>Concurrent::Atom</small>
@@ -2588,7 +2596,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/IVar.html#initialize-instance_method" title="Concurrent::IVar#initialize (method)">#initialize</a></span>
       <small>Concurrent::IVar</small>
@@ -2596,7 +2604,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MVar.html#initialize-instance_method" title="Concurrent::MVar#initialize (method)">#initialize</a></span>
       <small>Concurrent::MVar</small>
@@ -2604,7 +2612,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/TVar.html#initialize-instance_method" title="Concurrent::TVar#initialize (method)">#initialize</a></span>
       <small>Concurrent::TVar</small>
@@ -2612,7 +2620,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Transaction.html#initialize-instance_method" title="Concurrent::Transaction#initialize (method)">#initialize</a></span>
       <small>Concurrent::Transaction</small>
@@ -2620,7 +2628,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent/Error.html#initialize-instance_method" title="Concurrent::Agent::Error#initialize (method)">#initialize</a></span>
       <small>Concurrent::Agent::Error</small>
@@ -2628,7 +2636,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent/ValidationError.html#initialize-instance_method" title="Concurrent::Agent::ValidationError#initialize (method)">#initialize</a></span>
       <small>Concurrent::Agent::ValidationError</small>
@@ -2636,7 +2644,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#initialize-instance_method" title="Concurrent::Agent#initialize (method)">#initialize</a></span>
       <small>Concurrent::Agent</small>
@@ -2644,7 +2652,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Delay.html#initialize-instance_method" title="Concurrent::Delay#initialize (method)">#initialize</a></span>
       <small>Concurrent::Delay</small>
@@ -2652,7 +2660,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Tuple.html#initialize-instance_method" title="Concurrent::Tuple#initialize (method)">#initialize</a></span>
       <small>Concurrent::Tuple</small>
@@ -2660,7 +2668,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MultipleAssignmentError.html#initialize-instance_method" title="Concurrent::MultipleAssignmentError#initialize (method)">#initialize</a></span>
       <small>Concurrent::MultipleAssignmentError</small>
@@ -2668,7 +2676,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MultipleErrors.html#initialize-instance_method" title="Concurrent::MultipleErrors#initialize (method)">#initialize</a></span>
       <small>Concurrent::MultipleErrors</small>
@@ -2676,7 +2684,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Future.html#initialize-instance_method" title="Concurrent::Future#initialize (method)">#initialize</a></span>
       <small>Concurrent::Future</small>
@@ -2684,7 +2692,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promise.html#initialize-instance_method" title="Concurrent::Promise#initialize (method)">#initialize</a></span>
       <small>Concurrent::Promise</small>
@@ -2692,7 +2700,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#initialize-instance_method" title="Concurrent#initialize (method)">#initialize</a></span>
       <small>Concurrent</small>
@@ -2700,7 +2708,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/TimerTask.html#initialize-instance_method" title="Concurrent::TimerTask#initialize (method)">#initialize</a></span>
       <small>Concurrent::TimerTask</small>
@@ -2708,7 +2716,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Event.html#initialize-instance_method" title="Concurrent::Event#initialize (method)">#initialize</a></span>
       <small>Concurrent::Event</small>
@@ -2716,7 +2724,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ScheduledTask.html#initialize-instance_method" title="Concurrent::ScheduledTask#initialize (method)">#initialize</a></span>
       <small>Concurrent::ScheduledTask</small>
@@ -2724,7 +2732,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Semaphore.html#initialize-instance_method" title="Concurrent::Semaphore#initialize (method)">#initialize</a></span>
       <small>Concurrent::Semaphore</small>
@@ -2732,7 +2740,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/TimerSet.html#initialize-instance_method" title="Concurrent::TimerSet#initialize (method)">#initialize</a></span>
       <small>Concurrent::TimerSet</small>
@@ -2740,7 +2748,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicFixnum.html#initialize-instance_method" title="Concurrent::AtomicFixnum#initialize (method)">#initialize</a></span>
       <small>Concurrent::AtomicFixnum</small>
@@ -2748,7 +2756,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicBoolean.html#initialize-instance_method" title="Concurrent::AtomicBoolean#initialize (method)">#initialize</a></span>
       <small>Concurrent::AtomicBoolean</small>
@@ -2756,7 +2764,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/CyclicBarrier.html#initialize-instance_method" title="Concurrent::CyclicBarrier#initialize (method)">#initialize</a></span>
       <small>Concurrent::CyclicBarrier</small>
@@ -2764,7 +2772,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReadWriteLock.html#initialize-instance_method" title="Concurrent::ReadWriteLock#initialize (method)">#initialize</a></span>
       <small>Concurrent::ReadWriteLock</small>
@@ -2772,7 +2780,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization/Object.html#initialize-instance_method" title="Concurrent::Synchronization::Object#initialize (method)">#initialize</a></span>
       <small>Concurrent::Synchronization::Object</small>
@@ -2780,7 +2788,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicReference.html#initialize-instance_method" title="Concurrent::AtomicReference#initialize (method)">#initialize</a></span>
       <small>Concurrent::AtomicReference</small>
@@ -2788,7 +2796,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/CountDownLatch.html#initialize-instance_method" title="Concurrent::CountDownLatch#initialize (method)">#initialize</a></span>
       <small>Concurrent::CountDownLatch</small>
@@ -2796,7 +2804,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadLocalVar.html#initialize-instance_method" title="Concurrent::ThreadLocalVar#initialize (method)">#initialize</a></span>
       <small>Concurrent::ThreadLocalVar</small>
@@ -2804,7 +2812,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack/Node.html#initialize-instance_method" title="Concurrent::LockFreeStack::Node#initialize (method)">#initialize</a></span>
       <small>Concurrent::LockFreeStack::Node</small>
@@ -2812,7 +2820,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/FixedThreadPool.html#initialize-instance_method" title="Concurrent::FixedThreadPool#initialize (method)">#initialize</a></span>
       <small>Concurrent::FixedThreadPool</small>
@@ -2820,7 +2828,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/CachedThreadPool.html#initialize-instance_method" title="Concurrent::CachedThreadPool#initialize (method)">#initialize</a></span>
       <small>Concurrent::CachedThreadPool</small>
@@ -2828,7 +2836,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ImmediateExecutor.html#initialize-instance_method" title="Concurrent::ImmediateExecutor#initialize (method)">#initialize</a></span>
       <small>Concurrent::ImmediateExecutor</small>
@@ -2836,7 +2844,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SafeTaskExecutor.html#initialize-instance_method" title="Concurrent::SafeTaskExecutor#initialize (method)">#initialize</a></span>
       <small>Concurrent::SafeTaskExecutor</small>
@@ -2844,7 +2852,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SerializedExecution.html#initialize-instance_method" title="Concurrent::SerializedExecution#initialize (method)">#initialize</a></span>
       <small>Concurrent::SerializedExecution</small>
@@ -2852,7 +2860,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization.html#initialize-instance_method" title="Concurrent::Synchronization#initialize (method)">#initialize</a></span>
       <small>Concurrent::Synchronization</small>
@@ -2860,7 +2868,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicMarkableReference.html#initialize-instance_method" title="Concurrent::AtomicMarkableReference#initialize (method)">#initialize</a></span>
       <small>Concurrent::AtomicMarkableReference</small>
@@ -2868,7 +2876,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReentrantReadWriteLock.html#initialize-instance_method" title="Concurrent::ReentrantReadWriteLock#initialize (method)">#initialize</a></span>
       <small>Concurrent::ReentrantReadWriteLock</small>
@@ -2876,7 +2884,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/IndirectImmediateExecutor.html#initialize-instance_method" title="Concurrent::IndirectImmediateExecutor#initialize (method)">#initialize</a></span>
       <small>Concurrent::IndirectImmediateExecutor</small>
@@ -2884,7 +2892,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Collection/CopyOnWriteObserverSet.html#initialize-instance_method" title="Concurrent::Collection::CopyOnWriteObserverSet#initialize (method)">#initialize</a></span>
       <small>Concurrent::Collection::CopyOnWriteObserverSet</small>
@@ -2892,7 +2900,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Collection/CopyOnNotifyObserverSet.html#initialize-instance_method" title="Concurrent::Collection::CopyOnNotifyObserverSet#initialize (method)">#initialize</a></span>
       <small>Concurrent::Collection::CopyOnNotifyObserverSet</small>
@@ -2900,7 +2908,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SerializedExecutionDelegator.html#initialize-instance_method" title="Concurrent::SerializedExecutionDelegator#initialize (method)">#initialize</a></span>
       <small>Concurrent::SerializedExecutionDelegator</small>
@@ -2908,7 +2916,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/ValidationError.html#initialize-instance_method" title="Concurrent::Channel::ValidationError#initialize (method)">#initialize</a></span>
       <small>Concurrent::Channel::ValidationError</small>
@@ -2916,7 +2924,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#initialize-instance_method" title="Concurrent::Channel#initialize (method)">#initialize</a></span>
       <small>Concurrent::Channel</small>
@@ -2924,7 +2932,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#initialize-instance_method" title="Concurrent::Actor::Core#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -2932,7 +2940,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Root.html#initialize-instance_method" title="Concurrent::Actor::Root#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Root</small>
@@ -2940,7 +2948,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/ActorTerminated.html#initialize-instance_method" title="Concurrent::Actor::ActorTerminated#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::ActorTerminated</small>
@@ -2948,7 +2956,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/UnknownMessage.html#initialize-instance_method" title="Concurrent::Actor::UnknownMessage#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::UnknownMessage</small>
@@ -2956,7 +2964,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Tick.html#initialize-instance_method" title="Concurrent::Channel::Tick#initialize (method)">#initialize</a></span>
       <small>Concurrent::Channel::Tick</small>
@@ -2964,7 +2972,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#initialize-instance_method" title="Concurrent::Promises::Channel#initialize (method)">#initialize</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -2972,7 +2980,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Throttle.html#initialize-instance_method" title="Concurrent::Throttle#initialize (method)">#initialize</a></span>
       <small>Concurrent::Throttle</small>
@@ -2980,7 +2988,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LazyRegister.html#initialize-instance_method" title="Concurrent::LazyRegister#initialize (method)">#initialize</a></span>
       <small>Concurrent::LazyRegister</small>
@@ -2988,7 +2996,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Envelope.html#initialize-instance_method" title="Concurrent::Actor::Envelope#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Envelope</small>
@@ -2996,7 +3004,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Utils/Pool.html#initialize-instance_method" title="Concurrent::Actor::Utils::Pool#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Utils::Pool</small>
@@ -3004,7 +3012,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Cancellation.html#initialize-instance_method" title="Concurrent::Cancellation#initialize (method)">#initialize</a></span>
       <small>Concurrent::Cancellation</small>
@@ -3012,7 +3020,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/EnvironmentConstants/AbstractLogicOperationMatcher.html#initialize-instance_method" title="Concurrent::ErlangActor::EnvironmentConstants::AbstractLogicOperationMatcher#initialize (method)">#initialize</a></span>
       <small>Concurrent::ErlangActor::EnvironmentConstants::AbstractLogicOperationMatcher</small>
@@ -3020,7 +3028,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/NoActor.html#initialize-instance_method" title="Concurrent::ErlangActor::NoActor#initialize (method)">#initialize</a></span>
       <small>Concurrent::ErlangActor::NoActor</small>
@@ -3028,7 +3036,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Utils/AsAdHoc.html#initialize-instance_method" title="Concurrent::Actor::Utils::AsAdHoc#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Utils::AsAdHoc</small>
@@ -3036,7 +3044,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Base.html#initialize-instance_method" title="Concurrent::Channel::Buffer::Base#initialize (method)">#initialize</a></span>
       <small>Concurrent::Channel::Buffer::Base</small>
@@ -3044,7 +3052,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Utils/Balancer.html#initialize-instance_method" title="Concurrent::Actor::Utils::Balancer#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Utils::Balancer</small>
@@ -3052,7 +3060,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeQueue/Node.html#initialize-instance_method" title="Concurrent::LockFreeQueue::Node#initialize (method)">#initialize</a></span>
       <small>Concurrent::LockFreeQueue::Node</small>
@@ -3060,7 +3068,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Utils/Broadcast.html#initialize-instance_method" title="Concurrent::Actor::Utils::Broadcast#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Utils::Broadcast</small>
@@ -3068,7 +3076,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Buffer.html#initialize-instance_method" title="Concurrent::Actor::Behaviour::Buffer#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Behaviour::Buffer</small>
@@ -3076,7 +3084,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Linking.html#initialize-instance_method" title="Concurrent::Actor::Behaviour::Linking#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Behaviour::Linking</small>
@@ -3084,7 +3092,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Pausing.html#initialize-instance_method" title="Concurrent::Actor::Behaviour::Pausing#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Behaviour::Pausing</small>
@@ -3092,7 +3100,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Abstract.html#initialize-instance_method" title="Concurrent::Actor::Behaviour::Abstract#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Behaviour::Abstract</small>
@@ -3100,7 +3108,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet.html#initialize-instance_method" title="Concurrent::Edge::LockFreeLinkedSet#initialize (method)">#initialize</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet</small>
@@ -3108,7 +3116,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/WrappingExecutor.html#initialize-instance_method" title="Concurrent::WrappingExecutor#initialize (method)">#initialize</a></span>
       <small>Concurrent::WrappingExecutor</small>
@@ -3116,7 +3124,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Supervising.html#initialize-instance_method" title="Concurrent::Actor::Behaviour::Supervising#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Behaviour::Supervising</small>
@@ -3124,7 +3132,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Termination.html#initialize-instance_method" title="Concurrent::Actor::Behaviour::Termination#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Behaviour::Termination</small>
@@ -3132,7 +3140,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/SetResults.html#initialize-instance_method" title="Concurrent::Actor::Behaviour::SetResults#initialize (method)">#initialize</a></span>
       <small>Concurrent::Actor::Behaviour::SetResults</small>
@@ -3140,7 +3148,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Selector/TakeClause.html#initialize-instance_method" title="Concurrent::Channel::Selector::TakeClause#initialize (method)">#initialize</a></span>
       <small>Concurrent::Channel::Selector::TakeClause</small>
@@ -3148,7 +3156,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Selector/AfterClause.html#initialize-instance_method" title="Concurrent::Channel::Selector::AfterClause#initialize (method)">#initialize</a></span>
       <small>Concurrent::Channel::Selector::AfterClause</small>
@@ -3156,7 +3164,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Selector/ErrorClause.html#initialize-instance_method" title="Concurrent::Channel::Selector::ErrorClause#initialize (method)">#initialize</a></span>
       <small>Concurrent::Channel::Selector::ErrorClause</small>
@@ -3164,7 +3172,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Node.html#initialize-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Node#initialize (method)">#initialize</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet::Node</small>
@@ -3172,7 +3180,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Tail.html#initialize-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Tail#initialize (method)">#initialize</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet::Tail</small>
@@ -3180,7 +3188,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Selector/DefaultClause.html#initialize-instance_method" title="Concurrent::Channel::Selector::DefaultClause#initialize (method)">#initialize</a></span>
       <small>Concurrent::Channel::Selector::DefaultClause</small>
@@ -3188,7 +3196,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Window.html#initialize-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Window#initialize (method)">#initialize</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet::Window</small>
@@ -3196,7 +3204,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack.html#initialize-instance_method" title="Concurrent::LockFreeStack#initialize (method)">#initialize</a></span>
       <small>Concurrent::LockFreeStack</small>
@@ -3204,7 +3212,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MutableStruct.html#inspect-instance_method" title="Concurrent::MutableStruct#inspect (method)">#inspect</a></span>
       <small>Concurrent::MutableStruct</small>
@@ -3212,7 +3220,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MultipleAssignmentError.html#inspect-instance_method" title="Concurrent::MultipleAssignmentError#inspect (method)">#inspect</a></span>
       <small>Concurrent::MultipleAssignmentError</small>
@@ -3220,7 +3228,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ImmutableStruct.html#inspect-instance_method" title="Concurrent::ImmutableStruct#inspect (method)">#inspect</a></span>
       <small>Concurrent::ImmutableStruct</small>
@@ -3228,7 +3236,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SettableStruct.html#inspect-instance_method" title="Concurrent::SettableStruct#inspect (method)">#inspect</a></span>
       <small>Concurrent::SettableStruct</small>
@@ -3236,7 +3244,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MultipleAssignmentError.html#inspection_data-instance_method" title="Concurrent::MultipleAssignmentError#inspection_data (method)">#inspection_data</a></span>
       <small>Concurrent::MultipleAssignmentError</small>
@@ -3244,7 +3252,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#internal_state-instance_method" title="Concurrent::Promises::AbstractEventFuture#internal_state (method)">#internal_state</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
@@ -3252,7 +3260,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeQueue/Node.html#item-instance_method" title="Concurrent::LockFreeQueue::Node#item (method)">#item</a></span>
       <small>Concurrent::LockFreeQueue::Node</small>
@@ -3260,7 +3268,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Cancellation.html#join-instance_method" title="Concurrent::Cancellation#join (method)">#join</a></span>
       <small>Concurrent::Cancellation</small>
@@ -3268,7 +3276,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Maybe.html#just-class_method" title="Concurrent::Maybe.just (method)">just</a></span>
       <small>Concurrent::Maybe</small>
@@ -3276,7 +3284,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Maybe.html#just-instance_method" title="Concurrent::Maybe#just (method)">#just</a></span>
       <small>Concurrent::Maybe</small>
@@ -3284,7 +3292,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Maybe.html#just%3F-instance_method" title="Concurrent::Maybe#just? (method)">#just?</a></span>
       <small>Concurrent::Maybe</small>
@@ -3292,7 +3300,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Node.html#key-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Node#key (method)">#key</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet::Node</small>
@@ -3300,7 +3308,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#key-instance_method" title="Concurrent::Map#key (method)">#key</a></span>
       <small>Concurrent::Map</small>
@@ -3308,7 +3316,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Node.html#key_for-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Node#key_for (method)">#key_for</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet::Node</small>
@@ -3316,7 +3324,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#keys-instance_method" title="Concurrent::Map#keys (method)">#keys</a></span>
       <small>Concurrent::Map</small>
@@ -3324,7 +3332,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#kill-instance_method" title="Concurrent::ThreadPoolExecutor#kill (method)">#kill</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -3332,7 +3340,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#kill-instance_method" title="Concurrent::SingleThreadExecutor#kill (method)">#kill</a></span>
       <small>Concurrent::SingleThreadExecutor</small>
@@ -3340,7 +3348,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SimpleExecutorService.html#kill-instance_method" title="Concurrent::SimpleExecutorService#kill (method)">#kill</a></span>
       <small>Concurrent::SimpleExecutorService</small>
@@ -3348,7 +3356,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/TimerSet.html#kill-instance_method" title="Concurrent::TimerSet#kill (method)">#kill</a></span>
       <small>Concurrent::TimerSet</small>
@@ -3356,7 +3364,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#largest_length-instance_method" title="Concurrent::ThreadPoolExecutor#largest_length (method)">#largest_length</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -3364,7 +3372,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Node.html#last%3F-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Node#last? (method)">#last?</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet::Node</small>
@@ -3372,7 +3380,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#leave_transaction-class_method" title="Concurrent.leave_transaction (method)">leave_transaction</a></span>
       <small>Concurrent</small>
@@ -3380,7 +3388,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#length-instance_method" title="Concurrent::ThreadPoolExecutor#length (method)">#length</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -3388,7 +3396,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Linking.html#link-instance_method" title="Concurrent::Actor::Behaviour::Linking#link (method)">#link</a></span>
       <small>Concurrent::Actor::Behaviour::Linking</small>
@@ -3396,7 +3404,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#link-instance_method" title="Concurrent::ErlangActor::Environment#link (method)">#link</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -3404,7 +3412,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour.html#linking-class_method" title="Concurrent::Actor::Behaviour.linking (method)">linking</a></span>
       <small>Concurrent::Actor::Behaviour</small>
@@ -3412,7 +3420,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Resolvable.html#locking_order_by-class_method" title="Concurrent::Promises::Resolvable.locking_order_by (method)">locking_order_by</a></span>
       <small>Concurrent::Promises::Resolvable</small>
@@ -3420,7 +3428,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#log-instance_method" title="Concurrent::Actor::Core#log (method)">#log</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -3428,7 +3436,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/InternalDelegations.html#log-instance_method" title="Concurrent::Actor::InternalDelegations#log (method)">#log</a></span>
       <small>Concurrent::Actor::InternalDelegations</small>
@@ -3436,7 +3444,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ProcessingActor.html#mailbox-instance_method" title="Concurrent::ProcessingActor#mailbox (method)">#mailbox</a></span>
       <small>Concurrent::ProcessingActor</small>
@@ -3444,7 +3452,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicBoolean.html#make_false-instance_method" title="Concurrent::AtomicBoolean#make_false (method)">#make_false</a></span>
       <small>Concurrent::AtomicBoolean</small>
@@ -3452,7 +3460,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#make_future-instance_method" title="Concurrent::Promises::FactoryMethods#make_future (method)">#make_future</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -3460,7 +3468,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicBoolean.html#make_true-instance_method" title="Concurrent::AtomicBoolean#make_true (method)">#make_true</a></span>
       <small>Concurrent::AtomicBoolean</small>
@@ -3468,7 +3476,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Reference.html#map-instance_method" title="Concurrent::Actor::Reference#map (method)">#map</a></span>
       <small>Concurrent::Actor::Reference</small>
@@ -3476,7 +3484,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicMarkableReference.html#mark-instance_method" title="Concurrent::AtomicMarkableReference#mark (method)">#mark</a></span>
       <small>Concurrent::AtomicMarkableReference</small>
@@ -3484,7 +3492,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Throttle.html#max_capacity-instance_method" title="Concurrent::Throttle#max_capacity (method)">#max_capacity</a></span>
       <small>Concurrent::Throttle</small>
@@ -3492,7 +3500,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#max_length-instance_method" title="Concurrent::ThreadPoolExecutor#max_length (method)">#max_length</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -3500,7 +3508,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#max_queue-instance_method" title="Concurrent::ThreadPoolExecutor#max_queue (method)">#max_queue</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -3508,7 +3516,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ImmutableStruct.html#merge-instance_method" title="Concurrent::ImmutableStruct#merge (method)">#merge</a></span>
       <small>Concurrent::ImmutableStruct</small>
@@ -3516,7 +3524,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MutableStruct.html#merge-instance_method" title="Concurrent::MutableStruct#merge (method)">#merge</a></span>
       <small>Concurrent::MutableStruct</small>
@@ -3524,7 +3532,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SettableStruct.html#merge-instance_method" title="Concurrent::SettableStruct#merge (method)">#merge</a></span>
       <small>Concurrent::SettableStruct</small>
@@ -3532,7 +3540,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#merge_pair-instance_method" title="Concurrent::Map#merge_pair (method)">#merge_pair</a></span>
       <small>Concurrent::Map</small>
@@ -3540,7 +3548,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Reference.html#message-instance_method" title="Concurrent::Actor::Reference#message (method)">#message</a></span>
       <small>Concurrent::Actor::Reference</small>
@@ -3548,7 +3556,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Envelope.html#message-instance_method" title="Concurrent::Actor::Envelope#message (method)">#message</a></span>
       <small>Concurrent::Actor::Envelope</small>
@@ -3556,7 +3564,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#min_length-instance_method" title="Concurrent::ThreadPoolExecutor#min_length (method)">#min_length</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -3564,7 +3572,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MVar.html#modify-instance_method" title="Concurrent::MVar#modify (method)">#modify</a></span>
       <small>Concurrent::MVar</small>
@@ -3572,7 +3580,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MVar.html#modify!-instance_method" title="Concurrent::MVar#modify! (method)">#modify!</a></span>
       <small>Concurrent::MVar</small>
@@ -3580,7 +3588,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#monitor-instance_method" title="Concurrent::ErlangActor::Environment#monitor (method)">#monitor</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -3588,7 +3596,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Tick.html#monotonic-instance_method" title="Concurrent::Channel::Tick#monotonic (method)">#monotonic</a></span>
       <small>Concurrent::Channel::Tick</small>
@@ -3596,7 +3604,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#monotonic_time-class_method" title="Concurrent.monotonic_time (method)">monotonic_time</a></span>
       <small>Concurrent</small>
@@ -3604,7 +3612,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#name-instance_method" title="Concurrent::ErlangActor::Environment#name (method)">#name</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -3612,7 +3620,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/PublicDelegations.html#name-instance_method" title="Concurrent::Actor::PublicDelegations#name (method)">#name</a></span>
       <small>Concurrent::Actor::PublicDelegations</small>
@@ -3620,7 +3628,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Pid.html#name-instance_method" title="Concurrent::ErlangActor::Pid#name (method)">#name</a></span>
       <small>Concurrent::ErlangActor::Pid</small>
@@ -3628,7 +3636,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#name-instance_method" title="Concurrent::Actor::Core#name (method)">#name</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -3636,7 +3644,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Async.html#new-class_method" title="Concurrent::Async.new (method)">new</a></span>
       <small>Concurrent::Async</small>
@@ -3644,7 +3652,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#new_fast_executor-class_method" title="Concurrent.new_fast_executor (method)">new_fast_executor</a></span>
       <small>Concurrent</small>
@@ -3652,7 +3660,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#new_io_executor-class_method" title="Concurrent.new_io_executor (method)">new_io_executor</a></span>
       <small>Concurrent</small>
@@ -3660,7 +3668,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Base.html#next-instance_method" title="Concurrent::Channel::Buffer::Base#next (method)">#next</a></span>
       <small>Concurrent::Channel::Buffer::Base</small>
@@ -3668,7 +3676,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Buffered.html#next-instance_method" title="Concurrent::Channel::Buffer::Buffered#next (method)">#next</a></span>
       <small>Concurrent::Channel::Buffer::Buffered</small>
@@ -3676,7 +3684,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Unbuffered.html#next-instance_method" title="Concurrent::Channel::Buffer::Unbuffered#next (method)">#next</a></span>
       <small>Concurrent::Channel::Buffer::Unbuffered</small>
@@ -3684,7 +3692,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#next-instance_method" title="Concurrent::Channel#next (method)">#next</a></span>
       <small>Concurrent::Channel</small>
@@ -3692,7 +3700,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Timer.html#next-instance_method" title="Concurrent::Channel::Buffer::Timer#next (method)">#next</a></span>
       <small>Concurrent::Channel::Buffer::Timer</small>
@@ -3700,7 +3708,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#next%3F-instance_method" title="Concurrent::Channel#next? (method)">#next?</a></span>
       <small>Concurrent::Channel</small>
@@ -3708,7 +3716,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack/Node_5Bnil_2C_20nil_5D.html#next_node-class_method" title="Node[nil, nil].next_node (method)">next_node</a></span>
       <small>Node[nil, nil]</small>
@@ -3716,7 +3724,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack/Node.html#next_node-instance_method" title="Concurrent::LockFreeStack::Node#next_node (method)">#next_node</a></span>
       <small>Concurrent::LockFreeStack::Node</small>
@@ -3724,7 +3732,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Node.html#next_node-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Node#next_node (method)">#next_node</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet::Node</small>
@@ -3732,7 +3740,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Maybe.html#nothing-class_method" title="Concurrent::Maybe.nothing (method)">nothing</a></span>
       <small>Concurrent::Maybe</small>
@@ -3740,7 +3748,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Maybe.html#nothing-instance_method" title="Concurrent::Maybe#nothing (method)">#nothing</a></span>
       <small>Concurrent::Maybe</small>
@@ -3748,7 +3756,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Maybe.html#nothing%3F-instance_method" title="Concurrent::Maybe#nothing? (method)">#nothing?</a></span>
       <small>Concurrent::Maybe</small>
@@ -3756,7 +3764,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Collection/CopyOnWriteObserverSet.html#notify_and_delete_observers-instance_method" title="Concurrent::Collection::CopyOnWriteObserverSet#notify_and_delete_observers (method)">#notify_and_delete_observers</a></span>
       <small>Concurrent::Collection::CopyOnWriteObserverSet</small>
@@ -3764,7 +3772,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Collection/CopyOnNotifyObserverSet.html#notify_and_delete_observers-instance_method" title="Concurrent::Collection::CopyOnNotifyObserverSet#notify_and_delete_observers (method)">#notify_and_delete_observers</a></span>
       <small>Concurrent::Collection::CopyOnNotifyObserverSet</small>
@@ -3772,7 +3780,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Collection/CopyOnNotifyObserverSet.html#notify_observers-instance_method" title="Concurrent::Collection::CopyOnNotifyObserverSet#notify_observers (method)">#notify_observers</a></span>
       <small>Concurrent::Collection::CopyOnNotifyObserverSet</small>
@@ -3780,7 +3788,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Collection/CopyOnWriteObserverSet.html#notify_observers-instance_method" title="Concurrent::Collection::CopyOnWriteObserverSet#notify_observers (method)">#notify_observers</a></span>
       <small>Concurrent::Collection::CopyOnWriteObserverSet</small>
@@ -3788,7 +3796,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/CyclicBarrier.html#number_waiting-instance_method" title="Concurrent::CyclicBarrier#number_waiting (method)">#number_waiting</a></span>
       <small>Concurrent::CyclicBarrier</small>
@@ -3796,7 +3804,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Base.html#offer-instance_method" title="Concurrent::Channel::Buffer::Base#offer (method)">#offer</a></span>
       <small>Concurrent::Channel::Buffer::Base</small>
@@ -3804,7 +3812,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#offer-instance_method" title="Concurrent::Channel#offer (method)">#offer</a></span>
       <small>Concurrent::Channel</small>
@@ -3812,7 +3820,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Unbuffered.html#offer-instance_method" title="Concurrent::Channel::Buffer::Unbuffered#offer (method)">#offer</a></span>
       <small>Concurrent::Channel::Buffer::Unbuffered</small>
@@ -3820,7 +3828,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Sliding.html#offer-instance_method" title="Concurrent::Channel::Buffer::Sliding#offer (method)">#offer</a></span>
       <small>Concurrent::Channel::Buffer::Sliding</small>
@@ -3828,7 +3836,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Dropping.html#offer-instance_method" title="Concurrent::Channel::Buffer::Dropping#offer (method)">#offer</a></span>
       <small>Concurrent::Channel::Buffer::Dropping</small>
@@ -3836,7 +3844,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Buffered.html#offer-instance_method" title="Concurrent::Channel::Buffer::Buffered#offer (method)">#offer</a></span>
       <small>Concurrent::Channel::Buffer::Buffered</small>
@@ -3844,7 +3852,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Timer.html#offer-instance_method" title="Concurrent::Channel::Buffer::Timer#offer (method)">#offer</a></span>
       <small>Concurrent::Channel::Buffer::Timer</small>
@@ -3852,7 +3860,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#offer!-instance_method" title="Concurrent::Channel#offer! (method)">#offer!</a></span>
       <small>Concurrent::Channel</small>
@@ -3860,7 +3868,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#offer%3F-instance_method" title="Concurrent::Channel#offer? (method)">#offer?</a></span>
       <small>Concurrent::Channel</small>
@@ -3868,7 +3876,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Throttle.html#on-instance_method" title="Concurrent::Throttle#on (method)">#on</a></span>
       <small>Concurrent::Throttle</small>
@@ -3876,7 +3884,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#on-instance_method" title="Concurrent::ErlangActor::Environment#on (method)">#on</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -3884,7 +3892,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Pausing.html#on_envelope-instance_method" title="Concurrent::Actor::Behaviour::Pausing#on_envelope (method)">#on_envelope</a></span>
       <small>Concurrent::Actor::Behaviour::Pausing</small>
@@ -3892,7 +3900,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/ErrorsOnUnknownMessage.html#on_envelope-instance_method" title="Concurrent::Actor::Behaviour::ErrorsOnUnknownMessage#on_envelope (method)">#on_envelope</a></span>
       <small>Concurrent::Actor::Behaviour::ErrorsOnUnknownMessage</small>
@@ -3900,7 +3908,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Buffer.html#on_envelope-instance_method" title="Concurrent::Actor::Behaviour::Buffer#on_envelope (method)">#on_envelope</a></span>
       <small>Concurrent::Actor::Behaviour::Buffer</small>
@@ -3908,7 +3916,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Linking.html#on_envelope-instance_method" title="Concurrent::Actor::Behaviour::Linking#on_envelope (method)">#on_envelope</a></span>
       <small>Concurrent::Actor::Behaviour::Linking</small>
@@ -3916,7 +3924,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/ExecutesContext.html#on_envelope-instance_method" title="Concurrent::Actor::Behaviour::ExecutesContext#on_envelope (method)">#on_envelope</a></span>
       <small>Concurrent::Actor::Behaviour::ExecutesContext</small>
@@ -3924,7 +3932,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#on_envelope-instance_method" title="Concurrent::Actor::Core#on_envelope (method)">#on_envelope</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -3932,7 +3940,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Awaits.html#on_envelope-instance_method" title="Concurrent::Actor::Behaviour::Awaits#on_envelope (method)">#on_envelope</a></span>
       <small>Concurrent::Actor::Behaviour::Awaits</small>
@@ -3940,7 +3948,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/RemovesChild.html#on_envelope-instance_method" title="Concurrent::Actor::Behaviour::RemovesChild#on_envelope (method)">#on_envelope</a></span>
       <small>Concurrent::Actor::Behaviour::RemovesChild</small>
@@ -3948,7 +3956,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/SetResults.html#on_envelope-instance_method" title="Concurrent::Actor::Behaviour::SetResults#on_envelope (method)">#on_envelope</a></span>
       <small>Concurrent::Actor::Behaviour::SetResults</small>
@@ -3956,7 +3964,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Abstract.html#on_envelope-instance_method" title="Concurrent::Actor::Behaviour::Abstract#on_envelope (method)">#on_envelope</a></span>
       <small>Concurrent::Actor::Behaviour::Abstract</small>
@@ -3964,7 +3972,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Termination.html#on_envelope-instance_method" title="Concurrent::Actor::Behaviour::Termination#on_envelope (method)">#on_envelope</a></span>
       <small>Concurrent::Actor::Behaviour::Termination</small>
@@ -3972,7 +3980,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#on_envelope-instance_method" title="Concurrent::Actor::AbstractContext#on_envelope (method)">#on_envelope</a></span>
       <small>Concurrent::Actor::AbstractContext</small>
@@ -3980,7 +3988,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Supervising.html#on_envelope-instance_method" title="Concurrent::Actor::Behaviour::Supervising#on_envelope (method)">#on_envelope</a></span>
       <small>Concurrent::Actor::Behaviour::Supervising</small>
@@ -3988,7 +3996,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Buffer.html#on_event-instance_method" title="Concurrent::Actor::Behaviour::Buffer#on_event (method)">#on_event</a></span>
       <small>Concurrent::Actor::Behaviour::Buffer</small>
@@ -3996,7 +4004,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Linking.html#on_event-instance_method" title="Concurrent::Actor::Behaviour::Linking#on_event (method)">#on_event</a></span>
       <small>Concurrent::Actor::Behaviour::Linking</small>
@@ -4004,7 +4012,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Pausing.html#on_event-instance_method" title="Concurrent::Actor::Behaviour::Pausing#on_event (method)">#on_event</a></span>
       <small>Concurrent::Actor::Behaviour::Pausing</small>
@@ -4012,7 +4020,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#on_event-instance_method" title="Concurrent::Actor::AbstractContext#on_event (method)">#on_event</a></span>
       <small>Concurrent::Actor::AbstractContext</small>
@@ -4020,7 +4028,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/ExecutesContext.html#on_event-instance_method" title="Concurrent::Actor::Behaviour::ExecutesContext#on_event (method)">#on_event</a></span>
       <small>Concurrent::Actor::Behaviour::ExecutesContext</small>
@@ -4028,7 +4036,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Abstract.html#on_event-instance_method" title="Concurrent::Actor::Behaviour::Abstract#on_event (method)">#on_event</a></span>
       <small>Concurrent::Actor::Behaviour::Abstract</small>
@@ -4036,7 +4044,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#on_fulfillment-instance_method" title="Concurrent::Promises::Future#on_fulfillment (method)">#on_fulfillment</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -4044,7 +4052,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#on_fulfillment!-instance_method" title="Concurrent::Promises::Future#on_fulfillment! (method)">#on_fulfillment!</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -4052,7 +4060,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#on_fulfillment_using-instance_method" title="Concurrent::Promises::Future#on_fulfillment_using (method)">#on_fulfillment_using</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -4060,7 +4068,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Utils/Balancer.html#on_message-instance_method" title="Concurrent::Actor::Utils::Balancer#on_message (method)">#on_message</a></span>
       <small>Concurrent::Actor::Utils::Balancer</small>
@@ -4068,7 +4076,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#on_message-instance_method" title="Concurrent::Actor::AbstractContext#on_message (method)">#on_message</a></span>
       <small>Concurrent::Actor::AbstractContext</small>
@@ -4076,7 +4084,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Utils/AsAdHoc.html#on_message-instance_method" title="Concurrent::Actor::Utils::AsAdHoc#on_message (method)">#on_message</a></span>
       <small>Concurrent::Actor::Utils::AsAdHoc</small>
@@ -4084,7 +4092,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Utils/Pool.html#on_message-instance_method" title="Concurrent::Actor::Utils::Pool#on_message (method)">#on_message</a></span>
       <small>Concurrent::Actor::Utils::Pool</small>
@@ -4092,7 +4100,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/DefaultDeadLetterHandler.html#on_message-instance_method" title="Concurrent::Actor::DefaultDeadLetterHandler#on_message (method)">#on_message</a></span>
       <small>Concurrent::Actor::DefaultDeadLetterHandler</small>
@@ -4100,7 +4108,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Root.html#on_message-instance_method" title="Concurrent::Actor::Root#on_message (method)">#on_message</a></span>
       <small>Concurrent::Actor::Root</small>
@@ -4108,7 +4116,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Utils/Broadcast.html#on_message-instance_method" title="Concurrent::Actor::Utils::Broadcast#on_message (method)">#on_message</a></span>
       <small>Concurrent::Actor::Utils::Broadcast</small>
@@ -4116,7 +4124,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#on_rejection-instance_method" title="Concurrent::Promises::Future#on_rejection (method)">#on_rejection</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -4124,7 +4132,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#on_rejection!-instance_method" title="Concurrent::Promises::Future#on_rejection! (method)">#on_rejection!</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -4132,7 +4140,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#on_rejection_using-instance_method" title="Concurrent::Promises::Future#on_rejection_using (method)">#on_rejection_using</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -4140,7 +4148,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#on_resolution-instance_method" title="Concurrent::Promises::AbstractEventFuture#on_resolution (method)">#on_resolution</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
@@ -4148,7 +4156,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#on_resolution!-instance_method" title="Concurrent::Promises::AbstractEventFuture#on_resolution! (method)">#on_resolution!</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
@@ -4156,7 +4164,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#on_resolution_using-instance_method" title="Concurrent::Promises::AbstractEventFuture#on_resolution_using (method)">#on_resolution_using</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
@@ -4164,7 +4172,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promise.html#on_success-instance_method" title="Concurrent::Promise#on_success (method)">#on_success</a></span>
       <small>Concurrent::Promise</small>
@@ -4172,7 +4180,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Maybe.html#or-instance_method" title="Concurrent::Maybe#or (method)">#or</a></span>
       <small>Concurrent::Maybe</small>
@@ -4180,7 +4188,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Cancellation.html#origin-instance_method" title="Concurrent::Cancellation#origin (method)">#origin</a></span>
       <small>Concurrent::Cancellation</small>
@@ -4188,7 +4196,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/PublicDelegations.html#parent-instance_method" title="Concurrent::Actor::PublicDelegations#parent (method)">#parent</a></span>
       <small>Concurrent::Actor::PublicDelegations</small>
@@ -4196,7 +4204,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#parent-instance_method" title="Concurrent::Actor::Core#parent (method)">#parent</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -4204,7 +4212,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/CyclicBarrier.html#parties-instance_method" title="Concurrent::CyclicBarrier#parties (method)">#parties</a></span>
       <small>Concurrent::CyclicBarrier</small>
@@ -4212,7 +4220,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Abstract.html#pass-instance_method" title="Concurrent::Actor::Behaviour::Abstract#pass (method)">#pass</a></span>
       <small>Concurrent::Actor::Behaviour::Abstract</small>
@@ -4220,7 +4228,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#pass-instance_method" title="Concurrent::Actor::AbstractContext#pass (method)">#pass</a></span>
       <small>Concurrent::Actor::AbstractContext</small>
@@ -4228,7 +4236,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#path-instance_method" title="Concurrent::Actor::Core#path (method)">#path</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -4236,7 +4244,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/PublicDelegations.html#path-instance_method" title="Concurrent::Actor::PublicDelegations#path (method)">#path</a></span>
       <small>Concurrent::Actor::PublicDelegations</small>
@@ -4244,7 +4252,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Pausing.html#pause!-instance_method" title="Concurrent::Actor::Behaviour::Pausing#pause! (method)">#pause!</a></span>
       <small>Concurrent::Actor::Behaviour::Pausing</small>
@@ -4252,7 +4260,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Pausing.html#paused%3F-instance_method" title="Concurrent::Actor::Behaviour::Pausing#paused? (method)">#paused?</a></span>
       <small>Concurrent::Actor::Behaviour::Pausing</small>
@@ -4260,7 +4268,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack.html#peek-instance_method" title="Concurrent::LockFreeStack#peek (method)">#peek</a></span>
       <small>Concurrent::LockFreeStack</small>
@@ -4268,7 +4276,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#peek-instance_method" title="Concurrent::Promises::Channel#peek (method)">#peek</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -4276,7 +4284,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#peek_matching-instance_method" title="Concurrent::Promises::Channel#peek_matching (method)">#peek_matching</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -4284,7 +4292,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#pending%3F-instance_method" title="Concurrent::Promises::AbstractEventFuture#pending? (method)">#pending?</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
@@ -4292,7 +4300,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Concern/Obligation.html#pending%3F-instance_method" title="Concurrent::Concern::Obligation#pending? (method)">#pending?</a></span>
       <small>Concurrent::Concern::Obligation</small>
@@ -4300,7 +4308,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#physical_processor_count-class_method" title="Concurrent.physical_processor_count (method)">physical_processor_count</a></span>
       <small>Concurrent</small>
@@ -4308,7 +4316,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/NoActor.html#pid-instance_method" title="Concurrent::ErlangActor::NoActor#pid (method)">#pid</a></span>
       <small>Concurrent::ErlangActor::NoActor</small>
@@ -4316,7 +4324,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#pid-instance_method" title="Concurrent::ErlangActor::Environment#pid (method)">#pid</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -4324,7 +4332,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Buffered.html#poll-instance_method" title="Concurrent::Channel::Buffer::Buffered#poll (method)">#poll</a></span>
       <small>Concurrent::Channel::Buffer::Buffered</small>
@@ -4332,7 +4340,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Unbuffered.html#poll-instance_method" title="Concurrent::Channel::Buffer::Unbuffered#poll (method)">#poll</a></span>
       <small>Concurrent::Channel::Buffer::Unbuffered</small>
@@ -4340,7 +4348,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Timer.html#poll-instance_method" title="Concurrent::Channel::Buffer::Timer#poll (method)">#poll</a></span>
       <small>Concurrent::Channel::Buffer::Timer</small>
@@ -4348,7 +4356,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Base.html#poll-instance_method" title="Concurrent::Channel::Buffer::Base#poll (method)">#poll</a></span>
       <small>Concurrent::Channel::Buffer::Base</small>
@@ -4356,7 +4364,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#poll-instance_method" title="Concurrent::Channel#poll (method)">#poll</a></span>
       <small>Concurrent::Channel</small>
@@ -4364,7 +4372,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#poll!-instance_method" title="Concurrent::Channel#poll! (method)">#poll!</a></span>
       <small>Concurrent::Channel</small>
@@ -4372,7 +4380,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#poll%3F-instance_method" title="Concurrent::Channel#poll? (method)">#poll?</a></span>
       <small>Concurrent::Channel</small>
@@ -4380,7 +4388,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#pop-instance_method" title="Concurrent::Promises::Channel#pop (method)">#pop</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -4388,7 +4396,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack.html#pop-instance_method" title="Concurrent::LockFreeStack#pop (method)">#pop</a></span>
       <small>Concurrent::LockFreeStack</small>
@@ -4396,7 +4404,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#pop_matching-instance_method" title="Concurrent::Promises::Channel#pop_matching (method)">#pop_matching</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -4404,7 +4412,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#pop_op-instance_method" title="Concurrent::Promises::Channel#pop_op (method)">#pop_op</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -4412,7 +4420,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#pop_op_matching-instance_method" title="Concurrent::Promises::Channel#pop_op_matching (method)">#pop_op_matching</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -4420,7 +4428,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ImmediateExecutor.html#post-instance_method" title="Concurrent::ImmediateExecutor#post (method)">#post</a></span>
       <small>Concurrent::ImmediateExecutor</small>
@@ -4428,7 +4436,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SimpleExecutorService.html#post-class_method" title="Concurrent::SimpleExecutorService.post (method)">post</a></span>
       <small>Concurrent::SimpleExecutorService</small>
@@ -4436,7 +4444,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SerializedExecution.html#post-instance_method" title="Concurrent::SerializedExecution#post (method)">#post</a></span>
       <small>Concurrent::SerializedExecution</small>
@@ -4444,7 +4452,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/IndirectImmediateExecutor.html#post-instance_method" title="Concurrent::IndirectImmediateExecutor#post (method)">#post</a></span>
       <small>Concurrent::IndirectImmediateExecutor</small>
@@ -4452,7 +4460,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SerializedExecutionDelegator.html#post-instance_method" title="Concurrent::SerializedExecutionDelegator#post (method)">#post</a></span>
       <small>Concurrent::SerializedExecutionDelegator</small>
@@ -4460,7 +4468,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#post-instance_method" title="Concurrent::ThreadPoolExecutor#post (method)">#post</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -4468,7 +4476,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#post-instance_method" title="Concurrent::SingleThreadExecutor#post (method)">#post</a></span>
       <small>Concurrent::SingleThreadExecutor</small>
@@ -4476,7 +4484,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/WrappingExecutor.html#post-instance_method" title="Concurrent::WrappingExecutor#post (method)">#post</a></span>
       <small>Concurrent::WrappingExecutor</small>
@@ -4484,7 +4492,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/TimerSet.html#post-instance_method" title="Concurrent::TimerSet#post (method)">#post</a></span>
       <small>Concurrent::TimerSet</small>
@@ -4492,7 +4500,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SimpleExecutorService.html#post-instance_method" title="Concurrent::SimpleExecutorService#post (method)">#post</a></span>
       <small>Concurrent::SimpleExecutorService</small>
@@ -4500,7 +4508,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SerializedExecution.html#posts-instance_method" title="Concurrent::SerializedExecution#posts (method)">#posts</a></span>
       <small>Concurrent::SerializedExecution</small>
@@ -4508,7 +4516,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Window.html#pred-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Window#pred (method)">#pred</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet::Window</small>
@@ -4516,7 +4524,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#process_envelope-instance_method" title="Concurrent::Actor::Core#process_envelope (method)">#process_envelope</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -4524,7 +4532,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Buffer.html#process_envelope-instance_method" title="Concurrent::Actor::Behaviour::Buffer#process_envelope (method)">#process_envelope</a></span>
       <small>Concurrent::Actor::Behaviour::Buffer</small>
@@ -4532,7 +4540,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Buffer.html#process_envelopes%3F-instance_method" title="Concurrent::Actor::Behaviour::Buffer#process_envelopes? (method)">#process_envelopes?</a></span>
       <small>Concurrent::Actor::Behaviour::Buffer</small>
@@ -4540,7 +4548,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ScheduledTask.html#processing%3F-instance_method" title="Concurrent::ScheduledTask#processing? (method)">#processing?</a></span>
       <small>Concurrent::ScheduledTask</small>
@@ -4548,7 +4556,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#processor_count-class_method" title="Concurrent.processor_count (method)">processor_count</a></span>
       <small>Concurrent</small>
@@ -4556,7 +4564,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack.html#push-instance_method" title="Concurrent::LockFreeStack#push (method)">#push</a></span>
       <small>Concurrent::LockFreeStack</small>
@@ -4564,7 +4572,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#push-instance_method" title="Concurrent::Promises::Channel#push (method)">#push</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -4572,7 +4580,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#push_op-instance_method" title="Concurrent::Promises::Channel#push_op (method)">#push_op</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -4580,7 +4588,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Buffered.html#put-instance_method" title="Concurrent::Channel::Buffer::Buffered#put (method)">#put</a></span>
       <small>Concurrent::Channel::Buffer::Buffered</small>
@@ -4588,7 +4596,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#put-instance_method" title="Concurrent::Channel#put (method)">#put</a></span>
       <small>Concurrent::Channel</small>
@@ -4596,7 +4604,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Unbuffered.html#put-instance_method" title="Concurrent::Channel::Buffer::Unbuffered#put (method)">#put</a></span>
       <small>Concurrent::Channel::Buffer::Unbuffered</small>
@@ -4604,7 +4612,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Timer.html#put-instance_method" title="Concurrent::Channel::Buffer::Timer#put (method)">#put</a></span>
       <small>Concurrent::Channel::Buffer::Timer</small>
@@ -4612,7 +4620,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MVar.html#put-instance_method" title="Concurrent::MVar#put (method)">#put</a></span>
       <small>Concurrent::MVar</small>
@@ -4620,7 +4628,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Base.html#put-instance_method" title="Concurrent::Channel::Buffer::Base#put (method)">#put</a></span>
       <small>Concurrent::Channel::Buffer::Base</small>
@@ -4628,7 +4636,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Sliding.html#put-instance_method" title="Concurrent::Channel::Buffer::Sliding#put (method)">#put</a></span>
       <small>Concurrent::Channel::Buffer::Sliding</small>
@@ -4636,7 +4644,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Dropping.html#put-instance_method" title="Concurrent::Channel::Buffer::Dropping#put (method)">#put</a></span>
       <small>Concurrent::Channel::Buffer::Dropping</small>
@@ -4644,7 +4652,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#put!-instance_method" title="Concurrent::Channel#put! (method)">#put!</a></span>
       <small>Concurrent::Channel</small>
@@ -4652,7 +4660,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#put%3F-instance_method" title="Concurrent::Channel#put? (method)">#put?</a></span>
       <small>Concurrent::Channel</small>
@@ -4660,7 +4668,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#put_if_absent-instance_method" title="Concurrent::Map#put_if_absent (method)">#put_if_absent</a></span>
       <small>Concurrent::Map</small>
@@ -4668,7 +4676,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#queue_length-instance_method" title="Concurrent::ThreadPoolExecutor#queue_length (method)">#queue_length</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -4676,7 +4684,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Transaction.html#read-instance_method" title="Concurrent::Transaction#read (method)">#read</a></span>
       <small>Concurrent::Transaction</small>
@@ -4684,7 +4692,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Concern/Obligation.html#reason-instance_method" title="Concurrent::Concern::Obligation#reason (method)">#reason</a></span>
       <small>Concurrent::Concern::Obligation</small>
@@ -4692,7 +4700,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#reason-instance_method" title="Concurrent::Promises::Future#reason (method)">#reason</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -4700,7 +4708,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Terminated.html#reason-instance_method" title="Concurrent::ErlangActor::Terminated#reason (method)">#reason</a></span>
       <small>Concurrent::ErlangActor::Terminated</small>
@@ -4708,7 +4716,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableFuture.html#reason-instance_method" title="Concurrent::Promises::ResolvableFuture#reason (method)">#reason</a></span>
       <small>Concurrent::Promises::ResolvableFuture</small>
@@ -4716,7 +4724,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#receive-instance_method" title="Concurrent::ErlangActor::Environment#receive (method)">#receive</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -4724,7 +4732,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ProcessingActor.html#receive-instance_method" title="Concurrent::ProcessingActor#receive (method)">#receive</a></span>
       <small>Concurrent::ProcessingActor</small>
@@ -4732,7 +4740,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Delay.html#reconfigure-instance_method" title="Concurrent::Delay#reconfigure (method)">#reconfigure</a></span>
       <small>Concurrent::Delay</small>
@@ -4740,7 +4748,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/InternalDelegations.html#redirect-instance_method" title="Concurrent::Actor::InternalDelegations#redirect (method)">#redirect</a></span>
       <small>Concurrent::Actor::InternalDelegations</small>
@@ -4748,7 +4756,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/PublicDelegations.html#reference-instance_method" title="Concurrent::Actor::PublicDelegations#reference (method)">#reference</a></span>
       <small>Concurrent::Actor::PublicDelegations</small>
@@ -4756,7 +4764,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#reference-instance_method" title="Concurrent::Actor::Core#reference (method)">#reference</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -4764,7 +4772,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/ActorTerminated.html#reference-instance_method" title="Concurrent::Actor::ActorTerminated#reference (method)">#reference</a></span>
       <small>Concurrent::Actor::ActorTerminated</small>
@@ -4772,7 +4780,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Down.html#reference-instance_method" title="Concurrent::ErlangActor::Down#reference (method)">#reference</a></span>
       <small>Concurrent::ErlangActor::Down</small>
@@ -4780,7 +4788,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LazyRegister.html#register-instance_method" title="Concurrent::LazyRegister#register (method)">#register</a></span>
       <small>Concurrent::LazyRegister</small>
@@ -4788,7 +4796,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LazyRegister.html#registered%3F-instance_method" title="Concurrent::LazyRegister#registered? (method)">#registered?</a></span>
       <small>Concurrent::LazyRegister</small>
@@ -4796,7 +4804,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableFuture.html#reject-instance_method" title="Concurrent::Promises::ResolvableFuture#reject (method)">#reject</a></span>
       <small>Concurrent::Promises::ResolvableFuture</small>
@@ -4804,7 +4812,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promise.html#reject-class_method" title="Concurrent::Promise.reject (method)">reject</a></span>
       <small>Concurrent::Promise</small>
@@ -4812,7 +4820,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Envelope.html#reject!-instance_method" title="Concurrent::Actor::Envelope#reject! (method)">#reject!</a></span>
       <small>Concurrent::Actor::Envelope</small>
@@ -4820,7 +4828,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Abstract.html#reject_envelope-instance_method" title="Concurrent::Actor::Behaviour::Abstract#reject_envelope (method)">#reject_envelope</a></span>
       <small>Concurrent::Actor::Behaviour::Abstract</small>
@@ -4828,7 +4836,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#rejected%3F-instance_method" title="Concurrent::Promises::Future#rejected? (method)">#rejected?</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -4836,7 +4844,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Concern/Obligation.html#rejected%3F-instance_method" title="Concurrent::Concern::Obligation#rejected? (method)">#rejected?</a></span>
       <small>Concurrent::Concern::Obligation</small>
@@ -4844,7 +4852,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#rejected_future-instance_method" title="Concurrent::Promises::FactoryMethods#rejected_future (method)">#rejected_future</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -4852,7 +4860,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Throttle.html#release-instance_method" title="Concurrent::Throttle#release (method)">#release</a></span>
       <small>Concurrent::Throttle</small>
@@ -4860,7 +4868,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Resolvable.html#release-instance_method" title="Concurrent::Promises::Resolvable#release (method)">#release</a></span>
       <small>Concurrent::Promises::Resolvable</small>
@@ -4868,7 +4876,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Semaphore.html#release-instance_method" title="Concurrent::Semaphore#release (method)">#release</a></span>
       <small>Concurrent::Semaphore</small>
@@ -4876,7 +4884,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReadWriteLock.html#release_read_lock-instance_method" title="Concurrent::ReadWriteLock#release_read_lock (method)">#release_read_lock</a></span>
       <small>Concurrent::ReadWriteLock</small>
@@ -4884,7 +4892,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReentrantReadWriteLock.html#release_read_lock-instance_method" title="Concurrent::ReentrantReadWriteLock#release_read_lock (method)">#release_read_lock</a></span>
       <small>Concurrent::ReentrantReadWriteLock</small>
@@ -4892,7 +4900,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReentrantReadWriteLock.html#release_write_lock-instance_method" title="Concurrent::ReentrantReadWriteLock#release_write_lock (method)">#release_write_lock</a></span>
       <small>Concurrent::ReentrantReadWriteLock</small>
@@ -4900,7 +4908,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReadWriteLock.html#release_write_lock-instance_method" title="Concurrent::ReadWriteLock#release_write_lock (method)">#release_write_lock</a></span>
       <small>Concurrent::ReadWriteLock</small>
@@ -4908,7 +4916,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#remaining_capacity-instance_method" title="Concurrent::ThreadPoolExecutor#remaining_capacity (method)">#remaining_capacity</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -4916,7 +4924,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet.html#remove-instance_method" title="Concurrent::Edge::LockFreeLinkedSet#remove (method)">#remove</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet</small>
@@ -4924,7 +4932,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#remove_child-instance_method" title="Concurrent::Actor::Core#remove_child (method)">#remove_child</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -4932,7 +4940,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack.html#replace_if-instance_method" title="Concurrent::LockFreeStack#replace_if (method)">#replace_if</a></span>
       <small>Concurrent::LockFreeStack</small>
@@ -4940,7 +4948,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#replace_if_exists-instance_method" title="Concurrent::Map#replace_if_exists (method)">#replace_if_exists</a></span>
       <small>Concurrent::Map</small>
@@ -4948,7 +4956,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#replace_pair-instance_method" title="Concurrent::Map#replace_pair (method)">#replace_pair</a></span>
       <small>Concurrent::Map</small>
@@ -4956,7 +4964,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#reply-instance_method" title="Concurrent::ErlangActor::Environment#reply (method)">#reply</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -4964,7 +4972,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#reply_resolution-instance_method" title="Concurrent::ErlangActor::Environment#reply_resolution (method)">#reply_resolution</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -4972,7 +4980,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ScheduledTask.html#reschedule-instance_method" title="Concurrent::ScheduledTask#reschedule (method)">#reschedule</a></span>
       <small>Concurrent::ScheduledTask</small>
@@ -4980,7 +4988,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#rescue-instance_method" title="Concurrent::Promises::Future#rescue (method)">#rescue</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -4988,7 +4996,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promise.html#rescue-instance_method" title="Concurrent::Promise#rescue (method)">#rescue</a></span>
       <small>Concurrent::Promise</small>
@@ -4996,7 +5004,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#rescue_on-instance_method" title="Concurrent::Promises::Future#rescue_on (method)">#rescue_on</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -5004,7 +5012,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Resolvable.html#reserve-instance_method" title="Concurrent::Promises::Resolvable#reserve (method)">#reserve</a></span>
       <small>Concurrent::Promises::Resolvable</small>
@@ -5012,7 +5020,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/CyclicBarrier.html#reset-instance_method" title="Concurrent::CyclicBarrier#reset (method)">#reset</a></span>
       <small>Concurrent::CyclicBarrier</small>
@@ -5020,7 +5028,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ScheduledTask.html#reset-instance_method" title="Concurrent::ScheduledTask#reset (method)">#reset</a></span>
       <small>Concurrent::ScheduledTask</small>
@@ -5028,7 +5036,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Event.html#reset-instance_method" title="Concurrent::Event#reset (method)">#reset</a></span>
       <small>Concurrent::Event</small>
@@ -5036,7 +5044,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Atom.html#reset-instance_method" title="Concurrent::Atom#reset (method)">#reset</a></span>
       <small>Concurrent::Atom</small>
@@ -5044,7 +5052,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Pausing.html#reset!-instance_method" title="Concurrent::Actor::Behaviour::Pausing#reset! (method)">#reset!</a></span>
       <small>Concurrent::Actor::Behaviour::Pausing</small>
@@ -5052,7 +5060,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#resolvable_event-instance_method" title="Concurrent::Promises::FactoryMethods#resolvable_event (method)">#resolvable_event</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -5060,7 +5068,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#resolvable_event_on-instance_method" title="Concurrent::Promises::FactoryMethods#resolvable_event_on (method)">#resolvable_event_on</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -5068,7 +5076,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#resolvable_future-instance_method" title="Concurrent::Promises::FactoryMethods#resolvable_future (method)">#resolvable_future</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -5076,7 +5084,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#resolvable_future_on-instance_method" title="Concurrent::Promises::FactoryMethods#resolvable_future_on (method)">#resolvable_future_on</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -5084,7 +5092,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableFuture.html#resolve-instance_method" title="Concurrent::Promises::ResolvableFuture#resolve (method)">#resolve</a></span>
       <small>Concurrent::Promises::ResolvableFuture</small>
@@ -5092,7 +5100,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableEvent.html#resolve-instance_method" title="Concurrent::Promises::ResolvableEvent#resolve (method)">#resolve</a></span>
       <small>Concurrent::Promises::ResolvableEvent</small>
@@ -5100,7 +5108,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#resolved%3F-instance_method" title="Concurrent::Promises::AbstractEventFuture#resolved? (method)">#resolved?</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
@@ -5108,7 +5116,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#resolved_event-instance_method" title="Concurrent::Promises::FactoryMethods#resolved_event (method)">#resolved_event</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -5116,7 +5124,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#resolved_future-instance_method" title="Concurrent::Promises::FactoryMethods#resolved_future (method)">#resolved_future</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -5124,7 +5132,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#restart-instance_method" title="Concurrent::Agent#restart (method)">#restart</a></span>
       <small>Concurrent::Agent</small>
@@ -5132,7 +5140,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Pausing.html#restart!-instance_method" title="Concurrent::Actor::Behaviour::Pausing#restart! (method)">#restart!</a></span>
       <small>Concurrent::Actor::Behaviour::Pausing</small>
@@ -5140,7 +5148,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour.html#restarting_behaviour_definition-class_method" title="Concurrent::Actor::Behaviour.restarting_behaviour_definition (method)">restarting_behaviour_definition</a></span>
       <small>Concurrent::Actor::Behaviour</small>
@@ -5148,7 +5156,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#result-instance_method" title="Concurrent::Promises::Future#result (method)">#result</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -5156,7 +5164,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableFuture.html#result-instance_method" title="Concurrent::Promises::ResolvableFuture#result (method)">#result</a></span>
       <small>Concurrent::Promises::ResolvableFuture</small>
@@ -5164,7 +5172,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Pausing.html#resume!-instance_method" title="Concurrent::Actor::Behaviour::Pausing#resume! (method)">#resume!</a></span>
       <small>Concurrent::Actor::Behaviour::Pausing</small>
@@ -5172,7 +5180,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor.html#root-class_method" title="Concurrent::Actor.root (method)">root</a></span>
       <small>Concurrent::Actor</small>
@@ -5180,7 +5188,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#run-instance_method" title="Concurrent::Promises::Future#run (method)">#run</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -5188,7 +5196,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ImmediateExecutor.html#running%3F-instance_method" title="Concurrent::ImmediateExecutor#running? (method)">#running?</a></span>
       <small>Concurrent::ImmediateExecutor</small>
@@ -5196,7 +5204,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/TimerTask.html#running%3F-instance_method" title="Concurrent::TimerTask#running? (method)">#running?</a></span>
       <small>Concurrent::TimerTask</small>
@@ -5204,7 +5212,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#running%3F-instance_method" title="Concurrent::SingleThreadExecutor#running? (method)">#running?</a></span>
       <small>Concurrent::SingleThreadExecutor</small>
@@ -5212,7 +5220,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SimpleExecutorService.html#running%3F-instance_method" title="Concurrent::SimpleExecutorService#running? (method)">#running?</a></span>
       <small>Concurrent::SimpleExecutorService</small>
@@ -5220,7 +5228,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#running%3F-instance_method" title="Concurrent::ThreadPoolExecutor#running? (method)">#running?</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -5228,7 +5236,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization/Object.html#safe_initialization!-class_method" title="Concurrent::Synchronization::Object.safe_initialization! (method)">safe_initialization!</a></span>
       <small>Concurrent::Synchronization::Object</small>
@@ -5236,7 +5244,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization/Object.html#safe_initialization%3F-class_method" title="Concurrent::Synchronization::Object.safe_initialization? (method)">safe_initialization?</a></span>
       <small>Concurrent::Synchronization::Object</small>
@@ -5244,7 +5252,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#schedule-instance_method" title="Concurrent::Promises::FactoryMethods#schedule (method)">#schedule</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -5252,7 +5260,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#schedule-instance_method" title="Concurrent::Promises::Future#schedule (method)">#schedule</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -5260,7 +5268,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Event.html#schedule-instance_method" title="Concurrent::Promises::Event#schedule (method)">#schedule</a></span>
       <small>Concurrent::Promises::Event</small>
@@ -5268,7 +5276,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Core.html#schedule_execution-instance_method" title="Concurrent::Actor::Core#schedule_execution (method)">#schedule_execution</a></span>
       <small>Concurrent::Actor::Core</small>
@@ -5276,7 +5284,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#schedule_on-instance_method" title="Concurrent::Promises::FactoryMethods#schedule_on (method)">#schedule_on</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -5284,7 +5292,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ScheduledTask.html#schedule_time-instance_method" title="Concurrent::ScheduledTask#schedule_time (method)">#schedule_time</a></span>
       <small>Concurrent::ScheduledTask</small>
@@ -5292,7 +5300,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#scheduled_task_count-instance_method" title="Concurrent::ThreadPoolExecutor#scheduled_task_count (method)">#scheduled_task_count</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -5300,7 +5308,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SettableStruct.html#select-instance_method" title="Concurrent::SettableStruct#select (method)">#select</a></span>
       <small>Concurrent::SettableStruct</small>
@@ -5308,7 +5316,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#select-instance_method" title="Concurrent::Promises::Channel#select (method)">#select</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -5316,7 +5324,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#select-class_method" title="Concurrent::Promises::Channel.select (method)">select</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -5324,7 +5332,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ImmutableStruct.html#select-instance_method" title="Concurrent::ImmutableStruct#select (method)">#select</a></span>
       <small>Concurrent::ImmutableStruct</small>
@@ -5332,7 +5340,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#select-class_method" title="Concurrent::Channel.select (method)">select</a></span>
       <small>Concurrent::Channel</small>
@@ -5340,7 +5348,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MutableStruct.html#select-instance_method" title="Concurrent::MutableStruct#select (method)">#select</a></span>
       <small>Concurrent::MutableStruct</small>
@@ -5348,7 +5356,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#select_matching-class_method" title="Concurrent::Promises::Channel.select_matching (method)">select_matching</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -5356,7 +5364,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#select_matching-instance_method" title="Concurrent::Promises::Channel#select_matching (method)">#select_matching</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -5364,7 +5372,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#select_op-class_method" title="Concurrent::Promises::Channel.select_op (method)">select_op</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -5372,7 +5380,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#select_op-instance_method" title="Concurrent::Promises::Channel#select_op (method)">#select_op</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -5380,7 +5388,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#select_op_matching-instance_method" title="Concurrent::Promises::Channel#select_op_matching (method)">#select_op_matching</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -5388,7 +5396,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#select_op_matching-class_method" title="Concurrent::Promises::Channel.select_op_matching (method)">select_op_matching</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -5396,7 +5404,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#send-instance_method" title="Concurrent::Agent#send (method)">#send</a></span>
       <small>Concurrent::Agent</small>
@@ -5404,7 +5412,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#send!-instance_method" title="Concurrent::Agent#send! (method)">#send!</a></span>
       <small>Concurrent::Agent</small>
@@ -5412,7 +5420,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#send_off-instance_method" title="Concurrent::Agent#send_off (method)">#send_off</a></span>
       <small>Concurrent::Agent</small>
@@ -5420,7 +5428,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#send_off!-instance_method" title="Concurrent::Agent#send_off! (method)">#send_off!</a></span>
       <small>Concurrent::Agent</small>
@@ -5428,7 +5436,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#send_via-instance_method" title="Concurrent::Agent#send_via (method)">#send_via</a></span>
       <small>Concurrent::Agent</small>
@@ -5436,7 +5444,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#send_via!-instance_method" title="Concurrent::Agent#send_via! (method)">#send_via!</a></span>
       <small>Concurrent::Agent</small>
@@ -5444,7 +5452,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Envelope.html#sender-instance_method" title="Concurrent::Actor::Envelope#sender (method)">#sender</a></span>
       <small>Concurrent::Actor::Envelope</small>
@@ -5452,7 +5460,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Envelope.html#sender_path-instance_method" title="Concurrent::Actor::Envelope#sender_path (method)">#sender_path</a></span>
       <small>Concurrent::Actor::Envelope</small>
@@ -5460,7 +5468,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#serialized%3F-instance_method" title="Concurrent::ThreadPoolExecutor#serialized? (method)">#serialized?</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -5468,7 +5476,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#serialized%3F-instance_method" title="Concurrent::SingleThreadExecutor#serialized? (method)">#serialized?</a></span>
       <small>Concurrent::SingleThreadExecutor</small>
@@ -5476,7 +5484,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/WrappingExecutor.html#serialized%3F-instance_method" title="Concurrent::WrappingExecutor#serialized? (method)">#serialized?</a></span>
       <small>Concurrent::WrappingExecutor</small>
@@ -5484,7 +5492,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/IVar.html#set-instance_method" title="Concurrent::IVar#set (method)">#set</a></span>
       <small>Concurrent::IVar</small>
@@ -5492,7 +5500,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Event.html#set-instance_method" title="Concurrent::Event#set (method)">#set</a></span>
       <small>Concurrent::Event</small>
@@ -5500,7 +5508,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promise.html#set-instance_method" title="Concurrent::Promise#set (method)">#set</a></span>
       <small>Concurrent::Promise</small>
@@ -5508,7 +5516,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicMarkableReference.html#set-instance_method" title="Concurrent::AtomicMarkableReference#set (method)">#set</a></span>
       <small>Concurrent::AtomicMarkableReference</small>
@@ -5516,7 +5524,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicReference.html#set-instance_method" title="Concurrent::AtomicReference#set (method)">#set</a></span>
       <small>Concurrent::AtomicReference</small>
@@ -5524,7 +5532,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Tuple.html#set-instance_method" title="Concurrent::Tuple#set (method)">#set</a></span>
       <small>Concurrent::Tuple</small>
@@ -5532,7 +5540,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Future.html#set-instance_method" title="Concurrent::Future#set (method)">#set</a></span>
       <small>Concurrent::Future</small>
@@ -5540,7 +5548,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MVar.html#set!-instance_method" title="Concurrent::MVar#set! (method)">#set!</a></span>
       <small>Concurrent::MVar</small>
@@ -5548,7 +5556,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Event.html#set%3F-instance_method" title="Concurrent::Event#set? (method)">#set?</a></span>
       <small>Concurrent::Event</small>
@@ -5556,7 +5564,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#shutdown-instance_method" title="Concurrent::ThreadPoolExecutor#shutdown (method)">#shutdown</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -5564,7 +5572,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#shutdown-instance_method" title="Concurrent::SingleThreadExecutor#shutdown (method)">#shutdown</a></span>
       <small>Concurrent::SingleThreadExecutor</small>
@@ -5572,7 +5580,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SimpleExecutorService.html#shutdown-instance_method" title="Concurrent::SimpleExecutorService#shutdown (method)">#shutdown</a></span>
       <small>Concurrent::SimpleExecutorService</small>
@@ -5580,7 +5588,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ImmediateExecutor.html#shutdown-instance_method" title="Concurrent::ImmediateExecutor#shutdown (method)">#shutdown</a></span>
       <small>Concurrent::ImmediateExecutor</small>
@@ -5588,7 +5596,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SimpleExecutorService.html#shutdown%3F-instance_method" title="Concurrent::SimpleExecutorService#shutdown? (method)">#shutdown?</a></span>
       <small>Concurrent::SimpleExecutorService</small>
@@ -5596,7 +5604,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#shutdown%3F-instance_method" title="Concurrent::SingleThreadExecutor#shutdown? (method)">#shutdown?</a></span>
       <small>Concurrent::SingleThreadExecutor</small>
@@ -5604,7 +5612,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ImmediateExecutor.html#shutdown%3F-instance_method" title="Concurrent::ImmediateExecutor#shutdown? (method)">#shutdown?</a></span>
       <small>Concurrent::ImmediateExecutor</small>
@@ -5612,7 +5620,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#shutdown%3F-instance_method" title="Concurrent::ThreadPoolExecutor#shutdown? (method)">#shutdown?</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -5620,7 +5628,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#shuttingdown%3F-instance_method" title="Concurrent::ThreadPoolExecutor#shuttingdown? (method)">#shuttingdown?</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -5628,7 +5636,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#shuttingdown%3F-instance_method" title="Concurrent::SingleThreadExecutor#shuttingdown? (method)">#shuttingdown?</a></span>
       <small>Concurrent::SingleThreadExecutor</small>
@@ -5636,7 +5644,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ImmediateExecutor.html#shuttingdown%3F-instance_method" title="Concurrent::ImmediateExecutor#shuttingdown? (method)">#shuttingdown?</a></span>
       <small>Concurrent::ImmediateExecutor</small>
@@ -5644,7 +5652,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SimpleExecutorService.html#shuttingdown%3F-instance_method" title="Concurrent::SimpleExecutorService#shuttingdown? (method)">#shuttingdown?</a></span>
       <small>Concurrent::SimpleExecutorService</small>
@@ -5652,7 +5660,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization.html#signal-instance_method" title="Concurrent::Synchronization#signal (method)">#signal</a></span>
       <small>Concurrent::Synchronization</small>
@@ -5660,7 +5668,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Base.html#size-instance_method" title="Concurrent::Channel::Buffer::Base#size (method)">#size</a></span>
       <small>Concurrent::Channel::Buffer::Base</small>
@@ -5668,7 +5676,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#size-instance_method" title="Concurrent::Map#size (method)">#size</a></span>
       <small>Concurrent::Map</small>
@@ -5676,7 +5684,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#size-instance_method" title="Concurrent::Promises::Channel#size (method)">#size</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -5684,7 +5692,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Tuple.html#size-instance_method" title="Concurrent::Tuple#size (method)">#size</a></span>
       <small>Concurrent::Tuple</small>
@@ -5692,7 +5700,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Unbuffered.html#size-instance_method" title="Concurrent::Channel::Buffer::Unbuffered#size (method)">#size</a></span>
       <small>Concurrent::Channel::Buffer::Unbuffered</small>
@@ -5700,7 +5708,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#spawn-instance_method" title="Concurrent::ErlangActor::Environment#spawn (method)">#spawn</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -5708,7 +5716,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor.html#spawn-class_method" title="Concurrent::Actor.spawn (method)">spawn</a></span>
       <small>Concurrent::Actor</small>
@@ -5716,7 +5724,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#spawn-class_method" title="Concurrent::Actor::AbstractContext.spawn (method)">spawn</a></span>
       <small>Concurrent::Actor::AbstractContext</small>
@@ -5724,7 +5732,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/FunctionShortcuts.html#spawn-instance_method" title="Concurrent::ErlangActor::FunctionShortcuts#spawn (method)">#spawn</a></span>
       <small>Concurrent::ErlangActor::FunctionShortcuts</small>
@@ -5732,7 +5740,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor.html#spawn!-class_method" title="Concurrent::Actor.spawn! (method)">spawn!</a></span>
       <small>Concurrent::Actor</small>
@@ -5740,7 +5748,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#spawn!-class_method" title="Concurrent::Actor::AbstractContext.spawn! (method)">spawn!</a></span>
       <small>Concurrent::Actor::AbstractContext</small>
@@ -5748,7 +5756,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Functions.html#spawn_actor-instance_method" title="Concurrent::ErlangActor::Functions#spawn_actor (method)">#spawn_actor</a></span>
       <small>Concurrent::ErlangActor::Functions</small>
@@ -5756,7 +5764,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#state-instance_method" title="Concurrent::Promises::AbstractEventFuture#state (method)">#state</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
@@ -5764,7 +5772,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Concern/Obligation.html#state-instance_method" title="Concurrent::Concern::Obligation#state (method)">#state</a></span>
       <small>Concurrent::Concern::Obligation</small>
@@ -5772,7 +5780,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Abstract.html#subsequent-instance_method" title="Concurrent::Actor::Behaviour::Abstract#subsequent (method)">#subsequent</a></span>
       <small>Concurrent::Actor::Behaviour::Abstract</small>
@@ -5780,7 +5788,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeQueue/Node.html#successor-instance_method" title="Concurrent::LockFreeQueue::Node#successor (method)">#successor</a></span>
       <small>Concurrent::LockFreeQueue::Node</small>
@@ -5788,7 +5796,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeQueue/Node.html#successor=-instance_method" title="Concurrent::LockFreeQueue::Node#successor= (method)">#successor=</a></span>
       <small>Concurrent::LockFreeQueue::Node</small>
@@ -5796,7 +5804,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Edge/LockFreeLinkedSet/Node.html#successor_reference-instance_method" title="Concurrent::Edge::LockFreeLinkedSet::Node#successor_reference (method)">#successor_reference</a></span>
       <small>Concurrent::Edge::LockFreeLinkedSet::Node</small>
@@ -5804,7 +5812,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour.html#supervised-class_method" title="Concurrent::Actor::Behaviour.supervised (method)">supervised</a></span>
       <small>Concurrent::Actor::Behaviour</small>
@@ -5812,7 +5820,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour.html#supervising-class_method" title="Concurrent::Actor::Behaviour.supervising (method)">supervising</a></span>
       <small>Concurrent::Actor::Behaviour</small>
@@ -5820,7 +5828,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Atom.html#swap-instance_method" title="Concurrent::Atom#swap (method)">#swap</a></span>
       <small>Concurrent::Atom</small>
@@ -5828,7 +5836,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeQueue/Node.html#swap_successor-instance_method" title="Concurrent::LockFreeQueue::Node#swap_successor (method)">#swap_successor</a></span>
       <small>Concurrent::LockFreeQueue::Node</small>
@@ -5836,7 +5844,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization.html#synchronize-instance_method" title="Concurrent::Synchronization#synchronize (method)">#synchronize</a></span>
       <small>Concurrent::Synchronization</small>
@@ -5844,7 +5852,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Buffered.html#take-instance_method" title="Concurrent::Channel::Buffer::Buffered#take (method)">#take</a></span>
       <small>Concurrent::Channel::Buffer::Buffered</small>
@@ -5852,7 +5860,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Base.html#take-instance_method" title="Concurrent::Channel::Buffer::Base#take (method)">#take</a></span>
       <small>Concurrent::Channel::Buffer::Base</small>
@@ -5860,7 +5868,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#take-instance_method" title="Concurrent::Channel#take (method)">#take</a></span>
       <small>Concurrent::Channel</small>
@@ -5868,7 +5876,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Unbuffered.html#take-instance_method" title="Concurrent::Channel::Buffer::Unbuffered#take (method)">#take</a></span>
       <small>Concurrent::Channel::Buffer::Unbuffered</small>
@@ -5876,7 +5884,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MVar.html#take-instance_method" title="Concurrent::MVar#take (method)">#take</a></span>
       <small>Concurrent::MVar</small>
@@ -5884,7 +5892,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Buffer/Timer.html#take-instance_method" title="Concurrent::Channel::Buffer::Timer#take (method)">#take</a></span>
       <small>Concurrent::Channel::Buffer::Timer</small>
@@ -5892,7 +5900,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#take!-instance_method" title="Concurrent::Channel#take! (method)">#take!</a></span>
       <small>Concurrent::Channel</small>
@@ -5900,7 +5908,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#take%3F-instance_method" title="Concurrent::Channel#take? (method)">#take?</a></span>
       <small>Concurrent::Channel</small>
@@ -5908,7 +5916,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Reference.html#tell-instance_method" title="Concurrent::Actor::Reference#tell (method)">#tell</a></span>
       <small>Concurrent::Actor::Reference</small>
@@ -5916,7 +5924,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/AbstractContext.html#tell-instance_method" title="Concurrent::Actor::AbstractContext#tell (method)">#tell</a></span>
       <small>Concurrent::Actor::AbstractContext</small>
@@ -5924,7 +5932,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Pid.html#tell-instance_method" title="Concurrent::ErlangActor::Pid#tell (method)">#tell</a></span>
       <small>Concurrent::ErlangActor::Pid</small>
@@ -5932,7 +5940,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ProcessingActor.html#tell!-instance_method" title="Concurrent::ProcessingActor#tell! (method)">#tell!</a></span>
       <small>Concurrent::ProcessingActor</small>
@@ -5940,7 +5948,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ProcessingActor.html#tell_op-instance_method" title="Concurrent::ProcessingActor#tell_op (method)">#tell_op</a></span>
       <small>Concurrent::ProcessingActor</small>
@@ -5948,7 +5956,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Pid.html#tell_op-instance_method" title="Concurrent::ErlangActor::Pid#tell_op (method)">#tell_op</a></span>
       <small>Concurrent::ErlangActor::Pid</small>
@@ -5956,7 +5964,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/FunctionShortcuts.html#terminate-instance_method" title="Concurrent::ErlangActor::FunctionShortcuts#terminate (method)">#terminate</a></span>
       <small>Concurrent::ErlangActor::FunctionShortcuts</small>
@@ -5964,7 +5972,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#terminate-instance_method" title="Concurrent::ErlangActor::Environment#terminate (method)">#terminate</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -5972,7 +5980,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/InternalDelegations.html#terminate!-instance_method" title="Concurrent::Actor::InternalDelegations#terminate! (method)">#terminate!</a></span>
       <small>Concurrent::Actor::InternalDelegations</small>
@@ -5980,7 +5988,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Termination.html#terminate!-instance_method" title="Concurrent::Actor::Behaviour::Termination#terminate! (method)">#terminate!</a></span>
       <small>Concurrent::Actor::Behaviour::Termination</small>
@@ -5988,7 +5996,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Functions.html#terminate_actor-instance_method" title="Concurrent::ErlangActor::Functions#terminate_actor (method)">#terminate_actor</a></span>
       <small>Concurrent::ErlangActor::Functions</small>
@@ -5996,7 +6004,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Pid.html#terminated-instance_method" title="Concurrent::ErlangActor::Pid#terminated (method)">#terminated</a></span>
       <small>Concurrent::ErlangActor::Pid</small>
@@ -6004,7 +6012,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Termination.html#terminated-instance_method" title="Concurrent::Actor::Behaviour::Termination#terminated (method)">#terminated</a></span>
       <small>Concurrent::Actor::Behaviour::Termination</small>
@@ -6012,7 +6020,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#terminated-instance_method" title="Concurrent::ErlangActor::Environment#terminated (method)">#terminated</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -6020,7 +6028,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Termination.html#terminated%3F-instance_method" title="Concurrent::Actor::Behaviour::Termination#terminated? (method)">#terminated?</a></span>
       <small>Concurrent::Actor::Behaviour::Termination</small>
@@ -6028,7 +6036,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/InternalDelegations.html#terminated%3F-instance_method" title="Concurrent::Actor::InternalDelegations#terminated? (method)">#terminated?</a></span>
       <small>Concurrent::Actor::InternalDelegations</small>
@@ -6036,7 +6044,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ProcessingActor.html#termination-instance_method" title="Concurrent::ProcessingActor#termination (method)">#termination</a></span>
       <small>Concurrent::ProcessingActor</small>
@@ -6044,7 +6052,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promise.html#then-instance_method" title="Concurrent::Promise#then (method)">#then</a></span>
       <small>Concurrent::Promise</small>
@@ -6052,7 +6060,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#then-instance_method" title="Concurrent::Promises::Future#then (method)">#then</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -6060,7 +6068,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future/ActorIntegration.html#then_ask-instance_method" title="Concurrent::Promises::Future::ActorIntegration#then_ask (method)">#then_ask</a></span>
       <small>Concurrent::Promises::Future::ActorIntegration</small>
@@ -6068,7 +6076,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future/NewChannelIntegration.html#then_channel_push-instance_method" title="Concurrent::Promises::Future::NewChannelIntegration#then_channel_push (method)">#then_channel_push</a></span>
       <small>Concurrent::Promises::Future::NewChannelIntegration</small>
@@ -6076,7 +6084,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future/FlatShortcuts.html#then_flat_event-instance_method" title="Concurrent::Promises::Future::FlatShortcuts#then_flat_event (method)">#then_flat_event</a></span>
       <small>Concurrent::Promises::Future::FlatShortcuts</small>
@@ -6084,7 +6092,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future/FlatShortcuts.html#then_flat_event_on-instance_method" title="Concurrent::Promises::Future::FlatShortcuts#then_flat_event_on (method)">#then_flat_event_on</a></span>
       <small>Concurrent::Promises::Future::FlatShortcuts</small>
@@ -6092,7 +6100,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future/FlatShortcuts.html#then_flat_future-instance_method" title="Concurrent::Promises::Future::FlatShortcuts#then_flat_future (method)">#then_flat_future</a></span>
       <small>Concurrent::Promises::Future::FlatShortcuts</small>
@@ -6100,7 +6108,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future/FlatShortcuts.html#then_flat_future_on-instance_method" title="Concurrent::Promises::Future::FlatShortcuts#then_flat_future_on (method)">#then_flat_future_on</a></span>
       <small>Concurrent::Promises::Future::FlatShortcuts</small>
@@ -6108,7 +6116,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#then_on-instance_method" title="Concurrent::Promises::Future#then_on (method)">#then_on</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -6116,7 +6124,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#ticker-class_method" title="Concurrent::Channel.ticker (method)">ticker</a></span>
       <small>Concurrent::Channel</small>
@@ -6124,7 +6132,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Cancellation.html#timeout-class_method" title="Concurrent::Cancellation.timeout (method)">timeout</a></span>
       <small>Concurrent::Cancellation</small>
@@ -6132,7 +6140,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/TimerTask.html#timeout_interval-instance_method" title="Concurrent::TimerTask#timeout_interval (method)">#timeout_interval</a></span>
       <small>Concurrent::TimerTask</small>
@@ -6140,7 +6148,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel.html#timer-class_method" title="Concurrent::Channel.timer (method)">timer</a></span>
       <small>Concurrent::Channel</small>
@@ -6148,7 +6156,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Cancellation.html#to_ary-instance_method" title="Concurrent::Cancellation#to_ary (method)">#to_ary</a></span>
       <small>Concurrent::Cancellation</small>
@@ -6156,7 +6164,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ProcessingActor.html#to_ary-instance_method" title="Concurrent::ProcessingActor#to_ary (method)">#to_ary</a></span>
       <small>Concurrent::ProcessingActor</small>
@@ -6164,7 +6172,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Terminated.html#to_ary-instance_method" title="Concurrent::ErlangActor::Terminated#to_ary (method)">#to_ary</a></span>
       <small>Concurrent::ErlangActor::Terminated</small>
@@ -6172,7 +6180,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Down.html#to_ary-instance_method" title="Concurrent::ErlangActor::Down#to_ary (method)">#to_ary</a></span>
       <small>Concurrent::ErlangActor::Down</small>
@@ -6180,7 +6188,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#to_event-instance_method" title="Concurrent::Promises::Future#to_event (method)">#to_event</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -6188,7 +6196,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Event.html#to_event-instance_method" title="Concurrent::Promises::Event#to_event (method)">#to_event</a></span>
       <small>Concurrent::Promises::Event</small>
@@ -6196,7 +6204,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Event.html#to_future-instance_method" title="Concurrent::Promises::Event#to_future (method)">#to_future</a></span>
       <small>Concurrent::Promises::Event</small>
@@ -6204,7 +6212,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#to_future-instance_method" title="Concurrent::Promises::Future#to_future (method)">#to_future</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -6212,7 +6220,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SettableStruct.html#to_h-instance_method" title="Concurrent::SettableStruct#to_h (method)">#to_h</a></span>
       <small>Concurrent::SettableStruct</small>
@@ -6220,7 +6228,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MutableStruct.html#to_h-instance_method" title="Concurrent::MutableStruct#to_h (method)">#to_h</a></span>
       <small>Concurrent::MutableStruct</small>
@@ -6228,7 +6236,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ImmutableStruct.html#to_h-instance_method" title="Concurrent::ImmutableStruct#to_h (method)">#to_h</a></span>
       <small>Concurrent::ImmutableStruct</small>
@@ -6236,7 +6244,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#to_s-instance_method" title="Concurrent::Promises::Future#to_s (method)">#to_s</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -6244,7 +6252,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Pid.html#to_s-instance_method" title="Concurrent::ErlangActor::Pid#to_s (method)">#to_s</a></span>
       <small>Concurrent::ErlangActor::Pid</small>
@@ -6252,7 +6260,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Cancellation.html#to_s-instance_method" title="Concurrent::Cancellation#to_s (method)">#to_s</a></span>
       <small>Concurrent::Cancellation</small>
@@ -6260,7 +6268,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Reference.html#to_s-instance_method" title="Concurrent::Actor::Reference#to_s (method)">#to_s</a></span>
       <small>Concurrent::Actor::Reference</small>
@@ -6268,7 +6276,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#to_s-instance_method" title="Concurrent::Promises::AbstractEventFuture#to_s (method)">#to_s</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
@@ -6276,7 +6284,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack.html#to_s-instance_method" title="Concurrent::LockFreeStack#to_s (method)">#to_s</a></span>
       <small>Concurrent::LockFreeStack</small>
@@ -6284,7 +6292,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Throttle.html#to_s-instance_method" title="Concurrent::Throttle#to_s (method)">#to_s</a></span>
       <small>Concurrent::Throttle</small>
@@ -6292,7 +6300,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicReference.html#to_s-instance_method" title="Concurrent::AtomicReference#to_s (method)">#to_s</a></span>
       <small>Concurrent::AtomicReference</small>
@@ -6300,7 +6308,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#to_s-instance_method" title="Concurrent::Promises::Channel#to_s (method)">#to_s</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -6308,7 +6316,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Tick.html#to_s-instance_method" title="Concurrent::Channel::Tick#to_s (method)">#to_s</a></span>
       <small>Concurrent::Channel::Tick</small>
@@ -6316,7 +6324,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicFixnum.html#to_s-instance_method" title="Concurrent::AtomicFixnum#to_s (method)">#to_s</a></span>
       <small>Concurrent::AtomicFixnum</small>
@@ -6324,7 +6332,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ProcessingActor.html#to_s-instance_method" title="Concurrent::ProcessingActor#to_s (method)">#to_s</a></span>
       <small>Concurrent::ProcessingActor</small>
@@ -6332,7 +6340,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicBoolean.html#to_s-instance_method" title="Concurrent::AtomicBoolean#to_s (method)">#to_s</a></span>
       <small>Concurrent::AtomicBoolean</small>
@@ -6340,7 +6348,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor.html#to_spawn_options-class_method" title="Concurrent::Actor.to_spawn_options (method)">to_spawn_options</a></span>
       <small>Concurrent::Actor</small>
@@ -6348,7 +6356,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/InternalStates/Fulfilled/new_28nil_29.html#to_sym-class_method" title="Fulfilled.new(nil).to_sym (method)">to_sym</a></span>
       <small>Fulfilled.new(nil)</small>
@@ -6356,7 +6364,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#touch-instance_method" title="Concurrent::Promises::AbstractEventFuture#touch (method)">#touch</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
@@ -6364,7 +6372,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#trap-instance_method" title="Concurrent::ErlangActor::Environment#trap (method)">#trap</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -6372,7 +6380,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Termination.html#trapping=-instance_method" title="Concurrent::Actor::Behaviour::Termination#trapping= (method)">#trapping=</a></span>
       <small>Concurrent::Actor::Behaviour::Termination</small>
@@ -6380,7 +6388,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Termination.html#trapping%3F-instance_method" title="Concurrent::Actor::Behaviour::Termination#trapping? (method)">#trapping?</a></span>
       <small>Concurrent::Actor::Behaviour::Termination</small>
@@ -6388,7 +6396,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#traps%3F-instance_method" title="Concurrent::ErlangActor::Environment#traps? (method)">#traps?</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -6396,7 +6404,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicBoolean.html#true%3F-instance_method" title="Concurrent::AtomicBoolean#true? (method)">#true?</a></span>
       <small>Concurrent::AtomicBoolean</small>
@@ -6404,7 +6412,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Event.html#try%3F-instance_method" title="Concurrent::Event#try? (method)">#try?</a></span>
       <small>Concurrent::Event</small>
@@ -6412,7 +6420,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Semaphore.html#try_acquire-instance_method" title="Concurrent::Semaphore#try_acquire (method)">#try_acquire</a></span>
       <small>Concurrent::Semaphore</small>
@@ -6420,7 +6428,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Throttle.html#try_acquire-instance_method" title="Concurrent::Throttle#try_acquire (method)">#try_acquire</a></span>
       <small>Concurrent::Throttle</small>
@@ -6428,7 +6436,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#try_exchange-instance_method" title="Concurrent#try_exchange (method)">#try_exchange</a></span>
       <small>Concurrent</small>
@@ -6436,7 +6444,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#try_pop-instance_method" title="Concurrent::Promises::Channel#try_pop (method)">#try_pop</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -6444,7 +6452,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#try_pop_matching-instance_method" title="Concurrent::Promises::Channel#try_pop_matching (method)">#try_pop_matching</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -6452,7 +6460,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#try_push-instance_method" title="Concurrent::Promises::Channel#try_push (method)">#try_push</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -6460,7 +6468,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MVar.html#try_put!-instance_method" title="Concurrent::MVar#try_put! (method)">#try_put!</a></span>
       <small>Concurrent::MVar</small>
@@ -6468,7 +6476,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReentrantReadWriteLock.html#try_read_lock-instance_method" title="Concurrent::ReentrantReadWriteLock#try_read_lock (method)">#try_read_lock</a></span>
       <small>Concurrent::ReentrantReadWriteLock</small>
@@ -6476,7 +6484,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#try_select-instance_method" title="Concurrent::Promises::Channel#try_select (method)">#try_select</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -6484,7 +6492,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#try_select-class_method" title="Concurrent::Promises::Channel.try_select (method)">try_select</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -6492,7 +6500,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#try_select_matching-instance_method" title="Concurrent::Promises::Channel#try_select_matching (method)">#try_select_matching</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -6500,7 +6508,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Channel.html#try_select_matching-class_method" title="Concurrent::Promises::Channel.try_select_matching (method)">try_select_matching</a></span>
       <small>Concurrent::Promises::Channel</small>
@@ -6508,7 +6516,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/IVar.html#try_set-instance_method" title="Concurrent::IVar#try_set (method)">#try_set</a></span>
       <small>Concurrent::IVar</small>
@@ -6516,7 +6524,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MVar.html#try_take!-instance_method" title="Concurrent::MVar#try_take! (method)">#try_take!</a></span>
       <small>Concurrent::MVar</small>
@@ -6524,7 +6532,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicReference.html#try_update-instance_method" title="Concurrent::AtomicReference#try_update (method)">#try_update</a></span>
       <small>Concurrent::AtomicReference</small>
@@ -6532,7 +6540,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicMarkableReference.html#try_update-instance_method" title="Concurrent::AtomicMarkableReference#try_update (method)">#try_update</a></span>
       <small>Concurrent::AtomicMarkableReference</small>
@@ -6540,7 +6548,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicReference.html#try_update!-instance_method" title="Concurrent::AtomicReference#try_update! (method)">#try_update!</a></span>
       <small>Concurrent::AtomicReference</small>
@@ -6548,7 +6556,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicMarkableReference.html#try_update!-instance_method" title="Concurrent::AtomicMarkableReference#try_update! (method)">#try_update!</a></span>
       <small>Concurrent::AtomicMarkableReference</small>
@@ -6556,7 +6564,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReentrantReadWriteLock.html#try_write_lock-instance_method" title="Concurrent::ReentrantReadWriteLock#try_write_lock (method)">#try_write_lock</a></span>
       <small>Concurrent::ReentrantReadWriteLock</small>
@@ -6564,7 +6572,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Transaction/ReadLogEntry.html#tvar-instance_method" title="Concurrent::Transaction::ReadLogEntry#tvar (method)">#tvar</a></span>
       <small>Concurrent::Transaction::ReadLogEntry</small>
@@ -6572,7 +6580,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour/Linking.html#unlink-instance_method" title="Concurrent::Actor::Behaviour::Linking#unlink (method)">#unlink</a></span>
       <small>Concurrent::Actor::Behaviour::Linking</small>
@@ -6580,7 +6588,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ErlangActor/Environment.html#unlink-instance_method" title="Concurrent::ErlangActor::Environment#unlink (method)">#unlink</a></span>
       <small>Concurrent::ErlangActor::Environment</small>
@@ -6588,7 +6596,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Transaction.html#unlock-instance_method" title="Concurrent::Transaction#unlock (method)">#unlock</a></span>
       <small>Concurrent::Transaction</small>
@@ -6596,7 +6604,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LazyRegister.html#unregister-instance_method" title="Concurrent::LazyRegister#unregister (method)">#unregister</a></span>
       <small>Concurrent::LazyRegister</small>
@@ -6604,7 +6612,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Concern/Obligation.html#unscheduled%3F-instance_method" title="Concurrent::Concern::Obligation#unscheduled? (method)">#unscheduled?</a></span>
       <small>Concurrent::Concern::Obligation</small>
@@ -6612,7 +6620,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicMarkableReference.html#update-instance_method" title="Concurrent::AtomicMarkableReference#update (method)">#update</a></span>
       <small>Concurrent::AtomicMarkableReference</small>
@@ -6620,7 +6628,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicReference.html#update-instance_method" title="Concurrent::AtomicReference#update (method)">#update</a></span>
       <small>Concurrent::AtomicReference</small>
@@ -6628,7 +6636,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicFixnum.html#update-instance_method" title="Concurrent::AtomicFixnum#update (method)">#update</a></span>
       <small>Concurrent::AtomicFixnum</small>
@@ -6636,7 +6644,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeQueue/Node.html#update_successor-instance_method" title="Concurrent::LockFreeQueue::Node#update_successor (method)">#update_successor</a></span>
       <small>Concurrent::LockFreeQueue::Node</small>
@@ -6644,7 +6652,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#use_simple_logger-class_method" title="Concurrent.use_simple_logger (method)">use_simple_logger</a></span>
       <small>Concurrent</small>
@@ -6652,7 +6660,7 @@
   </li>
   
 
-  <li class="odd deprecated">
+  <li class="even deprecated">
     <div class="item">
       <span class='object_link'><a href="Concurrent.html#use_stdlib_logger-class_method" title="Concurrent.use_stdlib_logger (method)">use_stdlib_logger</a></span>
       <small>Concurrent</small>
@@ -6660,7 +6668,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Actor/Behaviour.html#user_messages-class_method" title="Concurrent::Actor::Behaviour.user_messages (method)">user_messages</a></span>
       <small>Concurrent::Actor::Behaviour</small>
@@ -6668,7 +6676,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Channel/Tick.html#utc-instance_method" title="Concurrent::Channel::Tick#utc (method)">#utc</a></span>
       <small>Concurrent::Channel::Tick</small>
@@ -6676,7 +6684,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Transaction.html#valid%3F-instance_method" title="Concurrent::Transaction#valid? (method)">#valid?</a></span>
       <small>Concurrent::Transaction</small>
@@ -6684,7 +6692,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Delay.html#value-instance_method" title="Concurrent::Delay#value (method)">#value</a></span>
       <small>Concurrent::Delay</small>
@@ -6692,7 +6700,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableFuture.html#value-instance_method" title="Concurrent::Promises::ResolvableFuture#value (method)">#value</a></span>
       <small>Concurrent::Promises::ResolvableFuture</small>
@@ -6700,7 +6708,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#value-instance_method" title="Concurrent::Agent#value (method)">#value</a></span>
       <small>Concurrent::Agent</small>
@@ -6708,7 +6716,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/TVar.html#value-instance_method" title="Concurrent::TVar#value (method)">#value</a></span>
       <small>Concurrent::TVar</small>
@@ -6716,7 +6724,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Atom.html#value-instance_method" title="Concurrent::Atom#value (method)">#value</a></span>
       <small>Concurrent::Atom</small>
@@ -6724,7 +6732,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicMarkableReference.html#value-instance_method" title="Concurrent::AtomicMarkableReference#value (method)">#value</a></span>
       <small>Concurrent::AtomicMarkableReference</small>
@@ -6732,7 +6740,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Concern/Obligation.html#value-instance_method" title="Concurrent::Concern::Obligation#value (method)">#value</a></span>
       <small>Concurrent::Concern::Obligation</small>
@@ -6740,7 +6748,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicFixnum.html#value-instance_method" title="Concurrent::AtomicFixnum#value (method)">#value</a></span>
       <small>Concurrent::AtomicFixnum</small>
@@ -6748,7 +6756,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicBoolean.html#value-instance_method" title="Concurrent::AtomicBoolean#value (method)">#value</a></span>
       <small>Concurrent::AtomicBoolean</small>
@@ -6756,7 +6764,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadLocalVar.html#value-instance_method" title="Concurrent::ThreadLocalVar#value (method)">#value</a></span>
       <small>Concurrent::ThreadLocalVar</small>
@@ -6764,7 +6772,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/LockFreeStack/Node.html#value-instance_method" title="Concurrent::LockFreeStack::Node#value (method)">#value</a></span>
       <small>Concurrent::LockFreeStack::Node</small>
@@ -6772,7 +6780,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#value-instance_method" title="Concurrent::Promises::Future#value (method)">#value</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -6780,7 +6788,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Concern/Dereferenceable.html#value-instance_method" title="Concurrent::Concern::Dereferenceable#value (method)">#value</a></span>
       <small>Concurrent::Concern::Dereferenceable</small>
@@ -6788,7 +6796,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#value!-instance_method" title="Concurrent::Promises::Future#value! (method)">#value!</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -6796,7 +6804,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableFuture.html#value!-instance_method" title="Concurrent::Promises::ResolvableFuture#value! (method)">#value!</a></span>
       <small>Concurrent::Promises::ResolvableFuture</small>
@@ -6804,7 +6812,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Concern/Obligation.html#value!-instance_method" title="Concurrent::Concern::Obligation#value! (method)">#value!</a></span>
       <small>Concurrent::Concern::Obligation</small>
@@ -6812,7 +6820,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Delay.html#value!-instance_method" title="Concurrent::Delay#value! (method)">#value!</a></span>
       <small>Concurrent::Delay</small>
@@ -6820,7 +6828,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicFixnum.html#value=-instance_method" title="Concurrent::AtomicFixnum#value= (method)">#value=</a></span>
       <small>Concurrent::AtomicFixnum</small>
@@ -6828,7 +6836,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/TVar.html#value=-instance_method" title="Concurrent::TVar#value= (method)">#value=</a></span>
       <small>Concurrent::TVar</small>
@@ -6836,7 +6844,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/AtomicBoolean.html#value=-instance_method" title="Concurrent::AtomicBoolean#value= (method)">#value=</a></span>
       <small>Concurrent::AtomicBoolean</small>
@@ -6844,7 +6852,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadLocalVar.html#value=-instance_method" title="Concurrent::ThreadLocalVar#value= (method)">#value=</a></span>
       <small>Concurrent::ThreadLocalVar</small>
@@ -6852,7 +6860,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#value%3F-instance_method" title="Concurrent::Map#value? (method)">#value?</a></span>
       <small>Concurrent::Map</small>
@@ -6860,7 +6868,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MutableStruct.html#values-instance_method" title="Concurrent::MutableStruct#values (method)">#values</a></span>
       <small>Concurrent::MutableStruct</small>
@@ -6868,7 +6876,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SettableStruct.html#values-instance_method" title="Concurrent::SettableStruct#values (method)">#values</a></span>
       <small>Concurrent::SettableStruct</small>
@@ -6876,7 +6884,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Map.html#values-instance_method" title="Concurrent::Map#values (method)">#values</a></span>
       <small>Concurrent::Map</small>
@@ -6884,7 +6892,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ImmutableStruct.html#values-instance_method" title="Concurrent::ImmutableStruct#values (method)">#values</a></span>
       <small>Concurrent::ImmutableStruct</small>
@@ -6892,7 +6900,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ImmutableStruct.html#values_at-instance_method" title="Concurrent::ImmutableStruct#values_at (method)">#values_at</a></span>
       <small>Concurrent::ImmutableStruct</small>
@@ -6900,7 +6908,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SettableStruct.html#values_at-instance_method" title="Concurrent::SettableStruct#values_at (method)">#values_at</a></span>
       <small>Concurrent::SettableStruct</small>
@@ -6908,7 +6916,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/MutableStruct.html#values_at-instance_method" title="Concurrent::MutableStruct#values_at (method)">#values_at</a></span>
       <small>Concurrent::MutableStruct</small>
@@ -6916,7 +6924,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Transaction/ReadLogEntry.html#version-instance_method" title="Concurrent::Transaction::ReadLogEntry#version (method)">#version</a></span>
       <small>Concurrent::Transaction::ReadLogEntry</small>
@@ -6924,7 +6932,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Agent.html#wait-instance_method" title="Concurrent::Agent#wait (method)">#wait</a></span>
       <small>Concurrent::Agent</small>
@@ -6932,7 +6940,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/CountDownLatch.html#wait-instance_method" title="Concurrent::CountDownLatch#wait (method)">#wait</a></span>
       <small>Concurrent::CountDownLatch</small>
@@ -6940,7 +6948,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Concern/Obligation.html#wait-instance_method" title="Concurrent::Concern::Obligation#wait (method)">#wait</a></span>
       <small>Concurrent::Concern::Obligation</small>
@@ -6948,7 +6956,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableEvent.html#wait-instance_method" title="Concurrent::Promises::ResolvableEvent#wait (method)">#wait</a></span>
       <small>Concurrent::Promises::ResolvableEvent</small>
@@ -6956,7 +6964,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Delay.html#wait-instance_method" title="Concurrent::Delay#wait (method)">#wait</a></span>
       <small>Concurrent::Delay</small>
@@ -6964,7 +6972,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/CyclicBarrier.html#wait-instance_method" title="Concurrent::CyclicBarrier#wait (method)">#wait</a></span>
       <small>Concurrent::CyclicBarrier</small>
@@ -6972,7 +6980,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization.html#wait-instance_method" title="Concurrent::Synchronization#wait (method)">#wait</a></span>
       <small>Concurrent::Synchronization</small>
@@ -6980,7 +6988,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableFuture.html#wait-instance_method" title="Concurrent::Promises::ResolvableFuture#wait (method)">#wait</a></span>
       <small>Concurrent::Promises::ResolvableFuture</small>
@@ -6988,7 +6996,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Event.html#wait-instance_method" title="Concurrent::Event#wait (method)">#wait</a></span>
       <small>Concurrent::Event</small>
@@ -6996,7 +7004,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#wait-instance_method" title="Concurrent::Promises::AbstractEventFuture#wait (method)">#wait</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
@@ -7004,7 +7012,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#wait!-instance_method" title="Concurrent::Promises::Future#wait! (method)">#wait!</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -7012,7 +7020,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableFuture.html#wait!-instance_method" title="Concurrent::Promises::ResolvableFuture#wait! (method)">#wait!</a></span>
       <small>Concurrent::Promises::ResolvableFuture</small>
@@ -7020,7 +7028,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Concern/Obligation.html#wait!-instance_method" title="Concurrent::Concern::Obligation#wait! (method)">#wait!</a></span>
       <small>Concurrent::Concern::Obligation</small>
@@ -7028,7 +7036,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SingleThreadExecutor.html#wait_for_termination-instance_method" title="Concurrent::SingleThreadExecutor#wait_for_termination (method)">#wait_for_termination</a></span>
       <small>Concurrent::SingleThreadExecutor</small>
@@ -7036,7 +7044,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadPoolExecutor.html#wait_for_termination-instance_method" title="Concurrent::ThreadPoolExecutor#wait_for_termination (method)">#wait_for_termination</a></span>
       <small>Concurrent::ThreadPoolExecutor</small>
@@ -7044,7 +7052,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ImmediateExecutor.html#wait_for_termination-instance_method" title="Concurrent::ImmediateExecutor#wait_for_termination (method)">#wait_for_termination</a></span>
       <small>Concurrent::ImmediateExecutor</small>
@@ -7052,7 +7060,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/SimpleExecutorService.html#wait_for_termination-instance_method" title="Concurrent::SimpleExecutorService#wait_for_termination (method)">#wait_for_termination</a></span>
       <small>Concurrent::SimpleExecutorService</small>
@@ -7060,7 +7068,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Future.html#wait_or_cancel-instance_method" title="Concurrent::Future#wait_or_cancel (method)">#wait_or_cancel</a></span>
       <small>Concurrent::Future</small>
@@ -7068,7 +7076,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Synchronization.html#wait_until-instance_method" title="Concurrent::Synchronization#wait_until (method)">#wait_until</a></span>
       <small>Concurrent::Synchronization</small>
@@ -7076,7 +7084,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#with_default_executor-instance_method" title="Concurrent::Promises::Future#with_default_executor (method)">#with_default_executor</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -7084,7 +7092,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Event.html#with_default_executor-instance_method" title="Concurrent::Promises::Event#with_default_executor (method)">#with_default_executor</a></span>
       <small>Concurrent::Promises::Event</small>
@@ -7092,7 +7100,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/AbstractEventFuture.html#with_default_executor-instance_method" title="Concurrent::Promises::AbstractEventFuture#with_default_executor (method)">#with_default_executor</a></span>
       <small>Concurrent::Promises::AbstractEventFuture</small>
@@ -7100,7 +7108,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableFuture.html#with_hidden_resolvable-instance_method" title="Concurrent::Promises::ResolvableFuture#with_hidden_resolvable (method)">#with_hidden_resolvable</a></span>
       <small>Concurrent::Promises::ResolvableFuture</small>
@@ -7108,7 +7116,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/ResolvableEvent.html#with_hidden_resolvable-instance_method" title="Concurrent::Promises::ResolvableEvent#with_hidden_resolvable (method)">#with_hidden_resolvable</a></span>
       <small>Concurrent::Promises::ResolvableEvent</small>
@@ -7116,7 +7124,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Concern/Observable.html#with_observer-instance_method" title="Concurrent::Concern::Observable#with_observer (method)">#with_observer</a></span>
       <small>Concurrent::Concern::Observable</small>
@@ -7124,7 +7132,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReadWriteLock.html#with_read_lock-instance_method" title="Concurrent::ReadWriteLock#with_read_lock (method)">#with_read_lock</a></span>
       <small>Concurrent::ReadWriteLock</small>
@@ -7132,7 +7140,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReentrantReadWriteLock.html#with_read_lock-instance_method" title="Concurrent::ReentrantReadWriteLock#with_read_lock (method)">#with_read_lock</a></span>
       <small>Concurrent::ReentrantReadWriteLock</small>
@@ -7140,7 +7148,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReadWriteLock.html#with_write_lock-instance_method" title="Concurrent::ReadWriteLock#with_write_lock (method)">#with_write_lock</a></span>
       <small>Concurrent::ReadWriteLock</small>
@@ -7148,7 +7156,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReentrantReadWriteLock.html#with_write_lock-instance_method" title="Concurrent::ReentrantReadWriteLock#with_write_lock (method)">#with_write_lock</a></span>
       <small>Concurrent::ReentrantReadWriteLock</small>
@@ -7156,7 +7164,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Transaction.html#write-instance_method" title="Concurrent::Transaction#write (method)">#write</a></span>
       <small>Concurrent::Transaction</small>
@@ -7164,7 +7172,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ReadWriteLock.html#write_locked%3F-instance_method" title="Concurrent::ReadWriteLock#write_locked? (method)">#write_locked?</a></span>
       <small>Concurrent::ReadWriteLock</small>
@@ -7172,7 +7180,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/ThreadSafe/Util/XorShiftRandom.html#xorshift-instance_method" title="Concurrent::ThreadSafe::Util::XorShiftRandom#xorshift (method)">#xorshift</a></span>
       <small>Concurrent::ThreadSafe::Util::XorShiftRandom</small>
@@ -7180,7 +7188,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promise.html#zip-class_method" title="Concurrent::Promise.zip (method)">zip</a></span>
       <small>Concurrent::Promise</small>
@@ -7188,7 +7196,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Event.html#zip-instance_method" title="Concurrent::Promises::Event#zip (method)">#zip</a></span>
       <small>Concurrent::Promises::Event</small>
@@ -7196,7 +7204,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promise.html#zip-instance_method" title="Concurrent::Promise#zip (method)">#zip</a></span>
       <small>Concurrent::Promise</small>
@@ -7204,7 +7212,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/Future.html#zip-instance_method" title="Concurrent::Promises::Future#zip (method)">#zip</a></span>
       <small>Concurrent::Promises::Future</small>
@@ -7212,7 +7220,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#zip_events-instance_method" title="Concurrent::Promises::FactoryMethods#zip_events (method)">#zip_events</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -7220,7 +7228,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#zip_events_on-instance_method" title="Concurrent::Promises::FactoryMethods#zip_events_on (method)">#zip_events_on</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -7228,7 +7236,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#zip_futures-instance_method" title="Concurrent::Promises::FactoryMethods#zip_futures (method)">#zip_futures</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -7236,7 +7244,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#zip_futures_on-instance_method" title="Concurrent::Promises::FactoryMethods#zip_futures_on (method)">#zip_futures_on</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -7244,7 +7252,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#zip_futures_over-instance_method" title="Concurrent::Promises::FactoryMethods#zip_futures_over (method)">#zip_futures_over</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>
@@ -7252,7 +7260,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Concurrent/Promises/FactoryMethods.html#zip_futures_over_on-instance_method" title="Concurrent::Promises::FactoryMethods#zip_futures_over_on (method)">#zip_futures_over_on</a></span>
       <small>Concurrent::Promises::FactoryMethods</small>

--- a/lib/concurrent-ruby/concurrent/map.rb
+++ b/lib/concurrent-ruby/concurrent/map.rb
@@ -143,8 +143,15 @@ module Concurrent
       end
     end
 
+    # Set a value with key
+    # @param [Object] key
+    # @param [Object] value
+    # @return [Object] the new value
+    def []=(key, value)
+      super
+    end
+
     alias_method :get, :[]
-    # TODO (pitr-ch 30-Oct-2018): doc
     alias_method :put, :[]=
 
     # Get a value with key, or default_value when key is absent,


### PR DESCRIPTION
Added in the documentation `Concurrent::Map` missed method.
![Screenshot](https://user-images.githubusercontent.com/78730546/110658877-209a5580-81d3-11eb-8f07-2af344446d6a.png)
