### PR TITLE
Make `Concurrent::Set` thread-safe on CRuby

### DIFF
--- a/lib/concurrent-ruby/concurrent/set.rb
+++ b/lib/concurrent-ruby/concurrent/set.rb
@@ -23,9 +23,13 @@ module Concurrent
   # @!macro internal_implementation_note
   SetImplementation = case
                       when Concurrent.on_cruby?
-                        # Because MRI never runs code in parallel, the existing
-                        # non-thread-safe structures should usually work fine.
-                        ::Set
+                        require 'monitor'
+                        require 'concurrent/thread_safe/util/data_structures'
+
+                        class CRubySet < ::Set
+                        end
+                        ThreadSafe::Util.make_synchronized_on_cruby Concurrent::CRubySet
+                        CRubySet
 
                       when Concurrent.on_jruby?
                         require 'jruby/synchronized'

--- a/lib/concurrent-ruby/concurrent/thread_safe/util/data_structures.rb
+++ b/lib/concurrent-ruby/concurrent/thread_safe/util/data_structures.rb
@@ -12,6 +12,25 @@ end
 module Concurrent
   module ThreadSafe
     module Util
+      def self.make_synchronized_on_cruby(klass)
+        klass.class_eval do
+          def initialize(*args, &block)
+            @_monitor = Monitor.new
+            super
+          end
+        end
+
+        klass.superclass.instance_methods(false).each do |method|
+          klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+            def #{method}(*args)
+              monitor = @_monitor
+              monitor or raise("BUG: Internal monitor was not properly initialized. Please report this to the concurrent-ruby developers.")
+              monitor.synchronize { super }
+            end
+          RUBY
+        end
+      end
+
       def self.make_synchronized_on_rbx(klass)
         klass.class_eval do
           private

--- a/spec/concurrent/set_spec.rb
+++ b/spec/concurrent/set_spec.rb
@@ -42,7 +42,7 @@ module Concurrent
     end
 
     context 'concurrency' do
-      it do
+      it '#add and #delete' do
         (1..Concurrent::ThreadSafe::Test::THREADS).map do |i|
           in_thread do
             1000.times do
@@ -54,6 +54,36 @@ module Concurrent
           end
         end.map(&:join)
         expect(set).to be_empty
+      end
+
+      it '#each' do
+        threads = []
+        ("a".."z").inject(set, &:<<) # setup a non-empty set
+
+        threads << in_thread do
+          2000.times do
+            size = nil
+            set.each do |member|
+              if size.nil?
+                size = set.length
+              else
+                expect(set.length).to eq(size)
+              end
+            end
+          end
+        end
+
+        threads += (1..19).map do |i|
+          in_thread do
+            v = i * 1000
+            10.times do
+              200.times { |j| set << (v+j) }
+              200.times { |j| set.delete(v+j) }
+            end
+          end
+        end
+
+        threads.map(&:join)
       end
     end
   end


### PR DESCRIPTION
See #900 for original issue pointing out that `Concurrent::Set#each` (and other methods as well) are not thread-safe because the implementation was short-circuited to be `::Set`.

This PR adds two commits:

- one introducing test coverage for thread-safe usage of `#each` combined with `#add` and `#delete`
- a second introducing a CRuby-specific `Set` implementation that uses `Monitor` to synchronize across all instance methods

This approach, using a new method `ThreadSafe::Util.make_synchronized_on_cruby`, borrows heavily from the approach used for Rubinius (see `ThreadSafe::Util.make_synchronized_on_rbx`).

Please let me know if this approach is too naïve, I fear I may be missing something obvious.
