### PR TITLE
Add new ConcurrentMap backend for TruffleRuby

### DIFF
--- a/lib/concurrent-ruby/concurrent/collection/map/truffleruby_map_backend.rb
+++ b/lib/concurrent-ruby/concurrent/collection/map/truffleruby_map_backend.rb
@@ -1,0 +1,14 @@
+module Concurrent
+
+  # @!visibility private
+  module Collection
+
+    # @!visibility private
+    class TruffleRubyMapBackend < TruffleRuby::ConcurrentMap
+      def initialize(options = nil)
+        options ||= {}
+        super(initial_capacity: options[:initial_capacity], load_factor: options[:load_factor])
+      end
+    end
+  end
+end

--- a/lib/concurrent-ruby/concurrent/map.rb
+++ b/lib/concurrent-ruby/concurrent/map.rb
@@ -16,8 +16,13 @@ module Concurrent
                           require 'concurrent/collection/map/mri_map_backend'
                           MriMapBackend
                         when Concurrent.on_rbx? || Concurrent.on_truffleruby?
-                          require 'concurrent/collection/map/atomic_reference_map_backend'
-                          AtomicReferenceMapBackend
+                          if defined?(::TruffleRuby::ConcurrentMap)
+                            require 'concurrent/collection/map/truffleruby_map_backend'
+                            TruffleRubyMapBackend
+                          else
+                            require 'concurrent/collection/map/atomic_reference_map_backend'
+                            AtomicReferenceMapBackend
+                          end
                         else
                           warn 'Concurrent::Map: unsupported Ruby engine, using a fully synchronized Concurrent::Map implementation'
                           require 'concurrent/collection/map/synchronized_map_backend'


### PR DESCRIPTION
We've created a new backend for more efficient mapping on TruffleRuby using [Java's ConcurrentHashMap](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html) library - https://github.com/oracle/truffleruby/pull/2339

The new backend is faster than the previous implementation for TruffleRuby, `AtomicReferenceMapBackend`. And also [faster than MRI and JRuby](https://github.com/oracle/truffleruby/pull/2339#issuecomment-833104880): 
> 675% relative to MRI and 539% relative to JRuby.

## Changes
* Add a `TruffleRubyMapBackend` that inherits from the new `TruffleRuby::ConcurrentMap`
* Use the `TruffleRubyMapBackend` backend for `Concurrent::Map` on TruffleRuby if available

## Testing
The new backend has been tested locally and passes the `map_spec` on this gem 