### PR TITLE
Add test CI flow for various Rubys on Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.7, jruby, jruby-head, truffleruby-head]
+        experimental: [false]
+        include:
+          - ruby: head
+            experimental: true
+          - ruby: truffleruby
+            experimental: true
+
+    env:
+      JAVA_OPTS: '-Xmx1024m'
+      RUBYOPT: '-w'
+      JRUBY_OPTS: '--dev'
+
+    name: "Tests: Ruby ${{ matrix.ruby }}"
+    steps:
+    - name: Clone Repo
+      uses: actions/checkout@v2
+    - name: Setup system Ruby ${{ matrix.ruby }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: |
+        gem install bundler --version 1.17.3
+        echo JAVA_OPTS: $JAVA_OPTS
+        bundle exec rake ci


### PR DESCRIPTION
## Change

Travis CI has been down for a while now and we'd like to switch to Github Actions. This change introduces a new CI build on Github Actions that runs tests on Ruby implementations and also mark some Ruby failing implementations as experimental so the build still passes.

It does not contain all the requirements from the previous Travis CI yet, but it's a good start. 

#### Currently, tests pass on these Ruby implementations: 
- 2.7, jruby, jruby-head, truffleruby-head

#### These Ruby implementations are marked experimental as they are failing: 
- head (ruby-head), truffleruby

## Missing Functionalities

There are some functionalities that exist in the previous CI (travis CI) that is missing from this change.

- Specifying jdk for JRuby implementations
- Running order of Ruby implementations based on importance/relevance 
- YARD uptodate in docs (`rake yard:master:uptodate`) 
- Running tests on Rubinius (currently, ruby/setup-ruby does not support Rubinius) 

## Questions

Would this change still be useful? 

The `truffleruby-head` is a flaky build, it passes sometimes but fails most. Should we mark it experimental (so the build will still be green if it fails)?