### PR TITLE
CI: Use JRuby 9.2.18.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ matrix:
     # Latest versions first
     - name: MRI 2.7.0 Latest
       rvm: 2.7.0
-    - name: Latest JRuby on Java 11
+    - name: Latest JRuby 9.2.18.0 on Java 11
       rvm: jruby-9.2.18.0
       jdk: oraclejdk11
-    - name: Latest JRuby on Java 8
+    - name: Latest JRuby 9.2.18.0 on Java 8
       rvm: jruby-9.2.18.0
       jdk: openjdk8
     - name: TruffleRuby Latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     # Latest versions first
     - name: MRI 2.7.0 Latest
       rvm: 2.7.0
-    - name: JRuby 9.2.16.0 Latest on Java 11
-      rvm: jruby-9.2.16.0
+    - name: Latest JRuby on Java 11
+      rvm: jruby-9.2.18.0
       jdk: oraclejdk11
-    - name: JRuby 9.2.16.0 Latest on Java 8
-      rvm: jruby-9.2.16.0
+    - name: Latest JRuby on Java 8
+      rvm: jruby-9.2.18.0
       jdk: openjdk8
     - name: TruffleRuby Latest
       rvm: truffleruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,20 @@ matrix:
   fast_finish: true
   include:
     # Latest versions first
-    - name: MRI 2.7.0 Latest
-      rvm: 2.7.0
+    - name: Latest MRI 2.7.3
+      rvm: 2.7.3
     - name: Latest JRuby 9.2.18.0 on Java 11
       rvm: jruby-9.2.18.0
       jdk: oraclejdk11
     - name: Latest JRuby 9.2.18.0 on Java 8
       rvm: jruby-9.2.18.0
       jdk: openjdk8
-    - name: TruffleRuby Latest
+    - name: Latest TruffleRuby
       rvm: truffleruby
+
+    # Documentation up-to-date check
     - name: YARD uptodate in docs
-      rvm: 2.7.0
+      rvm: 2.7.3
       script:
       - bundle install --with documentation
       - bundle exec rake yard:master:uptodate


### PR DESCRIPTION

This PR updates the CI matrix to use latest JRuby, **9.2.18.0**.

[JRuby 9.2.18.0 release blog post](https://www.jruby.org/2021/06/08/jruby-9-2-18-0.html)

Configure JRuby to update in fewer locations.