### PR TITLE
CI: Use JRuby 9.2.19.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     # Latest versions first
     - name: Latest MRI 2.7.3
       rvm: 2.7.3
-    - name: Latest JRuby 9.2.18.0 on Java 11
-      rvm: jruby-9.2.18.0
+    - name: Latest JRuby 9.2.19.0 on Java 11
+      rvm: jruby-9.2.19.0
       jdk: oraclejdk11
-    - name: Latest JRuby 9.2.18.0 on Java 8
-      rvm: jruby-9.2.18.0
+    - name: Latest JRuby 9.2.19.0 on Java 8
+      rvm: jruby-9.2.19.0
       jdk: openjdk8
     - name: Latest TruffleRuby
       rvm: truffleruby


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.19.0**.

[JRuby 9.2.19.0 release blog post](https://www.jruby.org/2021/06/15/jruby-9-2-19-0.html)