### PR TITLE
Specs: Use latest timecop v0.9.4, to fix ruby-head

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ end
 
 group :testing do
   gem 'rspec', '~> 3.7'
-  gem 'timecop', '~> 0.7.4'
+  gem 'timecop', '~> 0.9'
   gem 'sigdump', require: false
 end
 


### PR DESCRIPTION
This PR asks for a Timecop with a non-exact version, `0.9`, which resolves to 0.9.4. That version supports Ruby 3.1 aka ruby-head.  [Timecop changelog](https://github.com/travisjeffery/timecop/blob/master/History.md#v094).

## Background

Last commit to that line in the Gemfile was 6 years ago, with exact versions everywhere. https://github.com/ruby-concurrency/concurrent-ruby/commit/4cfd9c75ec2ee092796edfa7e4fba842c43f316b


## Result

With this version of timecop, **concurrent-ruby is green 🟢 on ruby-head**.


---

<details>

```
/home/runner/.rubies/ruby-head/bin/ruby -I/home/runner/work/concurrent-ruby/concurrent-ruby/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.10.1/lib:/home/runner/work/concurrent-ruby/concurrent-ruby/vendor/bundle/ruby/3.1.0/gems/rspec-support-3.10.2/lib /home/runner/work/concurrent-ruby/concurrent-ruby/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.10.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --color --backtrace --order defined --format documentation --tag ~notravis
<internal:timev>:301:in `initialize': no implicit conversion of Hash into Integer (TypeError)
	from /home/runner/work/concurrent-ruby/concurrent-ruby/vendor/bundle/ruby/3.1.0/gems/timecop-0.7.4/lib/timecop/time_extensions.rb:22:in `new'
	from /home/runner/work/concurrent-ruby/concurrent-ruby/vendor/bundle/ruby/3.1.0/gems/timecop-0.7.4/lib/timecop/time_extensions.rb:22:in `new_with_mock_time'
	from <internal:timev>:219:in `now'
	from /home/runner/work/concurrent-ruby/concurrent-ruby/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:89:in `start'
	from /home/runner/work/concurrent-ruby/concurrent-ruby/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/reporter.rb:72:in `report'
	from /home/runner/work/concurrent-ruby/concurrent-ruby/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:115:in `run_specs'
	from /home/runner/work/concurrent-ruby/concurrent-ruby/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:89:in `run'
	from /home/runner/work/concurrent-ruby/concurrent-ruby/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:71:in `run'
	from /home/runner/work/concurrent-ruby/concurrent-ruby/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.10.1/lib/rspec/core/runner.rb:45:in `invoke'
	from /home/runner/work/concurrent-ruby/concurrent-ruby/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.10.1/exe/rspec:4:in `<main>'
```

This was in one of the GitHub Actions results: https://github.com/ruby-concurrency/concurrent-ruby/runs/2848609176#step:4:94

</details>