### PR TITLE
Cleanup GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, jruby, jruby-head]
-        experimental: [false]
 
     env:
       JAVA_OPTS: '-Xmx1024m'
@@ -20,13 +19,10 @@ jobs:
     steps:
     - name: Clone Repo
       uses: actions/checkout@v2
-    - name: Setup system Ruby ${{ matrix.ruby }}
+    - name: Setup Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler-cache: true
     - name: Run tests
-      run: |
-        gem install bundler --version 1.17.3
-        echo JAVA_OPTS: $JAVA_OPTS
-        bundle exec rake ci
+      run: bundle exec rake ci

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -21,13 +21,10 @@ jobs:
     steps:
     - name: Clone Repo
       uses: actions/checkout@v2
-    - name: Setup system Ruby ${{ matrix.ruby }}
+    - name: Setup Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler-cache: true
     - name: Run tests
-      run: |
-        gem install bundler --version 1.17.3
-        echo JAVA_OPTS: $JAVA_OPTS
-        bundle exec rake ci
+      run: bundle exec rake ci


### PR DESCRIPTION
* No need to install Bundler a second time, it was also unused.
* JAVA_OPTS are already shown in the log.