### PR TITLE
Detect RbConfig::CONFIG["target_os"] == "darwin20"

### DIFF
--- a/lib/concurrent-ruby/concurrent/utility/processor_counter.rb
+++ b/lib/concurrent-ruby/concurrent/utility/processor_counter.rb
@@ -119,7 +119,7 @@ module Concurrent
 
       def compute_physical_processor_count
         ppc = case RbConfig::CONFIG["target_os"]
-              when /darwin1/
+              when /darwin\d\d/
                 IO.popen("/usr/sbin/sysctl -n hw.physicalcpu", &:read).to_i
               when /linux/
                 cores = {} # unique physical ID / core ID combinations


### PR DESCRIPTION
Reported by macOs Big Sur 11.4.