### PR TITLE
can get write lock after read locked more than once only by myself

### DIFF
--- a/lib/concurrent-ruby/concurrent/atomic/reentrant_read_write_lock.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/reentrant_read_write_lock.rb
@@ -267,12 +267,10 @@ module Concurrent
         #   running right now, AND no writers who came before us still waiting to
         #   acquire the lock
         # Additionally, if any read locks have been taken, we must hold all of them
-        if c == held
-          # If we successfully swap the RUNNING_WRITER bit on, then we can go ahead
-          if @Counter.compare_and_set(c, c+RUNNING_WRITER)
-            @HeldCount.value = held + WRITE_LOCK_HELD
-            return true
-          end
+        if held > 0 && @Counter.compare_and_set(1, c+RUNNING_WRITER)
+          # If we are the only one reader and successfully swap the RUNNING_WRITER bit on, then we can go ahead
+          @HeldCount.value = held + WRITE_LOCK_HELD
+          return true
         elsif @Counter.compare_and_set(c, c+WAITING_WRITER)
           while true
             # Now we have successfully incremented, so no more readers will be able to increment


### PR DESCRIPTION
The condition `@Count == @HeldCount` does not correctly indicate that WE ARE THE ONLY READER.

Because when we lock for read more than once, `@HeldCount` increases but `@Count` dosen't.

```ruby
lock.with_read_lock do
  lock.with_read_lock do
    # blocked here, can not acquire write lock ! Even though no else reader
    lock.with_write_lock {}
  end
end
```

So we just compare `@Count == 1` and try to set RUNNING_WRITER bit on