### PR TITLE
build: Trust CI system to have a Bundler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,5 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: |
-        gem install bundler --version 1.17.3
         echo JAVA_OPTS: $JAVA_OPTS
         bundle exec rake ci

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -28,6 +28,5 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: |
-        gem install bundler --version 1.17.3
         echo JAVA_OPTS: $JAVA_OPTS
         bundle exec rake ci


### PR DESCRIPTION
This PR cleans up an old, now-duplicate installation of Bundler.

We are using the `bundler-cache` feature of ruby/setup-ruby, which does the installing and caching of gems. Perhaps we can skip installing a Bundler.