### PR TITLE
Fix setting AtomicReferenceImplementation on TruffleRuby

### DIFF
--- a/lib/concurrent-ruby/concurrent/atomic/atomic_reference.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/atomic_reference.rb
@@ -170,6 +170,7 @@ module Concurrent
                                       alias_method :compare_and_swap, :compare_and_set
                                       alias_method :swap, :get_and_set
                                     end
+                                    TruffleRubyAtomicReference
                                   when Concurrent.on_rbx?
                                     # @note Extends `Rubinius::AtomicReference` version adding aliases
                                     #   and numeric logic.


### PR DESCRIPTION
* This accidentally worked before because until Ruby 2.7 `alias_method` returns the receiver.
* In Ruby 3 however, `alias_method` returns the first argument.

```
$ ruby -ve 'p class C; alias_method :id, :object_id; end'
ruby 2.7.4p191 (2021-07-07 revision a21a3b7d23) [x86_64-linux]
C
$ chruby 3.0.2                                           
$ ruby -ve 'p class C; alias_method :id, :object_id; end'
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux]
:id
```

This is blocking to implement the change about `alias_method`;s return value in https://github.com/oracle/truffleruby/pull/2499.
Could you make a bug fix release with this fix soon if possible?

cc @pitr-ch 