### PR TITLE
Support kwargs in initializer when mixing in Concurrent::Async

### DIFF
--- a/lib/concurrent-ruby/concurrent/async.rb
+++ b/lib/concurrent-ruby/concurrent/async.rb
@@ -267,8 +267,8 @@ module Concurrent
 
     # @!visibility private
     module ClassMethods
-      def new(*args, &block)
-        obj = original_new(*args, &block)
+      def new(*args, **kwargs, &block)
+        obj = original_new(*args, **kwargs, &block)
         obj.send(:init_synchronization)
         obj
       end

--- a/lib/concurrent-ruby/concurrent/async.rb
+++ b/lib/concurrent-ruby/concurrent/async.rb
@@ -267,10 +267,18 @@ module Concurrent
 
     # @!visibility private
     module ClassMethods
-      def new(*args, **kwargs, &block)
-        obj = original_new(*args, **kwargs, &block)
-        obj.send(:init_synchronization)
-        obj
+      if RUBY_VERSION >= "2.7.0"
+        def new(*args, **kwargs, &block)
+          obj = original_new(*args, **kwargs, &block)
+          obj.send(:init_synchronization)
+          obj
+        end
+      else
+        def new(*args, &block)
+          obj = original_new(*args, &block)
+          obj.send(:init_synchronization)
+          obj
+        end
       end
     end
     private_constant :ClassMethods


### PR DESCRIPTION
Classes with keyword arguments in their initializers cannot be initialized today if they include `Concurrent::Async`, as of Ruby 3.0.