### PR TITLE
SafeTaskExecutor respects local jump errors

### DIFF
--- a/lib/concurrent-ruby/concurrent/executor/safe_task_executor.rb
+++ b/lib/concurrent-ruby/concurrent/executor/safe_task_executor.rb
@@ -16,10 +16,10 @@ module Concurrent
 
     # @return [Array]
     def execute(*args)
-      synchronize do
-        success = false
-        value   = reason = nil
+      success = true
+      value   = reason = nil
 
+      synchronize do
         begin
           value   = @task.call(*args)
           success = true
@@ -27,9 +27,9 @@ module Concurrent
           reason  = ex
           success = false
         end
-
-        [success, value, reason]
       end
+
+      [success, value, reason]
     end
   end
 end

--- a/spec/concurrent/executor/safe_task_executor_spec.rb
+++ b/spec/concurrent/executor/safe_task_executor_spec.rb
@@ -94,6 +94,35 @@ module Concurrent
           }.to raise_error(Exception)
         end
       end
+
+      context 'local jump error' do
+        def execute
+          Thread.new do
+            executor = SafeTaskExecutor.new(-> { yield 42 })
+            @result = executor.execute
+          end.join
+        end
+
+        subject do
+          to_enum(:execute).first
+          @result
+        end
+
+        it 'should return success' do
+          success, _value, _reason = subject
+          expect(success).to be_truthy
+        end
+
+        it 'should return a nil value' do
+          _success, value, _reason = subject
+          expect(value).to be_nil
+        end
+
+        it 'should return a nil reason' do
+          _success, _value, reason = subject
+          expect(reason).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
See: https://bugs.ruby-lang.org/issues/18474
And: https://github.com/ruby-concurrency/concurrent-ruby/issues/931