### PR TITLE
Move jruby-head to the experimental workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, jruby, jruby-head]
+        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, jruby]
 
     env:
       JAVA_OPTS: '-Xmx1024m'

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [head, truffleruby, truffleruby-head]
+        ruby: [head, jruby-head, truffleruby, truffleruby-head]
 
     env:
       JAVA_OPTS: '-Xmx1024m'


### PR DESCRIPTION
It fails currently, probably due to some issues with kwargs: https://github.com/ruby-concurrency/concurrent-ruby/runs/5010387674?check_suite_focus=true.
Other head rubies are already in the experimental workflow.