### PR TITLE
caller_runs execution should not block the work queue

### DIFF
--- a/lib/concurrent-ruby/concurrent/executor/java_executor_service.rb
+++ b/lib/concurrent-ruby/concurrent/executor/java_executor_service.rb
@@ -20,7 +20,7 @@ if Concurrent.on_jruby?
 
       def post(*args, &task)
         raise ArgumentError.new('no block given') unless block_given?
-        return handle_fallback(*args, &task) unless running?
+        return fallback_action(*args, &task).call unless running?
         @executor.submit Job.new(args, task)
         true
       rescue Java::JavaUtilConcurrent::RejectedExecutionException

--- a/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb
@@ -156,10 +156,11 @@ module Concurrent
       if ns_assign_worker(*args, &task) || ns_enqueue(*args, &task)
         @scheduled_task_count += 1
       else
-        handle_fallback(*args, &task)
+        return fallback_action(*args, &task)
       end
 
       ns_prune_pool if @next_gc_time < Concurrent.monotonic_time
+      nil
     end
 
     # @!visibility private


### PR DESCRIPTION
`caller_runs` execution was being done while the executor lock was held. This caused the entire executor’s work queue to be blocked, with worker threads not able to take new work. We’ve restructured so that the execution is done as deferred work, outside of the lock.

Fixes #933.