### PR TITLE
Allow overriding default min_theads/max_threads/max_queue

### DIFF
--- a/lib/concurrent-ruby/concurrent/executor/cached_thread_pool.rb
+++ b/lib/concurrent-ruby/concurrent/executor/cached_thread_pool.rb
@@ -37,11 +37,11 @@ module Concurrent
     #
     #   @see http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html#newCachedThreadPool--
     def initialize(opts = {})
-      defaults  = { idletime: DEFAULT_THREAD_IDLETIMEOUT }
-      overrides = { min_threads: 0,
+      defaults  = { idletime: DEFAULT_THREAD_IDLETIMEOUT,
+                    min_threads: 0,
                     max_threads: DEFAULT_MAX_POOL_SIZE,
                     max_queue:   DEFAULT_MAX_QUEUE_SIZE }
-      super(defaults.merge(opts).merge(overrides))
+      super(defaults.merge(opts))
     end
 
     private

--- a/spec/concurrent/executor/cached_thread_pool_spec.rb
+++ b/spec/concurrent/executor/cached_thread_pool_spec.rb
@@ -17,7 +17,34 @@ module Concurrent
 
     let(:latch) { Concurrent::CountDownLatch.new }
 
-    context '#initialize' do
+    context '#initialize with overrides' do
+      subject do
+        described_class.new(
+          max_threads: 300,
+          min_threads: 10,
+          idletime: 30,
+          max_queue: 500,
+        )
+      end
+
+      it 'sets :max_length' do
+        expect(subject.max_length).to eq 300
+      end
+
+      it 'sets :min_length' do
+        expect(subject.min_length).to eq 10
+      end
+
+      it 'sets :idletime' do
+        expect(subject.idletime).to eq 30
+      end
+
+      it 'sets :max_queue' do
+        expect(subject.max_queue).to eq 500
+      end
+    end
+
+    context '#initialize with defaults' do
 
       subject { described_class.new }
 


### PR DESCRIPTION
If I specify `min_threads`/`max_threads`/`max_queue` in the constructor for `CachedThreadPool`, these options are just ignored. I don't understand why I should not be allowed to override the defaults.

```
pool = Concurrent::CachedThreadPool.new(min_threads: 10, max_threads: 100, max_queue: 1000)

irb(main):002:0> pool.max_length
=> 2147483647

irb(main):003:0> pool.min_length
=> 0

irb(main):004:0> pool.max_queue
=> 0
```