### PR TITLE
doc: Return type of Promises.any_event

### DIFF
--- a/lib/concurrent-ruby/concurrent/promises.rb
+++ b/lib/concurrent-ruby/concurrent/promises.rb
@@ -313,7 +313,7 @@ module Concurrent
       end
 
       # @!macro promises.shortcut.on
-      # @return [Future]
+      # @return [Event]
       def any_event(*futures_and_or_events)
         any_event_on default_executor, *futures_and_or_events
       end


### PR DESCRIPTION
`Promises.any_event` returns an `Event`, whether the arguments are `Event`s or `Future`s.