### PR TITLE
ResolvableEvent#resolve(true) should raise on reassignment

### DIFF
--- a/lib/concurrent-ruby/concurrent/promises.rb
+++ b/lib/concurrent-ruby/concurrent/promises.rb
@@ -892,7 +892,7 @@ module Concurrent
       private
 
       def rejected_resolution(raise_on_reassign, state)
-        Concurrent::MultipleAssignmentError.new('Event can be resolved only once') if raise_on_reassign
+        raise Concurrent::MultipleAssignmentError.new('Event can be resolved only once') if raise_on_reassign
         return false
       end
 

--- a/lib/concurrent-ruby/concurrent/promises.rb
+++ b/lib/concurrent-ruby/concurrent/promises.rb
@@ -1298,7 +1298,7 @@ module Concurrent
 
       # @!macro promise.param.raise_on_reassign
       #   @param [Boolean] raise_on_reassign should method raise exception if already resolved
-      #   @return [self, false] false is returner when raise_on_reassign is false and the receiver
+      #   @return [self, false] false is returned when raise_on_reassign is false and the receiver
       #     is already resolved.
       #
 

--- a/spec/concurrent/promises_spec.rb
+++ b/spec/concurrent/promises_spec.rb
@@ -560,6 +560,18 @@ RSpec.describe 'Concurrent::Promises' do
       expect(event.wait(0, true)).to be_truthy
     end
 
+    specify "#resolve(raise_on_reassign = true)" do
+      event = resolvable_event
+      event.resolve
+      expect { event.resolve }.to raise_error(Concurrent::MultipleAssignmentError)
+    end
+
+    specify "#resolve(raise_on_reassign = false)" do
+      event = resolvable_event
+      event.resolve
+      expect(event.resolve(false)).to be_falsey
+    end
+
     specify "reservation" do
       event = resolvable_event
       expect(event.reserve).to be_truthy


### PR DESCRIPTION
This patch fixes the bug that calling `ResolvableEvent#resolve` with `raise_on_reassign = true` on an already resolved `ResolvableEvent` does not raise an exception.

Fixes: https://github.com/ruby-concurrency/concurrent-ruby/issues/964

It seems that this bug has been there for ~7 years: https://github.com/ruby-concurrency/concurrent-ruby/blob/4519f945cfdbe4287690c8b1dd0e5362f5412a1c/lib/concurrent/edge/future.rb#L180