### PR TITLE
Require Ruby 2.3+ and drop Ruby 2.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, jruby, truffleruby]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, jruby, truffleruby]
 
     env:
       JAVA_OPTS: '-Xmx1024m'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Current
 
+* (#975) Set the Ruby compatibility version at 2.3
+* (#972) Remove Rubinius-related code
+
 ## Release v1.1.10
 
 concurrent-ruby:

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ be obeyed though. Features developed in `concurrent-ruby-edge` are expected to m
 
 ## Supported Ruby versions
 
-* MRI 2.2 and above
+* MRI 2.3 and above
 * Latest JRuby 9000
 * Latest TruffleRuby
 

--- a/concurrent-ruby-edge.gemspec
+++ b/concurrent-ruby-edge.gemspec
@@ -23,7 +23,7 @@ be obeyed though. Features developed in `concurrent-ruby-edge` are expected to m
 Please see http://concurrent-ruby.com for more information.
   TXT
 
-  s.required_ruby_version = '>= 2.2'
+  s.required_ruby_version = '>= 2.3'
 
   s.add_runtime_dependency 'concurrent-ruby', "~> #{Concurrent::VERSION}"
 end

--- a/concurrent-ruby-ext.gemspec
+++ b/concurrent-ruby-ext.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths    = ['lib']
   s.extensions       = 'ext/concurrent-ruby-ext/extconf.rb'
 
-  s.required_ruby_version = '>= 2.2'
+  s.required_ruby_version = '>= 2.3'
 
   s.add_runtime_dependency 'concurrent-ruby', "= #{Concurrent::VERSION}"
 end

--- a/concurrent-ruby.gemspec
+++ b/concurrent-ruby.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |s|
   TXT
   s.metadata["source_code_uri"] = "https://github.com/ruby-concurrency/concurrent-ruby"
   s.metadata["changelog_uri"] = "https://github.com/ruby-concurrency/concurrent-ruby/blob/master/CHANGELOG.md"
-  s.required_ruby_version = '>= 2.2'
+  s.required_ruby_version = '>= 2.3'
 end

--- a/lib/concurrent-ruby/concurrent/utility/engine.rb
+++ b/lib/concurrent-ruby/concurrent/utility/engine.rb
@@ -7,10 +7,6 @@ module Concurrent
         RUBY_ENGINE == 'jruby'
       end
 
-      def on_jruby_9000?
-        on_jruby? && ruby_version(JRUBY_VERSION, :>=, 9, 0, 0)
-      end
-
       def on_cruby?
         RUBY_ENGINE == 'ruby'
       end


### PR DESCRIPTION
* Set `required_ruby_version` to 2.3.
* `rb_data_object_alloc()` is deprecated since a long time by `rb_data_object_wrap()` but that is [not available in Ruby 2.2](https://github.com/ruby/ruby/blob/ruby_2_2/include/ruby/ruby.h#L1218), so drop Ruby 2.2 support.

Example failed CI run on 2.2:
https://github.com/ruby-concurrency/concurrent-ruby/actions/runs/3749315062/jobs/6367656392
```
compiling ../../../../ext/concurrent-ruby-ext/atomic_reference.c
../../../../ext/concurrent-ruby-ext/atomic_reference.c: In function ‘ir_alloc’:
../../../../ext/concurrent-ruby-ext/atomic_reference.c:47:10: warning: implicit declaration of function ‘rb_data_object_wrap’; did you mean ‘rb_data_object_get’? [-Wimplicit-function-declaration]
   47 |   return rb_data_object_wrap(klass, (void *) Qnil, ir_mark, NULL);
      |          ^~~~~~~~~~~~~~~~~~~
      |          rb_data_object_get
```