### PR TITLE
Let `Promises.any_fulfilled_future` take an `Event`

### DIFF
--- a/lib/concurrent-ruby/concurrent/promises.rb
+++ b/lib/concurrent-ruby/concurrent/promises.rb
@@ -2074,8 +2074,8 @@ module Concurrent
 
       private
 
-      def resolvable?(countdown, future, index)
-        future.fulfilled? ||
+      def resolvable?(countdown, event_or_future, index)
+        (event_or_future.is_a?(Event) ? event_or_future.resolved? : event_or_future.fulfilled?) ||
             # inlined super from BlockedPromise
             countdown.zero?
       end

--- a/spec/concurrent/promises_spec.rb
+++ b/spec/concurrent/promises_spec.rb
@@ -157,6 +157,24 @@ RSpec.describe 'Concurrent::Promises' do
 
       expect(any.value!).to eq :value
     end
+
+    it 'treats a resolved Event as a fulfilled Future' do
+        any = any_fulfilled_future(
+          resolved_event,
+          fulfilled_future(:value),
+        )
+
+        expect(any.value!).to eq nil
+    end
+
+    it 'treats a pending Event as a pending Future' do
+        any = any_fulfilled_future(
+          resolvable_event,
+          fulfilled_future(:value),
+        )
+
+        expect(any.value!).to eq :value
+    end
   end
 
   describe '.zip' do


### PR DESCRIPTION
This patch teaches `Promises.any_fulfilled_future` to treat a resolved `Event` as a fulfilled `Future` value of `nil`.

Closes: https://github.com/ruby-concurrency/concurrent-ruby/issues/963
