### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, jruby, truffleruby]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby, truffleruby]
 
     env:
       JAVA_OPTS: '-Xmx1024m'
@@ -18,7 +18,7 @@ jobs:
     name: "Tests: Ruby ${{ matrix.ruby }}"
     steps:
     - name: Clone Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -22,7 +22,7 @@ jobs:
     name: "Tests: Experimental Ruby ${{ matrix.ruby }}"
     steps:
     - name: Clone Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Also updates checkout action version.

Runs green on my fork, although there was a flap on Ruby 3.0 and JRuby on first run.