### PR TITLE
Run each spec file in a process to detect missing requires

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -114,6 +114,19 @@ Go back to your pull request after a few minutes and see whether it passed muste
 
 Please note that testing concurrency is hard. Very hard. We have a few tests that occasionally fail due (mostly) to incorrect synchronization within the test itself. If everything passes locally but you see an error on CI, it's possibly you've become victim to one of the tests. Don't worry, the Concurrent Ruby team reviews the tests output of all failed CI runs and will let you know if the failing test is unrelated to your commit.
 
+#### IntelliJ
+
+To setup this project with IntelliJ Ultimate, this worked well:
+* Save any local changes to `ext/concurrent-ruby`
+* `rm -rf ext/concurrent-ruby`
+* Open the root `concurrent-ruby` folder as a Ruby module
+* Set `lib/concurrent-ruby` as `lib/concurrent-ruby-edge` as sources
+* `git checkout ext/concurrent-ruby`
+* Import `ext/concurrent-ruby` as Java module
+
+If it's imported directly without removing `ext/concurrent-ruby` then the whole project is recognized as a Java module,
+and `require` resolution, etc does not work.
+
 #### Thank You
 
 Please do know that we really appreciate and value your time and work. We love you, really.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 on: [push, pull_request]
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -26,3 +29,17 @@ jobs:
         bundler-cache: true
     - name: Run tests
       run: bundle exec rake ci
+
+  isolated:
+    name: "Test isolated"
+    runs-on: ubuntu-latest
+    env:
+      RUBYOPT: '-w'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+          bundler-cache: true
+      - run: bundle exec rake compile
+      - run: bundle exec rake spec:isolated

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 require File.join(File.dirname(__FILE__), 'lib/concurrent-ruby/concurrent/version')
 require File.join(File.dirname(__FILE__ ), 'lib/concurrent-ruby-edge/concurrent/edge/version')
-require File.join(File.dirname(__FILE__ ), 'lib/concurrent-ruby/concurrent/utility/engine')
 
 no_path = ENV['NO_PATH']
 options = no_path ? {} : { path: '.' }

--- a/README.md
+++ b/README.md
@@ -271,7 +271,12 @@ Everything within this gem can be loaded simply by requiring it:
 require 'concurrent'
 ```
 
-*Requiring only specific abstractions from Concurrent Ruby is not yet supported.*
+You can also require a specific abstraction [part of the public documentation](https://ruby-concurrency.github.io/concurrent-ruby/master/index.html) since concurrent-ruby 1.2.0, for example:
+```ruby
+require 'concurrent/map'
+require 'concurrent/atomic/atomic_reference'
+require 'concurrent/executor/fixed_thread_pool'
+```
 
 To use the tools in the Edge gem it must be required separately:
 

--- a/Rakefile
+++ b/Rakefile
@@ -91,6 +91,19 @@ begin
   desc 'executed in CI'
   task :ci => [:compile, 'spec:ci']
 
+  desc 'run each spec file in a separate process to help find missing requires'
+  task 'spec:isolated' do
+    glob = "#{ENV['DIR'] || 'spec'}/**/*_spec.rb"
+    from = ENV['FROM']
+    env = { 'ISOLATED' => 'true' }
+    Dir[glob].each do |spec|
+      next if from and from != spec
+      from = nil if from == spec
+
+      sh env, 'rspec', spec
+    end
+  end
+
   task :default => [:clobber, :compile, :spec]
 rescue LoadError => e
   puts 'RSpec is not installed, skipping test task definitions: ' + e.message

--- a/concurrent-ruby.gemspec
+++ b/concurrent-ruby.gemspec
@@ -1,5 +1,4 @@
 require File.join(File.dirname(__FILE__ ), 'lib/concurrent-ruby/concurrent/version')
-require File.join(File.dirname(__FILE__ ), 'lib/concurrent-ruby/concurrent/utility/engine')
 
 Gem::Specification.new do |s|
   git_files = `git ls-files`.split("\n")

--- a/docs-source/actor/format.rb
+++ b/docs-source/actor/format.rb
@@ -13,7 +13,7 @@ input_paths = if ARGV.empty?
 input_paths.each_with_index do |input_path, i|
 
   pid = fork do
-    require File.join(root, 'init.rb')
+    require_relative 'init'
 
     begin
       output_path = input_path.gsub /\.in\.rb$/, '.out.rb'

--- a/docs-source/tvar.md
+++ b/docs-source/tvar.md
@@ -29,7 +29,7 @@ is first read or written. If it cannot lock a `TVar` it aborts and retries.
 There is no contention manager so competing transactions may retry eternally.
 
 ```ruby
-require 'concurrent-ruby'
+require 'concurrent'
 
 v1 = Concurrent::TVar.new(0)
 v2 = Concurrent::TVar.new(0)
@@ -60,7 +60,7 @@ However, the inconsistent reads are detected correctly at commit time. This
 means the script below will always print `[2000000, 200000]`.
 
 ```ruby
-require 'concurrent-ruby'
+require 'concurrent'
 
 v1 = Concurrent::TVar.new(0)
 v2 = Concurrent::TVar.new(0)

--- a/examples/benchmark_map.rb
+++ b/examples/benchmark_map.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require "benchmark"
-require "concurrent"
+require 'benchmark'
+require 'concurrent'
 
 hash  = {}
 map = Concurrent::Map.new

--- a/examples/format.rb
+++ b/examples/format.rb
@@ -12,7 +12,7 @@ input_paths = if ARGV.empty?
 input_paths.each_with_index do |input_path, i|
 
   pid = fork do
-    require_relative 'init.rb'
+    require_relative 'init'
 
     begin
       output_path = input_path.gsub /\.in\.rb$/, '.out.rb'

--- a/ext/concurrent-ruby-ext/extconf.rb
+++ b/ext/concurrent-ruby-ext/extconf.rb
@@ -1,8 +1,13 @@
 require 'fileutils'
+require 'mkmf'
+
+unless RUBY_ENGINE == "ruby"
+  File.write("Makefile", dummy_makefile($srcdir).join(""))
+  exit
+end
 
 extension_name = 'concurrent_ruby_ext'
 
-require 'mkmf'
 dir_config(extension_name)
 have_header "libkern/OSAtomic.h"
 

--- a/lib/concurrent-ruby-edge/concurrent/actor.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor.rb
@@ -1,6 +1,7 @@
+# NOTE: finer grained than require 'concurrent/actor' not supported
+
 require 'concurrent/configuration'
 require 'concurrent/executor/serialized_execution'
-require 'concurrent/synchronization'
 require 'concurrent/edge/promises'
 
 module Concurrent

--- a/lib/concurrent-ruby-edge/concurrent/actor/behaviour/abstract.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/behaviour/abstract.rb
@@ -1,4 +1,6 @@
 require 'concurrent/concern/logging'
+require 'concurrent/actor/type_check'
+require 'concurrent/actor/internal_delegations'
 
 module Concurrent
   module Actor

--- a/lib/concurrent-ruby-edge/concurrent/actor/behaviour/awaits.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/behaviour/awaits.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/behaviour/abstract'
+
 module Concurrent
   module Actor
     module Behaviour

--- a/lib/concurrent-ruby-edge/concurrent/actor/behaviour/buffer.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/behaviour/buffer.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/behaviour/abstract'
+
 module Concurrent
   module Actor
     module Behaviour

--- a/lib/concurrent-ruby-edge/concurrent/actor/behaviour/errors_on_unknown_message.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/behaviour/errors_on_unknown_message.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/behaviour/abstract'
+
 module Concurrent
   module Actor
     module Behaviour

--- a/lib/concurrent-ruby-edge/concurrent/actor/behaviour/executes_context.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/behaviour/executes_context.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/behaviour/abstract'
+
 module Concurrent
   module Actor
     module Behaviour

--- a/lib/concurrent-ruby-edge/concurrent/actor/behaviour/linking.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/behaviour/linking.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/behaviour/abstract'
+
 module Concurrent
   module Actor
     module Behaviour

--- a/lib/concurrent-ruby-edge/concurrent/actor/behaviour/pausing.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/behaviour/pausing.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/behaviour/abstract'
+
 module Concurrent
   module Actor
     module Behaviour

--- a/lib/concurrent-ruby-edge/concurrent/actor/behaviour/removes_child.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/behaviour/removes_child.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/behaviour/abstract'
+
 module Concurrent
   module Actor
     module Behaviour

--- a/lib/concurrent-ruby-edge/concurrent/actor/behaviour/sets_results.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/behaviour/sets_results.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/behaviour/abstract'
+
 module Concurrent
   module Actor
     module Behaviour

--- a/lib/concurrent-ruby-edge/concurrent/actor/behaviour/supervising.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/behaviour/supervising.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/behaviour/abstract'
+
 module Concurrent
   module Actor
     module Behaviour

--- a/lib/concurrent-ruby-edge/concurrent/actor/behaviour/termination.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/behaviour/termination.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/behaviour/abstract'
+
 module Concurrent
   module Actor
     module Behaviour

--- a/lib/concurrent-ruby-edge/concurrent/actor/context.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/context.rb
@@ -1,4 +1,6 @@
 require 'concurrent/concern/logging'
+require 'concurrent/actor/type_check'
+require 'concurrent/actor/internal_delegations'
 
 module Concurrent
   module Actor

--- a/lib/concurrent-ruby-edge/concurrent/actor/core.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/core.rb
@@ -1,11 +1,11 @@
+require 'set'
+require 'concurrent/actor/type_check'
 require 'concurrent/concern/logging'
 require 'concurrent/executors'
+require 'concurrent/synchronization/lockable_object'
 
 module Concurrent
   module Actor
-
-    require 'set'
-
     # Core of the actor.
     # @note Whole class should be considered private. An user should use {Context}s and {Reference}s only.
     # @note devel: core should not block on anything, e.g. it cannot wait on children to terminate

--- a/lib/concurrent-ruby-edge/concurrent/actor/default_dead_letter_handler.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/default_dead_letter_handler.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/context'
+
 module Concurrent
   module Actor
     class DefaultDeadLetterHandler < RestartingContext

--- a/lib/concurrent-ruby-edge/concurrent/actor/envelope.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/envelope.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/type_check'
+
 module Concurrent
   module Actor
     class Envelope

--- a/lib/concurrent-ruby-edge/concurrent/actor/errors.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/errors.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/type_check'
+
 module Concurrent
   module Actor
     Error = Class.new(StandardError)

--- a/lib/concurrent-ruby-edge/concurrent/actor/internal_delegations.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/internal_delegations.rb
@@ -1,3 +1,6 @@
+require 'logger'
+require 'concurrent/actor/public_delegations'
+
 module Concurrent
   module Actor
     module InternalDelegations

--- a/lib/concurrent-ruby-edge/concurrent/actor/reference.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/reference.rb
@@ -1,3 +1,6 @@
+require 'concurrent/actor/type_check'
+require 'concurrent/actor/public_delegations'
+
 module Concurrent
   module Actor
 

--- a/lib/concurrent-ruby-edge/concurrent/actor/root.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/root.rb
@@ -1,3 +1,6 @@
+require 'concurrent/actor/context'
+require 'concurrent/actor/core'
+
 module Concurrent
   module Actor
     # implements the root actor

--- a/lib/concurrent-ruby-edge/concurrent/actor/utils/ad_hoc.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/utils/ad_hoc.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/context'
+
 module Concurrent
   module Actor
     module Utils

--- a/lib/concurrent-ruby-edge/concurrent/actor/utils/balancer.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/utils/balancer.rb
@@ -1,3 +1,5 @@
+require 'concurrent/actor/context'
+
 module Concurrent
   module Actor
     module Utils

--- a/lib/concurrent-ruby-edge/concurrent/actor/utils/broadcast.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/utils/broadcast.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'concurrent/actor/context'
 
 module Concurrent
   module Actor

--- a/lib/concurrent-ruby-edge/concurrent/actor/utils/pool.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/utils/pool.rb
@@ -1,4 +1,5 @@
 require 'concurrent/actor/utils/balancer'
+require 'concurrent/actor/context'
 
 module Concurrent
   module Actor

--- a/lib/concurrent-ruby-edge/concurrent/channel/buffer/dropping.rb
+++ b/lib/concurrent-ruby-edge/concurrent/channel/buffer/dropping.rb
@@ -1,4 +1,5 @@
 require 'concurrent/channel/buffer/base'
+require 'concurrent/channel/buffer/buffered'
 
 module Concurrent
   class Channel

--- a/lib/concurrent-ruby-edge/concurrent/channel/buffer/sliding.rb
+++ b/lib/concurrent-ruby-edge/concurrent/channel/buffer/sliding.rb
@@ -1,4 +1,5 @@
 require 'concurrent/channel/buffer/base'
+require 'concurrent/channel/buffer/buffered'
 
 module Concurrent
   class Channel

--- a/lib/concurrent-ruby-edge/concurrent/channel/tick.rb
+++ b/lib/concurrent-ruby-edge/concurrent/channel/tick.rb
@@ -1,4 +1,4 @@
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/object'
 require 'concurrent/utility/monotonic_time'
 
 module Concurrent

--- a/lib/concurrent-ruby-edge/concurrent/edge/cancellation.rb
+++ b/lib/concurrent-ruby-edge/concurrent/edge/cancellation.rb
@@ -1,4 +1,6 @@
 require 'concurrent/concern/deprecation'
+require 'concurrent/synchronization/object'
+require 'concurrent/promises'
 
 module Concurrent
 

--- a/lib/concurrent-ruby-edge/concurrent/edge/channel.rb
+++ b/lib/concurrent-ruby-edge/concurrent/edge/channel.rb
@@ -1,3 +1,6 @@
+require 'concurrent/synchronization/object'
+require 'concurrent/edge/promises'
+
 # @!macro warn.edge
 module Concurrent
   module Promises

--- a/lib/concurrent-ruby-edge/concurrent/edge/erlang_actor.rb
+++ b/lib/concurrent-ruby-edge/concurrent/edge/erlang_actor.rb
@@ -1,3 +1,11 @@
+require 'set'
+require 'concurrent/atomic/count_down_latch'
+require 'concurrent/concern/logging'
+require 'concurrent/edge/channel'
+require 'concurrent/errors'
+require 'concurrent/promises'
+require 'concurrent/synchronization/object'
+
 module Concurrent
 
   # This module provides actor abstraction that has same behaviour as Erlang actor.

--- a/lib/concurrent-ruby-edge/concurrent/edge/lock_free_queue.rb
+++ b/lib/concurrent-ruby-edge/concurrent/edge/lock_free_queue.rb
@@ -1,3 +1,5 @@
+require 'concurrent/synchronization/object'
+
 module Concurrent
 
   # @!visibility private

--- a/lib/concurrent-ruby-edge/concurrent/edge/old_channel_integration.rb
+++ b/lib/concurrent-ruby-edge/concurrent/edge/old_channel_integration.rb
@@ -1,3 +1,5 @@
+require 'concurrent/promises'
+
 module Concurrent
   module Promises
     module FactoryMethods

--- a/lib/concurrent-ruby-edge/concurrent/edge/processing_actor.rb
+++ b/lib/concurrent-ruby-edge/concurrent/edge/processing_actor.rb
@@ -1,3 +1,7 @@
+require 'concurrent/synchronization/object'
+require 'concurrent/promises'
+require 'concurrent/edge/channel'
+
 module Concurrent
 
   # A new implementation of actor which also simulates the process, therefore it can be used

--- a/lib/concurrent-ruby-edge/concurrent/edge/throttle.rb
+++ b/lib/concurrent-ruby-edge/concurrent/edge/throttle.rb
@@ -1,3 +1,7 @@
+require 'concurrent/edge/lock_free_queue'
+require 'concurrent/promises'
+require 'concurrent/synchronization/object'
+
 module Concurrent
   # A tool managing concurrency level of tasks.
   # The maximum capacity is set in constructor.

--- a/lib/concurrent-ruby-edge/concurrent/executor/wrapping_executor.rb
+++ b/lib/concurrent-ruby-edge/concurrent/executor/wrapping_executor.rb
@@ -1,3 +1,6 @@
+require 'concurrent/synchronization/object'
+require 'concurrent/executor/executor_service'
+
 module Concurrent
 
   # A delegating executor which modifies each task with arguments

--- a/lib/concurrent-ruby/concurrent/agent.rb
+++ b/lib/concurrent-ruby/concurrent/agent.rb
@@ -1,9 +1,10 @@
 require 'concurrent/configuration'
 require 'concurrent/atomic/atomic_reference'
+require 'concurrent/atomic/count_down_latch'
 require 'concurrent/atomic/thread_local_var'
 require 'concurrent/collection/copy_on_write_observer_set'
 require 'concurrent/concern/observable'
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/lockable_object'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/atom.rb
+++ b/lib/concurrent-ruby/concurrent/atom.rb
@@ -1,7 +1,7 @@
 require 'concurrent/atomic/atomic_reference'
 require 'concurrent/collection/copy_on_notify_observer_set'
 require 'concurrent/concern/observable'
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/object'
 
 # @!macro thread_safe_variable_comparison
 #

--- a/lib/concurrent-ruby/concurrent/atomic/atomic_markable_reference.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/atomic_markable_reference.rb
@@ -1,3 +1,5 @@
+require 'concurrent/synchronization/object'
+
 module Concurrent
   # An atomic reference which maintains an object reference along with a mark bit
   # that can be updated atomically.

--- a/lib/concurrent-ruby/concurrent/atomic/atomic_markable_reference.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/atomic_markable_reference.rb
@@ -1,3 +1,4 @@
+require 'concurrent/errors'
 require 'concurrent/synchronization/object'
 
 module Concurrent

--- a/lib/concurrent-ruby/concurrent/atomic/atomic_reference.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/atomic_reference.rb
@@ -1,6 +1,8 @@
 require 'concurrent/utility/native_extension_loader' # load native parts first
 
+require 'concurrent/atomic_reference/atomic_direct_update'
 require 'concurrent/atomic_reference/numeric_cas_wrapper'
+require 'concurrent/atomic_reference/mutex_atomic'
 
 # Shim for TruffleRuby::AtomicReference
 if Concurrent.on_truffleruby? && !defined?(TruffleRuby::AtomicReference)
@@ -11,79 +13,6 @@ if Concurrent.on_truffleruby? && !defined?(TruffleRuby::AtomicReference)
 end
 
 module Concurrent
-
-  # Define update methods that use direct paths
-  #
-  # @!visibility private
-  # @!macro internal_implementation_note
-  module AtomicDirectUpdate
-
-    # @!macro atomic_reference_method_update
-    #
-    #   Pass the current value to the given block, replacing it
-    #   with the block's result. May retry if the value changes
-    #   during the block's execution.
-    #
-    #   @yield [Object] Calculate a new value for the atomic reference using
-    #     given (old) value
-    #   @yieldparam [Object] old_value the starting value of the atomic reference
-    #   @return [Object] the new value
-    def update
-      true until compare_and_set(old_value = get, new_value = yield(old_value))
-      new_value
-    end
-
-    # @!macro atomic_reference_method_try_update
-    #
-    #   Pass the current value to the given block, replacing it
-    #   with the block's result. Return nil if the update fails.
-    #
-    #   @yield [Object] Calculate a new value for the atomic reference using
-    #     given (old) value
-    #   @yieldparam [Object] old_value the starting value of the atomic reference
-    #   @note This method was altered to avoid raising an exception by default.
-    #     Instead, this method now returns `nil` in case of failure. For more info,
-    #     please see: https://github.com/ruby-concurrency/concurrent-ruby/pull/336
-    #   @return [Object] the new value, or nil if update failed
-    def try_update
-      old_value = get
-      new_value = yield old_value
-
-      return unless compare_and_set old_value, new_value
-
-      new_value
-    end
-
-    # @!macro atomic_reference_method_try_update!
-    #
-    #   Pass the current value to the given block, replacing it
-    #   with the block's result. Raise an exception if the update
-    #   fails.
-    #
-    #   @yield [Object] Calculate a new value for the atomic reference using
-    #     given (old) value
-    #   @yieldparam [Object] old_value the starting value of the atomic reference
-    #   @note This behavior mimics the behavior of the original
-    #     `AtomicReference#try_update` API. The reason this was changed was to
-    #     avoid raising exceptions (which are inherently slow) by default. For more
-    #     info: https://github.com/ruby-concurrency/concurrent-ruby/pull/336
-    #   @return [Object] the new value
-    #   @raise [Concurrent::ConcurrentUpdateError] if the update fails
-    def try_update!
-      old_value = get
-      new_value = yield old_value
-      unless compare_and_set(old_value, new_value)
-        if $VERBOSE
-          raise ConcurrentUpdateError, "Update failed"
-        else
-          raise ConcurrentUpdateError, "Update failed", ConcurrentUpdateError::CONC_UP_ERR_BACKTRACE
-        end
-      end
-      new_value
-    end
-  end
-
-  require 'concurrent/atomic_reference/mutex_atomic'
 
   # @!macro atomic_reference
   #
@@ -136,13 +65,6 @@ module Concurrent
   #
   #   @!method try_update!
   #     @!macro atomic_reference_method_try_update!
-
-
-  # @!macro internal_implementation_note
-  class ConcurrentUpdateError < ThreadError
-    # frozen pre-allocated backtrace to speed ConcurrentUpdateError
-    CONC_UP_ERR_BACKTRACE = ['backtrace elided; set verbose to enable'].freeze
-  end
 
   # @!macro internal_implementation_note
   AtomicReferenceImplementation = case

--- a/lib/concurrent-ruby/concurrent/atomic/cyclic_barrier.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/cyclic_barrier.rb
@@ -1,4 +1,4 @@
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/lockable_object'
 require 'concurrent/utility/native_integer'
 
 module Concurrent

--- a/lib/concurrent-ruby/concurrent/atomic/event.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/event.rb
@@ -1,5 +1,5 @@
 require 'thread'
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/lockable_object'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/atomic/mutex_count_down_latch.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/mutex_count_down_latch.rb
@@ -1,4 +1,4 @@
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/lockable_object'
 require 'concurrent/utility/native_integer'
 
 module Concurrent

--- a/lib/concurrent-ruby/concurrent/atomic/mutex_semaphore.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/mutex_semaphore.rb
@@ -1,4 +1,4 @@
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/lockable_object'
 require 'concurrent/utility/native_integer'
 
 module Concurrent

--- a/lib/concurrent-ruby/concurrent/atomic/read_write_lock.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/read_write_lock.rb
@@ -1,7 +1,8 @@
 require 'thread'
 require 'concurrent/atomic/atomic_fixnum'
 require 'concurrent/errors'
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/object'
+require 'concurrent/synchronization/lock'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/atomic/reentrant_read_write_lock.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/reentrant_read_write_lock.rb
@@ -1,7 +1,9 @@
 require 'thread'
 require 'concurrent/atomic/atomic_reference'
+require 'concurrent/atomic/atomic_fixnum'
 require 'concurrent/errors'
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/object'
+require 'concurrent/synchronization/lock'
 require 'concurrent/atomic/thread_local_var'
 
 module Concurrent

--- a/lib/concurrent-ruby/concurrent/atomic/semaphore.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/semaphore.rb
@@ -1,5 +1,4 @@
 require 'concurrent/atomic/mutex_semaphore'
-require 'concurrent/synchronization'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/atomic_reference/atomic_direct_update.rb
+++ b/lib/concurrent-ruby/concurrent/atomic_reference/atomic_direct_update.rb
@@ -1,0 +1,75 @@
+require 'concurrent/errors'
+
+module Concurrent
+
+  # Define update methods that use direct paths
+  #
+  # @!visibility private
+  # @!macro internal_implementation_note
+  module AtomicDirectUpdate
+
+    # @!macro atomic_reference_method_update
+    #
+    #   Pass the current value to the given block, replacing it
+    #   with the block's result. May retry if the value changes
+    #   during the block's execution.
+    #
+    #   @yield [Object] Calculate a new value for the atomic reference using
+    #     given (old) value
+    #   @yieldparam [Object] old_value the starting value of the atomic reference
+    #   @return [Object] the new value
+    def update
+      true until compare_and_set(old_value = get, new_value = yield(old_value))
+      new_value
+    end
+
+    # @!macro atomic_reference_method_try_update
+    #
+    #   Pass the current value to the given block, replacing it
+    #   with the block's result. Return nil if the update fails.
+    #
+    #   @yield [Object] Calculate a new value for the atomic reference using
+    #     given (old) value
+    #   @yieldparam [Object] old_value the starting value of the atomic reference
+    #   @note This method was altered to avoid raising an exception by default.
+    #     Instead, this method now returns `nil` in case of failure. For more info,
+    #     please see: https://github.com/ruby-concurrency/concurrent-ruby/pull/336
+    #   @return [Object] the new value, or nil if update failed
+    def try_update
+      old_value = get
+      new_value = yield old_value
+
+      return unless compare_and_set old_value, new_value
+
+      new_value
+    end
+
+    # @!macro atomic_reference_method_try_update!
+    #
+    #   Pass the current value to the given block, replacing it
+    #   with the block's result. Raise an exception if the update
+    #   fails.
+    #
+    #   @yield [Object] Calculate a new value for the atomic reference using
+    #     given (old) value
+    #   @yieldparam [Object] old_value the starting value of the atomic reference
+    #   @note This behavior mimics the behavior of the original
+    #     `AtomicReference#try_update` API. The reason this was changed was to
+    #     avoid raising exceptions (which are inherently slow) by default. For more
+    #     info: https://github.com/ruby-concurrency/concurrent-ruby/pull/336
+    #   @return [Object] the new value
+    #   @raise [Concurrent::ConcurrentUpdateError] if the update fails
+    def try_update!
+      old_value = get
+      new_value = yield old_value
+      unless compare_and_set(old_value, new_value)
+        if $VERBOSE
+          raise ConcurrentUpdateError, "Update failed"
+        else
+          raise ConcurrentUpdateError, "Update failed", ConcurrentUpdateError::CONC_UP_ERR_BACKTRACE
+        end
+      end
+      new_value
+    end
+  end
+end

--- a/lib/concurrent-ruby/concurrent/atomic_reference/mutex_atomic.rb
+++ b/lib/concurrent-ruby/concurrent/atomic_reference/mutex_atomic.rb
@@ -1,3 +1,5 @@
+require 'concurrent/atomic_reference/atomic_direct_update'
+require 'concurrent/atomic_reference/numeric_cas_wrapper'
 require 'concurrent/synchronization/safe_initialization'
 
 module Concurrent

--- a/lib/concurrent-ruby/concurrent/collection/copy_on_notify_observer_set.rb
+++ b/lib/concurrent-ruby/concurrent/collection/copy_on_notify_observer_set.rb
@@ -1,4 +1,4 @@
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/lockable_object'
 
 module Concurrent
   module Collection

--- a/lib/concurrent-ruby/concurrent/collection/copy_on_write_observer_set.rb
+++ b/lib/concurrent-ruby/concurrent/collection/copy_on_write_observer_set.rb
@@ -1,4 +1,4 @@
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/lockable_object'
 
 module Concurrent
   module Collection

--- a/lib/concurrent-ruby/concurrent/collection/lock_free_stack.rb
+++ b/lib/concurrent-ruby/concurrent/collection/lock_free_stack.rb
@@ -1,3 +1,5 @@
+require 'concurrent/synchronization/object'
+
 module Concurrent
 
   # @!macro warn.edge

--- a/lib/concurrent-ruby/concurrent/concern/logging.rb
+++ b/lib/concurrent-ruby/concurrent/concern/logging.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'concurrent/atomic/atomic_reference'
 
 module Concurrent
   module Concern
@@ -15,8 +16,6 @@ module Concurrent
       # @param [String, nil] message when nil block is used to generate the message
       # @yieldreturn [String] a message
       def log(level, progname, message = nil, &block)
-        #NOTE: Cannot require 'concurrent/configuration' above due to circular references.
-        #      Assume that the gem has been initialized if we've gotten this far.
         logger = if defined?(@logger) && @logger
                    @logger
                  else
@@ -28,5 +27,90 @@ module Concurrent
           "#{error.message} (#{error.class})\n#{error.backtrace.join "\n"}"
       end
     end
+  end
+end
+
+module Concurrent
+  extend Concern::Logging
+
+  # @return [Logger] Logger with provided level and output.
+  def self.create_simple_logger(level = Logger::FATAL, output = $stderr)
+    # TODO (pitr-ch 24-Dec-2016): figure out why it had to be replaced, stdlogger was deadlocking
+    lambda do |severity, progname, message = nil, &block|
+      return false if severity < level
+
+      message           = block ? block.call : message
+      formatted_message = case message
+                          when String
+                            message
+                          when Exception
+                            format "%s (%s)\n%s",
+                                   message.message, message.class, (message.backtrace || []).join("\n")
+                          else
+                            message.inspect
+                          end
+
+      output.print format "[%s] %5s -- %s: %s\n",
+                          Time.now.strftime('%Y-%m-%d %H:%M:%S.%L'),
+                          Logger::SEV_LABEL[severity],
+                          progname,
+                          formatted_message
+      true
+    end
+  end
+
+  # Use logger created by #create_simple_logger to log concurrent-ruby messages.
+  def self.use_simple_logger(level = Logger::FATAL, output = $stderr)
+    Concurrent.global_logger = create_simple_logger level, output
+  end
+
+  # @return [Logger] Logger with provided level and output.
+  # @deprecated
+  def self.create_stdlib_logger(level = Logger::FATAL, output = $stderr)
+    logger           = Logger.new(output)
+    logger.level     = level
+    logger.formatter = lambda do |severity, datetime, progname, msg|
+      formatted_message = case msg
+                          when String
+                            msg
+                          when Exception
+                            format "%s (%s)\n%s",
+                                   msg.message, msg.class, (msg.backtrace || []).join("\n")
+                          else
+                            msg.inspect
+                          end
+      format "[%s] %5s -- %s: %s\n",
+             datetime.strftime('%Y-%m-%d %H:%M:%S.%L'),
+             severity,
+             progname,
+             formatted_message
+    end
+
+    lambda do |loglevel, progname, message = nil, &block|
+      logger.add loglevel, message, progname, &block
+    end
+  end
+
+  # Use logger created by #create_stdlib_logger to log concurrent-ruby messages.
+  # @deprecated
+  def self.use_stdlib_logger(level = Logger::FATAL, output = $stderr)
+    Concurrent.global_logger = create_stdlib_logger level, output
+  end
+
+  # TODO (pitr-ch 27-Dec-2016): remove deadlocking stdlib_logger methods
+
+  # Suppresses all output when used for logging.
+  NULL_LOGGER   = lambda { |level, progname, message = nil, &block| }
+
+  # @!visibility private
+  GLOBAL_LOGGER = AtomicReference.new(create_simple_logger(Logger::WARN))
+  private_constant :GLOBAL_LOGGER
+
+  def self.global_logger
+    GLOBAL_LOGGER.value
+  end
+
+  def self.global_logger=(value)
+    GLOBAL_LOGGER.value = value
   end
 end

--- a/lib/concurrent-ruby/concurrent/configuration.rb
+++ b/lib/concurrent-ruby/concurrent/configuration.rb
@@ -3,6 +3,7 @@ require 'concurrent/delay'
 require 'concurrent/errors'
 require 'concurrent/concern/deprecation'
 require 'concurrent/executor/immediate_executor'
+require 'concurrent/executor/fixed_thread_pool'
 require 'concurrent/executor/cached_thread_pool'
 require 'concurrent/utility/processor_counter'
 

--- a/lib/concurrent-ruby/concurrent/configuration.rb
+++ b/lib/concurrent-ruby/concurrent/configuration.rb
@@ -1,101 +1,17 @@
 require 'thread'
 require 'concurrent/delay'
 require 'concurrent/errors'
-require 'concurrent/atomic/atomic_reference'
-require 'concurrent/concern/logging'
 require 'concurrent/concern/deprecation'
 require 'concurrent/executor/immediate_executor'
 require 'concurrent/executor/cached_thread_pool'
 require 'concurrent/utility/processor_counter'
 
 module Concurrent
-  extend Concern::Logging
   extend Concern::Deprecation
 
   autoload :Options, 'concurrent/options'
   autoload :TimerSet, 'concurrent/executor/timer_set'
   autoload :ThreadPoolExecutor, 'concurrent/executor/thread_pool_executor'
-
-  # @return [Logger] Logger with provided level and output.
-  def self.create_simple_logger(level = Logger::FATAL, output = $stderr)
-    # TODO (pitr-ch 24-Dec-2016): figure out why it had to be replaced, stdlogger was deadlocking
-    lambda do |severity, progname, message = nil, &block|
-      return false if severity < level
-
-      message           = block ? block.call : message
-      formatted_message = case message
-                          when String
-                            message
-                          when Exception
-                            format "%s (%s)\n%s",
-                                   message.message, message.class, (message.backtrace || []).join("\n")
-                          else
-                            message.inspect
-                          end
-
-      output.print format "[%s] %5s -- %s: %s\n",
-                          Time.now.strftime('%Y-%m-%d %H:%M:%S.%L'),
-                          Logger::SEV_LABEL[severity],
-                          progname,
-                          formatted_message
-      true
-    end
-  end
-
-  # Use logger created by #create_simple_logger to log concurrent-ruby messages.
-  def self.use_simple_logger(level = Logger::FATAL, output = $stderr)
-    Concurrent.global_logger = create_simple_logger level, output
-  end
-
-  # @return [Logger] Logger with provided level and output.
-  # @deprecated
-  def self.create_stdlib_logger(level = Logger::FATAL, output = $stderr)
-    logger           = Logger.new(output)
-    logger.level     = level
-    logger.formatter = lambda do |severity, datetime, progname, msg|
-      formatted_message = case msg
-                          when String
-                            msg
-                          when Exception
-                            format "%s (%s)\n%s",
-                                   msg.message, msg.class, (msg.backtrace || []).join("\n")
-                          else
-                            msg.inspect
-                          end
-      format "[%s] %5s -- %s: %s\n",
-             datetime.strftime('%Y-%m-%d %H:%M:%S.%L'),
-             severity,
-             progname,
-             formatted_message
-    end
-
-    lambda do |loglevel, progname, message = nil, &block|
-      logger.add loglevel, message, progname, &block
-    end
-  end
-
-  # Use logger created by #create_stdlib_logger to log concurrent-ruby messages.
-  # @deprecated
-  def self.use_stdlib_logger(level = Logger::FATAL, output = $stderr)
-    Concurrent.global_logger = create_stdlib_logger level, output
-  end
-
-  # TODO (pitr-ch 27-Dec-2016): remove deadlocking stdlib_logger methods
-
-  # Suppresses all output when used for logging.
-  NULL_LOGGER   = lambda { |level, progname, message = nil, &block| }
-
-  # @!visibility private
-  GLOBAL_LOGGER = AtomicReference.new(create_simple_logger(Logger::WARN))
-  private_constant :GLOBAL_LOGGER
-
-  def self.global_logger
-    GLOBAL_LOGGER.value
-  end
-
-  def self.global_logger=(value)
-    GLOBAL_LOGGER.value = value
-  end
 
   # @!visibility private
   GLOBAL_FAST_EXECUTOR = Delay.new { Concurrent.new_fast_executor }

--- a/lib/concurrent-ruby/concurrent/delay.rb
+++ b/lib/concurrent-ruby/concurrent/delay.rb
@@ -1,7 +1,7 @@
 require 'thread'
 require 'concurrent/concern/obligation'
 require 'concurrent/executor/immediate_executor'
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/lockable_object'
 
 module Concurrent
 
@@ -67,7 +67,7 @@ module Concurrent
 
     # Return the value this object represents after applying the options
     # specified by the `#set_deref_options` method. If the delayed operation
-    # raised an exception this method will return nil. The execption object
+    # raised an exception this method will return nil. The exception object
     # can be accessed via the `#reason` method.
     #
     # @param [Numeric] timeout the maximum number of seconds to wait

--- a/lib/concurrent-ruby/concurrent/errors.rb
+++ b/lib/concurrent-ruby/concurrent/errors.rb
@@ -66,4 +66,9 @@ module Concurrent
     end
   end
 
+  # @!macro internal_implementation_note
+  class ConcurrentUpdateError < ThreadError
+    # frozen pre-allocated backtrace to speed ConcurrentUpdateError
+    CONC_UP_ERR_BACKTRACE = ['backtrace elided; set verbose to enable'].freeze
+  end
 end

--- a/lib/concurrent-ruby/concurrent/executor/abstract_executor_service.rb
+++ b/lib/concurrent-ruby/concurrent/executor/abstract_executor_service.rb
@@ -1,7 +1,7 @@
 require 'concurrent/errors'
 require 'concurrent/concern/deprecation'
 require 'concurrent/executor/executor_service'
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/lockable_object'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/executor/java_executor_service.rb
+++ b/lib/concurrent-ruby/concurrent/executor/java_executor_service.rb
@@ -1,7 +1,7 @@
-if Concurrent.on_jruby?
+require 'concurrent/utility/engine'
 
+if Concurrent.on_jruby?
   require 'concurrent/errors'
-  require 'concurrent/utility/engine'
   require 'concurrent/executor/abstract_executor_service'
 
   module Concurrent

--- a/lib/concurrent-ruby/concurrent/executor/safe_task_executor.rb
+++ b/lib/concurrent-ruby/concurrent/executor/safe_task_executor.rb
@@ -1,4 +1,4 @@
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/lockable_object'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/executor/serialized_execution.rb
+++ b/lib/concurrent-ruby/concurrent/executor/serialized_execution.rb
@@ -1,6 +1,6 @@
 require 'concurrent/errors'
 require 'concurrent/concern/logging'
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/lockable_object'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/executor/simple_executor_service.rb
+++ b/lib/concurrent-ruby/concurrent/executor/simple_executor_service.rb
@@ -1,5 +1,8 @@
-require 'concurrent/atomics'
+require 'concurrent/atomic/atomic_boolean'
+require 'concurrent/atomic/atomic_fixnum'
+require 'concurrent/atomic/event'
 require 'concurrent/executor/executor_service'
+require 'concurrent/executor/ruby_executor_service'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/immutable_struct.rb
+++ b/lib/concurrent-ruby/concurrent/immutable_struct.rb
@@ -1,5 +1,5 @@
 require 'concurrent/synchronization/abstract_struct'
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/lockable_object'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/ivar.rb
+++ b/lib/concurrent-ruby/concurrent/ivar.rb
@@ -3,7 +3,8 @@ require 'concurrent/errors'
 require 'concurrent/collection/copy_on_write_observer_set'
 require 'concurrent/concern/obligation'
 require 'concurrent/concern/observable'
-require 'concurrent/synchronization'
+require 'concurrent/executor/safe_task_executor'
+require 'concurrent/synchronization/lockable_object'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/map.rb
+++ b/lib/concurrent-ruby/concurrent/map.rb
@@ -1,6 +1,5 @@
 require 'thread'
 require 'concurrent/constants'
-require 'concurrent/synchronization'
 require 'concurrent/utility/engine'
 
 module Concurrent

--- a/lib/concurrent-ruby/concurrent/maybe.rb
+++ b/lib/concurrent-ruby/concurrent/maybe.rb
@@ -1,4 +1,4 @@
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/object'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/mutable_struct.rb
+++ b/lib/concurrent-ruby/concurrent/mutable_struct.rb
@@ -1,5 +1,5 @@
 require 'concurrent/synchronization/abstract_struct'
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/lockable_object'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/mvar.rb
+++ b/lib/concurrent-ruby/concurrent/mvar.rb
@@ -1,5 +1,5 @@
 require 'concurrent/concern/dereferenceable'
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/object'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/promise.rb
+++ b/lib/concurrent-ruby/concurrent/promise.rb
@@ -66,7 +66,7 @@ module Concurrent
   # Start by requiring promises
   #
   # ```ruby
-  # require 'concurrent'
+  # require 'concurrent/promise'
   # ```
   #
   # Then create one

--- a/lib/concurrent-ruby/concurrent/promises.rb
+++ b/lib/concurrent-ruby/concurrent/promises.rb
@@ -1,7 +1,8 @@
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/object'
 require 'concurrent/atomic/atomic_boolean'
 require 'concurrent/atomic/atomic_fixnum'
 require 'concurrent/collection/lock_free_stack'
+require 'concurrent/configuration'
 require 'concurrent/errors'
 require 'concurrent/re_include'
 

--- a/lib/concurrent-ruby/concurrent/scheduled_task.rb
+++ b/lib/concurrent-ruby/concurrent/scheduled_task.rb
@@ -57,7 +57,7 @@ module Concurrent
   #
   # @example Basic usage
   #
-  #   require 'concurrent'
+  #   require 'concurrent/scheduled_task'
   #   require 'csv'
   #   require 'open-uri'
   #

--- a/lib/concurrent-ruby/concurrent/settable_struct.rb
+++ b/lib/concurrent-ruby/concurrent/settable_struct.rb
@@ -1,6 +1,6 @@
-require 'concurrent/synchronization/abstract_struct'
 require 'concurrent/errors'
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/abstract_struct'
+require 'concurrent/synchronization/lockable_object'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/synchronization.rb
+++ b/lib/concurrent-ruby/concurrent/synchronization.rb
@@ -1,14 +1,7 @@
-require 'concurrent/utility/engine'
+require 'concurrent/utility/native_extension_loader' # load native parts first
 
 require 'concurrent/synchronization/object'
-require 'concurrent/synchronization/volatile'
-
-require 'concurrent/synchronization/abstract_lockable_object'
-require 'concurrent/synchronization/mutex_lockable_object'
-require 'concurrent/synchronization/jruby_lockable_object'
-
 require 'concurrent/synchronization/lockable_object'
-
 require 'concurrent/synchronization/condition'
 require 'concurrent/synchronization/lock'
 

--- a/lib/concurrent-ruby/concurrent/synchronization/abstract_lockable_object.rb
+++ b/lib/concurrent-ruby/concurrent/synchronization/abstract_lockable_object.rb
@@ -1,4 +1,6 @@
 require 'concurrent/utility/native_extension_loader' # load native parts first
+require 'concurrent/utility/monotonic_time'
+require 'concurrent/synchronization/object'
 
 module Concurrent
   module Synchronization
@@ -36,7 +38,7 @@ module Concurrent
         if timeout
           wait_until = Concurrent.monotonic_time + timeout
           loop do
-            now              = Concurrent.monotonic_time
+            now = Concurrent.monotonic_time
             condition_result = condition.call
             return condition_result if now >= wait_until || condition_result
             ns_wait wait_until - now

--- a/lib/concurrent-ruby/concurrent/synchronization/condition.rb
+++ b/lib/concurrent-ruby/concurrent/synchronization/condition.rb
@@ -1,3 +1,5 @@
+require 'concurrent/synchronization/lockable_object'
+
 module Concurrent
   module Synchronization
 

--- a/lib/concurrent-ruby/concurrent/synchronization/lock.rb
+++ b/lib/concurrent-ruby/concurrent/synchronization/lock.rb
@@ -1,3 +1,5 @@
+require 'concurrent/synchronization/lockable_object'
+
 module Concurrent
   module Synchronization
 

--- a/lib/concurrent-ruby/concurrent/synchronization/lockable_object.rb
+++ b/lib/concurrent-ruby/concurrent/synchronization/lockable_object.rb
@@ -1,3 +1,8 @@
+require 'concurrent/utility/engine'
+require 'concurrent/synchronization/abstract_lockable_object'
+require 'concurrent/synchronization/mutex_lockable_object'
+require 'concurrent/synchronization/jruby_lockable_object'
+
 module Concurrent
   module Synchronization
 

--- a/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb
+++ b/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb
@@ -1,3 +1,5 @@
+require 'concurrent/synchronization/abstract_lockable_object'
+
 module Concurrent
   # noinspection RubyInstanceVariableNamingConvention
   module Synchronization

--- a/lib/concurrent-ruby/concurrent/synchronization/volatile.rb
+++ b/lib/concurrent-ruby/concurrent/synchronization/volatile.rb
@@ -1,4 +1,5 @@
 require 'concurrent/utility/native_extension_loader' # load native parts first
+require 'concurrent/utility/engine'
 require 'concurrent/synchronization/full_memory_barrier'
 
 module Concurrent

--- a/lib/concurrent-ruby/concurrent/thread_safe/synchronized_delegator.rb
+++ b/lib/concurrent-ruby/concurrent/thread_safe/synchronized_delegator.rb
@@ -2,49 +2,46 @@ require 'delegate'
 require 'monitor'
 
 module Concurrent
-  unless defined?(SynchronizedDelegator)
-
-    # This class provides a trivial way to synchronize all calls to a given object
-    # by wrapping it with a `Delegator` that performs `Monitor#enter/exit` calls
-    # around the delegated `#send`. Example:
-    #
-    #   array = [] # not thread-safe on many impls
-    #   array = SynchronizedDelegator.new([]) # thread-safe
-    #
-    # A simple `Monitor` provides a very coarse-grained way to synchronize a given
-    # object, in that it will cause synchronization for methods that have no need
-    # for it, but this is a trivial way to get thread-safety where none may exist
-    # currently on some implementations.
-    #
-    # This class is currently being considered for inclusion into stdlib, via
-    # https://bugs.ruby-lang.org/issues/8556
-    #
-    # @!visibility private
-    class SynchronizedDelegator < SimpleDelegator
-      def setup
-        @old_abort = Thread.abort_on_exception
-        Thread.abort_on_exception = true
-      end
-
-      def teardown
-        Thread.abort_on_exception = @old_abort
-      end
-
-      def initialize(obj)
-        __setobj__(obj)
-        @monitor = Monitor.new
-      end
-
-      def method_missing(method, *args, &block)
-        monitor = @monitor
-        begin
-          monitor.enter
-          super
-        ensure
-          monitor.exit
-        end
-      end
-
+  # This class provides a trivial way to synchronize all calls to a given object
+  # by wrapping it with a `Delegator` that performs `Monitor#enter/exit` calls
+  # around the delegated `#send`. Example:
+  #
+  #   array = [] # not thread-safe on many impls
+  #   array = SynchronizedDelegator.new([]) # thread-safe
+  #
+  # A simple `Monitor` provides a very coarse-grained way to synchronize a given
+  # object, in that it will cause synchronization for methods that have no need
+  # for it, but this is a trivial way to get thread-safety where none may exist
+  # currently on some implementations.
+  #
+  # This class is currently being considered for inclusion into stdlib, via
+  # https://bugs.ruby-lang.org/issues/8556
+  #
+  # @!visibility private
+  class SynchronizedDelegator < SimpleDelegator
+    def setup
+      @old_abort = Thread.abort_on_exception
+      Thread.abort_on_exception = true
     end
+
+    def teardown
+      Thread.abort_on_exception = @old_abort
+    end
+
+    def initialize(obj)
+      __setobj__(obj)
+      @monitor = Monitor.new
+    end
+
+    def method_missing(method, *args, &block)
+      monitor = @monitor
+      begin
+        monitor.enter
+        super
+      ensure
+        monitor.exit
+      end
+    end
+
   end
 end

--- a/lib/concurrent-ruby/concurrent/thread_safe/util/cheap_lockable.rb
+++ b/lib/concurrent-ruby/concurrent/thread_safe/util/cheap_lockable.rb
@@ -1,5 +1,6 @@
 require 'concurrent/thread_safe/util'
 require 'concurrent/thread_safe/util/volatile'
+require 'concurrent/utility/engine'
 
 module Concurrent
 

--- a/lib/concurrent-ruby/concurrent/thread_safe/util/data_structures.rb
+++ b/lib/concurrent-ruby/concurrent/thread_safe/util/data_structures.rb
@@ -1,4 +1,5 @@
 require 'concurrent/thread_safe/util'
+require 'concurrent/utility/engine'
 
 # Shim for TruffleRuby.synchronized
 if Concurrent.on_truffleruby? && !TruffleRuby.respond_to?(:synchronized)

--- a/lib/concurrent-ruby/concurrent/tvar.rb
+++ b/lib/concurrent-ruby/concurrent/tvar.rb
@@ -1,5 +1,5 @@
 require 'set'
-require 'concurrent/synchronization'
+require 'concurrent/synchronization/object'
 
 module Concurrent
 

--- a/spec/concurrent/agent_spec.rb
+++ b/spec/concurrent/agent_spec.rb
@@ -1,3 +1,9 @@
+require 'concurrent/agent'
+require 'concurrent/executor/single_thread_executor'
+require 'concurrent/executor/immediate_executor'
+require 'concurrent/executor/fixed_thread_pool'
+require 'concurrent/atomic/count_down_latch'
+
 require_relative 'concern/observable_shared'
 
 module Concurrent

--- a/spec/concurrent/array_spec.rb
+++ b/spec/concurrent/array_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/array'
+
 module Concurrent
   RSpec.describe Array do
     let!(:ary) { described_class.new }

--- a/spec/concurrent/async_spec.rb
+++ b/spec/concurrent/async_spec.rb
@@ -1,5 +1,6 @@
-module Concurrent
+require 'concurrent/async'
 
+module Concurrent
   RSpec.describe Async do
 
     let(:async_class) do

--- a/spec/concurrent/atom_spec.rb
+++ b/spec/concurrent/atom_spec.rb
@@ -1,4 +1,7 @@
 require_relative 'concern/observable_shared'
+require 'concurrent/atom'
+require 'concurrent/atomic/count_down_latch'
+require 'concurrent/atomic/atomic_fixnum'
 
 module Concurrent
 

--- a/spec/concurrent/atomic/atomic_boolean_spec.rb
+++ b/spec/concurrent/atomic/atomic_boolean_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/atomic/atomic_boolean'
+
 RSpec.shared_examples :atomic_boolean do
 
   describe 'construction' do

--- a/spec/concurrent/atomic/atomic_fixnum_spec.rb
+++ b/spec/concurrent/atomic/atomic_fixnum_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/atomic/atomic_fixnum'
+
 RSpec.shared_examples :atomic_fixnum do
 
   context 'construction' do

--- a/spec/concurrent/atomic/atomic_markable_reference_spec.rb
+++ b/spec/concurrent/atomic/atomic_markable_reference_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/atomic/atomic_markable_reference'
+
 RSpec.describe Concurrent::AtomicMarkableReference do
   subject { described_class.new 1000, true }
 

--- a/spec/concurrent/atomic/atomic_reference_spec.rb
+++ b/spec/concurrent/atomic/atomic_reference_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/atomic/atomic_reference'
+
 RSpec.shared_examples :atomic_reference do
 
   specify :test_construct do

--- a/spec/concurrent/atomic/atomic_reference_spec.rb
+++ b/spec/concurrent/atomic/atomic_reference_spec.rb
@@ -180,6 +180,12 @@ module Concurrent
   end
 
   RSpec.describe AtomicReference do
+    if RUBY_ENGINE != 'ruby'
+      it 'does not load the C extension' do
+        expect(defined?(Concurrent::CAtomicReference)).to be_falsey
+      end
+    end
+
     if Concurrent.on_jruby?
       it 'inherits from JavaAtomicReference' do
         expect(described_class.ancestors).to include(Concurrent::JavaAtomicReference)

--- a/spec/concurrent/atomic/count_down_latch_spec.rb
+++ b/spec/concurrent/atomic/count_down_latch_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/atomic/count_down_latch'
+
 RSpec.shared_examples :count_down_latch do
 
   let(:latch) { described_class.new(3) }

--- a/spec/concurrent/atomic/cyclic_barrier_spec.rb
+++ b/spec/concurrent/atomic/cyclic_barrier_spec.rb
@@ -1,3 +1,7 @@
+require 'concurrent/atomic/cyclic_barrier'
+require 'concurrent/atomic/count_down_latch'
+require 'concurrent/atomic/atomic_fixnum'
+
 module Concurrent
 
   RSpec.describe CyclicBarrier do

--- a/spec/concurrent/atomic/event_spec.rb
+++ b/spec/concurrent/atomic/event_spec.rb
@@ -1,3 +1,6 @@
+require 'concurrent/atomic/event'
+require 'concurrent/atomic/count_down_latch'
+
 module Concurrent
 
   RSpec.describe Event do

--- a/spec/concurrent/atomic/read_write_lock_spec.rb
+++ b/spec/concurrent/atomic/read_write_lock_spec.rb
@@ -1,3 +1,7 @@
+require 'concurrent/atomic/read_write_lock'
+require 'concurrent/atomic/count_down_latch'
+require 'concurrent/atomic/atomic_boolean'
+
 module Concurrent
 
   RSpec.describe ReadWriteLock do

--- a/spec/concurrent/atomic/reentrant_read_write_lock_spec.rb
+++ b/spec/concurrent/atomic/reentrant_read_write_lock_spec.rb
@@ -1,3 +1,8 @@
+require 'concurrent/utility/engine'
+require 'concurrent/atomic/reentrant_read_write_lock'
+require 'concurrent/atomic/count_down_latch'
+require 'concurrent/atomic/atomic_boolean'
+
 unless Concurrent.on_jruby?
 
   # NOTE: These tests depend heavily on the private/undocumented

--- a/spec/concurrent/atomic/semaphore_spec.rb
+++ b/spec/concurrent/atomic/semaphore_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/atomic/semaphore'
+
 RSpec.shared_examples :semaphore do
   let(:semaphore) { described_class.new(3) }
 

--- a/spec/concurrent/atomic/thread_local_var_spec.rb
+++ b/spec/concurrent/atomic/thread_local_var_spec.rb
@@ -1,8 +1,8 @@
 require 'rbconfig'
+require 'concurrent/atomic/thread_local_var'
+require 'concurrent/atomic/count_down_latch'
 
 module Concurrent
-
-  require 'concurrent/atomic/thread_local_var'
 
   RSpec.describe ThreadLocalVar do
 

--- a/spec/concurrent/cancellation_spec.rb
+++ b/spec/concurrent/cancellation_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/edge/cancellation'
+
 RSpec.describe 'Concurrent' do
   describe 'Cancellation', edge: true do
     specify 'basic' do

--- a/spec/concurrent/channel/buffer/base_spec.rb
+++ b/spec/concurrent/channel/buffer/base_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'buffered_shared'
+require 'concurrent/channel/buffer/base'
 
 module Concurrent::Channel::Buffer
 

--- a/spec/concurrent/channel/buffer/buffered_shared.rb
+++ b/spec/concurrent/channel/buffer/buffered_shared.rb
@@ -1,4 +1,5 @@
 require_relative 'base_shared'
+require 'concurrent/channel/buffer/buffered'
 
 RSpec.shared_examples :channel_buffered_buffer do
 

--- a/spec/concurrent/channel/buffer/dropping_spec.rb
+++ b/spec/concurrent/channel/buffer/dropping_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'buffered_shared'
+require 'concurrent/channel/buffer/dropping'
 
 module Concurrent::Channel::Buffer
 

--- a/spec/concurrent/channel/buffer/sliding_spec.rb
+++ b/spec/concurrent/channel/buffer/sliding_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'buffered_shared'
+require 'concurrent/channel/buffer/sliding'
 
 module Concurrent::Channel::Buffer
 

--- a/spec/concurrent/channel/buffer/ticker_spec.rb
+++ b/spec/concurrent/channel/buffer/ticker_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'timing_buffer_shared'
+require 'concurrent/channel/buffer/ticker'
 
 module Concurrent::Channel::Buffer
 

--- a/spec/concurrent/channel/buffer/timer_spec.rb
+++ b/spec/concurrent/channel/buffer/timer_spec.rb
@@ -1,4 +1,6 @@
 require_relative 'timing_buffer_shared'
+require 'concurrent/channel/buffer/timer'
+require 'concurrent/atomic/atomic_boolean'
 
 module Concurrent::Channel::Buffer
 

--- a/spec/concurrent/channel/buffer/timing_buffer_shared.rb
+++ b/spec/concurrent/channel/buffer/timing_buffer_shared.rb
@@ -1,4 +1,5 @@
 require_relative 'base_shared'
+require 'concurrent/atomic/atomic_boolean'
 
 RSpec.shared_examples :channel_timing_buffer do
 

--- a/spec/concurrent/channel/buffer/unbuffered_spec.rb
+++ b/spec/concurrent/channel/buffer/unbuffered_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'base_shared'
+require 'concurrent/channel/buffer/unbuffered'
 
 module Concurrent::Channel::Buffer
 

--- a/spec/concurrent/channel/integration_spec.rb
+++ b/spec/concurrent/channel/integration_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/utility/engine'
+
 RSpec.describe 'channel integration tests', edge: true do
 
   let!(:examples_root) { File.expand_path(File.join(File.dirname(__FILE__), '../../../examples')) }

--- a/spec/concurrent/channel/tick_spec.rb
+++ b/spec/concurrent/channel/tick_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/channel/tick'
+
 module Concurrent
 
   class Channel

--- a/spec/concurrent/channel_spec.rb
+++ b/spec/concurrent/channel_spec.rb
@@ -1,3 +1,7 @@
+require 'concurrent/channel'
+require 'concurrent/atomic/count_down_latch'
+require 'concurrent/executor/immediate_executor'
+
 module Concurrent
 
  RSpec.describe Channel, edge: true do

--- a/spec/concurrent/collection/copy_on_notify_observer_set_spec.rb
+++ b/spec/concurrent/collection/copy_on_notify_observer_set_spec.rb
@@ -1,3 +1,4 @@
+require 'concurrent/collection/copy_on_notify_observer_set'
 require_relative 'observer_set_shared'
 
 module Concurrent

--- a/spec/concurrent/collection/copy_on_write_observer_set_spec.rb
+++ b/spec/concurrent/collection/copy_on_write_observer_set_spec.rb
@@ -1,3 +1,4 @@
+require 'concurrent/collection/copy_on_write_observer_set'
 require_relative 'observer_set_shared'
 
 module Concurrent

--- a/spec/concurrent/collection/non_concurrent_priority_queue_spec.rb
+++ b/spec/concurrent/collection/non_concurrent_priority_queue_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/collection/non_concurrent_priority_queue'
+
 RSpec.shared_examples :priority_queue do
 
   subject{ described_class.new }

--- a/spec/concurrent/concern/dereferenceable_shared.rb
+++ b/spec/concurrent/concern/dereferenceable_shared.rb
@@ -1,3 +1,5 @@
+require 'concurrent/atomic/count_down_latch'
+
 RSpec.shared_examples :dereferenceable do
 
   it 'defaults :dup_on_deref to false' do
@@ -111,7 +113,6 @@ RSpec.shared_examples :dereferenceable do
   it 'supports dereference flags with observers' do
 
     if dereferenceable_subject(0).respond_to?(:add_observer)
-
       latch = Concurrent::CountDownLatch.new
       observer = Class.new do
         def initialize(latch)

--- a/spec/concurrent/concern/obligation_spec.rb
+++ b/spec/concurrent/concern/obligation_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/concern/obligation'
+
 module Concurrent
   module Concern
 

--- a/spec/concurrent/concern/observable_shared.rb
+++ b/spec/concurrent/concern/observable_shared.rb
@@ -1,3 +1,5 @@
+require 'concurrent/atomic/count_down_latch'
+
 RSpec.shared_examples :observable do
 
   let(:observer_set) do
@@ -116,7 +118,6 @@ RSpec.shared_examples :observable do
   end
 
   context 'first notification' do
-
     it 'calls the #update method on all observers without a specified :func' do
       latch = Concurrent::CountDownLatch.new(5)
       5.times do

--- a/spec/concurrent/concern/observable_spec.rb
+++ b/spec/concurrent/concern/observable_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/concern/observable'
+
 module Concurrent
   module Concern
 

--- a/spec/concurrent/configuration_spec.rb
+++ b/spec/concurrent/configuration_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/configuration'
+
 module Concurrent
 
    RSpec.describe 'configuration' do

--- a/spec/concurrent/dataflow_spec.rb
+++ b/spec/concurrent/dataflow_spec.rb
@@ -1,3 +1,6 @@
+require 'concurrent/dataflow'
+require 'concurrent/executor/simple_executor_service'
+
 module Concurrent
 
   RSpec.describe 'dataflow' do

--- a/spec/concurrent/delay_spec.rb
+++ b/spec/concurrent/delay_spec.rb
@@ -1,3 +1,4 @@
+require 'concurrent/delay'
 require_relative 'concern/dereferenceable_shared'
 require_relative 'concern/obligation_shared'
 

--- a/spec/concurrent/edge/channel_spec.rb
+++ b/spec/concurrent/edge/channel_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/edge/channel'
+
 RSpec.describe 'Concurrent' do
   describe 'Promises::Channel', edge: true do
     specify "#capacity" do

--- a/spec/concurrent/edge/erlang_actor_spec.rb
+++ b/spec/concurrent/edge/erlang_actor_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/edge/erlang_actor'
+
 RSpec.describe 'Concurrent' do
   describe 'ErlangActor', edge: true do
     # TODO (pitr-ch 06-Feb-2019): include constants instead

--- a/spec/concurrent/edge/lock_free_linked_set_spec.rb
+++ b/spec/concurrent/edge/lock_free_linked_set_spec.rb
@@ -1,5 +1,4 @@
-require 'concurrent'
-require 'concurrent/edge'
+require 'concurrent/edge/lock_free_linked_set'
 require 'securerandom'
 
 RSpec.describe Concurrent::Edge::LockFreeLinkedSet, edge: true do

--- a/spec/concurrent/exchanger_spec.rb
+++ b/spec/concurrent/exchanger_spec.rb
@@ -239,7 +239,7 @@ module Concurrent
     end
   end
 
-  if defined? JavaExchanger
+  if Concurrent.on_jruby?
     RSpec.describe JavaExchanger do
       it_behaves_like :exchanger
     end

--- a/spec/concurrent/exchanger_spec.rb
+++ b/spec/concurrent/exchanger_spec.rb
@@ -1,3 +1,6 @@
+require 'concurrent/exchanger'
+require 'concurrent/atomic/atomic_fixnum'
+
 RSpec.shared_examples 'exchanger method with indefinite timeout' do
 
   before(:each) do

--- a/spec/concurrent/executor/cached_thread_pool_spec.rb
+++ b/spec/concurrent/executor/cached_thread_pool_spec.rb
@@ -1,3 +1,4 @@
+require 'concurrent/executor/cached_thread_pool'
 require_relative 'thread_pool_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/executor_quits.rb
+++ b/spec/concurrent/executor/executor_quits.rb
@@ -2,7 +2,7 @@
 lib = File.expand_path '../../../lib/concurrent-ruby/'
 $LOAD_PATH.push lib unless $LOAD_PATH.include? lib
 
-require 'concurrent-ruby'
+require 'concurrent'
 
 executors = [Concurrent::CachedThreadPool.new, Concurrent::SingleThreadExecutor.new, Concurrent::FixedThreadPool.new(1)]
 executors.each do |executor|

--- a/spec/concurrent/executor/executor_service_shared.rb
+++ b/spec/concurrent/executor/executor_service_shared.rb
@@ -1,4 +1,7 @@
 require_relative 'global_thread_pool_shared'
+require 'concurrent/atomic/atomic_boolean'
+require 'concurrent/atomic/atomic_fixnum'
+require 'timeout'
 
 RSpec.shared_examples :executor_service do
 

--- a/spec/concurrent/executor/fixed_thread_pool_spec.rb
+++ b/spec/concurrent/executor/fixed_thread_pool_spec.rb
@@ -1,3 +1,4 @@
+require 'concurrent/executor/fixed_thread_pool'
 require_relative 'thread_pool_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/global_thread_pool_shared.rb
+++ b/spec/concurrent/executor/global_thread_pool_shared.rb
@@ -1,3 +1,5 @@
+require 'concurrent/atomic/count_down_latch'
+
 RSpec.shared_examples :global_thread_pool do
 
   context '#post' do

--- a/spec/concurrent/executor/immediate_executor_spec.rb
+++ b/spec/concurrent/executor/immediate_executor_spec.rb
@@ -1,3 +1,4 @@
+require 'concurrent/executor/immediate_executor'
 require_relative 'executor_service_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/indirect_immediate_executor_spec.rb
+++ b/spec/concurrent/executor/indirect_immediate_executor_spec.rb
@@ -1,3 +1,4 @@
+require 'concurrent/executor/indirect_immediate_executor'
 require_relative 'executor_service_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/java_single_thread_executor_spec.rb
+++ b/spec/concurrent/executor/java_single_thread_executor_spec.rb
@@ -1,5 +1,6 @@
-if Concurrent.on_jruby?
+require 'concurrent/utility/engine'
 
+if Concurrent.on_jruby?
   require_relative 'executor_service_shared'
 
   module Concurrent

--- a/spec/concurrent/executor/java_thread_pool_executor_spec.rb
+++ b/spec/concurrent/executor/java_thread_pool_executor_spec.rb
@@ -1,5 +1,6 @@
-if Concurrent.on_jruby?
+require 'concurrent/utility/engine'
 
+if Concurrent.on_jruby?
   require_relative 'thread_pool_executor_shared'
 
   module Concurrent

--- a/spec/concurrent/executor/ruby_single_thread_executor_spec.rb
+++ b/spec/concurrent/executor/ruby_single_thread_executor_spec.rb
@@ -1,3 +1,4 @@
+require 'concurrent/executor/ruby_single_thread_executor'
 require_relative 'executor_service_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/ruby_thread_pool_executor_spec.rb
+++ b/spec/concurrent/executor/ruby_thread_pool_executor_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'thread_pool_executor_shared'
+require 'concurrent/executor/thread_pool_executor'
 
 module Concurrent
 
@@ -164,7 +165,10 @@ module Concurrent
         described_class.new(opts)
       end
 
-      let(:names) { Concurrent::Set.new }
+      let(:names) do
+        require 'concurrent/set'
+        Concurrent::Set.new
+      end
 
       before do
         subject.post(names) { |names| names << Thread.current.name }

--- a/spec/concurrent/executor/safe_task_executor_spec.rb
+++ b/spec/concurrent/executor/safe_task_executor_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/executor/safe_task_executor'
+
 module Concurrent
 
   RSpec.describe SafeTaskExecutor do

--- a/spec/concurrent/executor/serialized_execution_spec.rb
+++ b/spec/concurrent/executor/serialized_execution_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/executor/serialized_execution_delegator'
+require 'concurrent/executor/immediate_executor'
 require_relative 'executor_service_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/simple_executor_service_spec.rb
+++ b/spec/concurrent/executor/simple_executor_service_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/executor/simple_executor_service'
+require 'concurrent/configuration'
 require_relative 'executor_service_shared'
 
 module Concurrent

--- a/spec/concurrent/executor/thread_pool_class_cast_spec.rb
+++ b/spec/concurrent/executor/thread_pool_class_cast_spec.rb
@@ -1,5 +1,7 @@
-module Concurrent
+require 'concurrent/executor/single_thread_executor'
+require 'concurrent/executor/thread_pool_executor'
 
+module Concurrent
   RSpec.describe SingleThreadExecutor do
     if Concurrent.on_jruby?
       it 'inherits from JavaSingleThreadExecutor' do

--- a/spec/concurrent/executor/thread_pool_executor_shared.rb
+++ b/spec/concurrent/executor/thread_pool_executor_shared.rb
@@ -1,4 +1,5 @@
 require_relative 'thread_pool_shared'
+require 'concurrent/atomic/atomic_fixnum'
 
 RSpec.shared_examples :thread_pool_executor do
 

--- a/spec/concurrent/executor/timer_set_spec.rb
+++ b/spec/concurrent/executor/timer_set_spec.rb
@@ -1,3 +1,6 @@
+require 'concurrent/executor/timer_set'
+require 'concurrent/atomic/count_down_latch'
+require 'concurrent/atomic/atomic_boolean'
 require 'timecop'
 
 module Concurrent

--- a/spec/concurrent/executor/wrapping_executor_spec.rb
+++ b/spec/concurrent/executor/wrapping_executor_spec.rb
@@ -1,3 +1,6 @@
+require 'concurrent/executor/wrapping_executor'
+require 'concurrent/configuration'
+
 module Concurrent
   RSpec.describe WrappingExecutor do
 

--- a/spec/concurrent/future_spec.rb
+++ b/spec/concurrent/future_spec.rb
@@ -1,3 +1,8 @@
+require 'concurrent/future'
+require 'concurrent/executor/simple_executor_service'
+require 'concurrent/executor/single_thread_executor'
+require 'concurrent/atomic/count_down_latch'
+
 require_relative 'ivar_shared'
 require_relative 'thread_arguments_shared'
 

--- a/spec/concurrent/hash_spec.rb
+++ b/spec/concurrent/hash_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/hash'
+
 module Concurrent
   RSpec.describe Hash do
     let!(:hsh) { described_class.new }

--- a/spec/concurrent/immutable_struct_spec.rb
+++ b/spec/concurrent/immutable_struct_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'struct_shared'
+require 'concurrent/immutable_struct'
 
 module Concurrent
   RSpec.describe ImmutableStruct do

--- a/spec/concurrent/ivar_spec.rb
+++ b/spec/concurrent/ivar_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'ivar_shared'
+require 'concurrent/ivar'
 
 module Concurrent
 

--- a/spec/concurrent/lazy_register_spec.rb
+++ b/spec/concurrent/lazy_register_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/lazy_register'
+
 module Concurrent
   RSpec.describe LazyRegister do
 

--- a/spec/concurrent/map_spec.rb
+++ b/spec/concurrent/map_spec.rb
@@ -1,4 +1,7 @@
 require_relative 'collection_each_shared'
+require 'concurrent/map'
+require 'concurrent/atomic/count_down_latch'
+
 Thread.abort_on_exception = true
 
 module Concurrent

--- a/spec/concurrent/maybe_spec.rb
+++ b/spec/concurrent/maybe_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/maybe'
+
 module Concurrent
 
   RSpec.describe Maybe do

--- a/spec/concurrent/monotonic_time_spec.rb
+++ b/spec/concurrent/monotonic_time_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/utility/monotonic_time'
+
 module Concurrent
 
   RSpec.describe :monotonic_time do

--- a/spec/concurrent/mutable_struct_spec.rb
+++ b/spec/concurrent/mutable_struct_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'struct_shared'
+require 'concurrent/mutable_struct'
 
 module Concurrent
   RSpec.describe MutableStruct do

--- a/spec/concurrent/mvar_spec.rb
+++ b/spec/concurrent/mvar_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'concern/dereferenceable_shared'
+require 'concurrent/mvar'
 
 module Concurrent
 

--- a/spec/concurrent/no_concurrent_files_loaded_before_spec.rb
+++ b/spec/concurrent/no_concurrent_files_loaded_before_spec.rb
@@ -1,0 +1,7 @@
+files_loaded_before = $LOADED_FEATURES.grep(/\/concurrent\//).grep_v(/\/version\.rb$/)
+
+RSpec.describe 'The test harness', if: ENV['ISOLATED'] do
+  it 'does not load concurrent-ruby files to ensure there are no missing requires' do
+    expect(files_loaded_before).to eq []
+  end
+end

--- a/spec/concurrent/options_spec.rb
+++ b/spec/concurrent/options_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/options'
+
 module Concurrent
 
   RSpec.describe Options do

--- a/spec/concurrent/processing_actor_spec.rb
+++ b/spec/concurrent/processing_actor_spec.rb
@@ -1,0 +1,74 @@
+require 'concurrent/edge/processing_actor'
+
+RSpec.describe 'Concurrent::ProcessingActor' do
+  specify do
+    actor = Concurrent::ProcessingActor.act do |the_actor|
+      the_actor.receive.then do |message|
+        # the actor ends with message
+        message
+      end
+    end #
+
+    actor.tell! :a_message
+    expect(actor.termination.value!).to eq :a_message
+
+    def count(actor, count)
+      # the block passed to receive is called when the actor receives the message
+      actor.receive.then do |number_or_command, answer|
+        # number_or_command, answer = p a
+        # p number_or_command, answer
+
+        # code which is evaluated after the number is received
+        case number_or_command
+        when :done
+          # this will become the result (final value) of the actor
+          count
+        when :count
+          # reply the current count
+          answer.fulfill count
+          # continue running
+          count(actor, count)
+        when Integer
+          # this will call count again to set up what to do on next message, based on new state `count + numer`
+          count(actor, count + number_or_command)
+        end
+      end
+      # evaluation of count ends immediately
+      # code which is evaluated before the number is received, should be empty
+    end
+
+    counter = Concurrent::ProcessingActor.act { |a| count a, 0 }
+    answer  = counter.tell!(2).ask_op { |a| [:count, a] }.value!
+    expect(counter.tell!(3).tell!(:done).termination.value!).to eq 5
+    expect(answer.value!).to eq 2
+
+    add_once_actor = Concurrent::ProcessingActor.act do |the_actor|
+      the_actor.receive.then do |a, b, reply|
+        result = a + b
+        reply.fulfill result
+        # terminate with result value
+        result
+      end
+    end
+
+    expect(add_once_actor.ask_op { |a| [1, 2, a] }.value!.value!).to eq 3
+    # expect(add_once_actor.ask_operation(%w(ab cd)).reason).to be_a_kind_of RuntimeError
+    expect(add_once_actor.termination.value!).to eq 3
+
+    def pair_adder(actor)
+      (actor.receive & actor.receive).then do |(value1, answer1), (value2, answer2)|
+        result = value1 + value2
+        answer1.fulfill result if answer1
+        answer2.fulfill result if answer2
+        pair_adder actor
+      end
+    end
+
+    pair_adder = Concurrent::ProcessingActor.act { |a| pair_adder a }
+    pair_adder.ask_op { |a| [2, a] }
+    answer = pair_adder.ask_op { |a| [3, a] }.value!
+    expect(answer.value!).to eq 5
+    expect((pair_adder.ask_op { |a| ['a', a] }.value! & pair_adder.ask_op { |a| ['b', a] }.value!).value!).to eq %w[ab ab]
+    expect((pair_adder.ask_op { |a| ['a', a] }.value! | pair_adder.ask_op { |a| ['b', a] }.value!).value!).to eq 'ab'
+  end
+end

--- a/spec/concurrent/promise_spec.rb
+++ b/spec/concurrent/promise_spec.rb
@@ -1,3 +1,8 @@
+require 'concurrent/promise'
+require 'concurrent/executor/simple_executor_service'
+require 'concurrent/executor/single_thread_executor'
+require 'concurrent/atomic/count_down_latch'
+
 require_relative 'ivar_shared'
 require_relative 'thread_arguments_shared'
 

--- a/spec/concurrent/promises_spec.rb
+++ b/spec/concurrent/promises_spec.rb
@@ -1,5 +1,5 @@
 require 'concurrent/edge/promises'
-require 'thread'
+require 'concurrent/atomic/count_down_latch'
 
 RSpec.describe 'Concurrent::Promises' do
 
@@ -711,7 +711,8 @@ RSpec.describe 'Concurrent::Promises' do
   end
 
   describe 'interoperability' do
-    it 'with processing actor', if: !defined?(JRUBY_VERSION) do
+    it 'with processing actor', if: !Concurrent.on_jruby? do
+      require 'concurrent/actor'
       actor = Concurrent::Actor::Utils::AdHoc.spawn :doubler do
         -> v { v * 2 }
       end
@@ -722,20 +723,20 @@ RSpec.describe 'Concurrent::Promises' do
           value!).to eq 6
     end
 
-    if Concurrent.const_defined? :ErlangActor
-      it 'with erlang actor' do
-        actor = Concurrent::ErlangActor.spawn type: :on_thread do
-          reply receive * 2
-        end
-
-        expect(future { 2 }.
-            then_ask(actor).
-            then { |v| v + 2 }.
-            value!).to eq 6
+    it 'with erlang actor' do
+      require 'concurrent/edge/erlang_actor'
+      actor = Concurrent::ErlangActor.spawn type: :on_thread do
+        reply receive * 2
       end
+
+      expect(future { 2 }.
+          then_ask(actor).
+          then { |v| v + 2 }.
+          value!).to eq 6
     end
 
     it 'with channel' do
+      require 'concurrent/edge/channel'
       ch1 = Concurrent::Promises::Channel.new
       ch2 = Concurrent::Promises::Channel.new
 
@@ -752,78 +753,5 @@ RSpec.describe 'Concurrent::Promises' do
 
   specify 'zip_futures_over' do
     expect(zip_futures_over([1, 2]) { |v| v.succ }.value!).to eq [2, 3]
-  end
-end
-
-RSpec.describe 'Concurrent::ProcessingActor' do
-  specify do
-    actor = Concurrent::ProcessingActor.act do |the_actor|
-      the_actor.receive.then do |message|
-        # the actor ends with message
-        message
-      end
-    end #
-
-    actor.tell! :a_message
-    expect(actor.termination.value!).to eq :a_message
-
-    def count(actor, count)
-      # the block passed to receive is called when the actor receives the message
-      actor.receive.then do |number_or_command, answer|
-        # number_or_command, answer = p a
-        # p number_or_command, answer
-
-        # code which is evaluated after the number is received
-        case number_or_command
-        when :done
-          # this will become the result (final value) of the actor
-          count
-        when :count
-          # reply the current count
-          answer.fulfill count
-          # continue running
-          count(actor, count)
-        when Integer
-          # this will call count again to set up what to do on next message, based on new state `count + numer`
-          count(actor, count + number_or_command)
-        end
-      end
-      # evaluation of count ends immediately
-      # code which is evaluated before the number is received, should be empty
-    end
-
-    counter = Concurrent::ProcessingActor.act { |a| count a, 0 }
-    answer  = counter.tell!(2).ask_op { |a| [:count, a] }.value!
-    expect(counter.tell!(3).tell!(:done).termination.value!).to eq 5
-    expect(answer.value!).to eq 2
-
-    add_once_actor = Concurrent::ProcessingActor.act do |the_actor|
-      the_actor.receive.then do |a, b, reply|
-        result = a + b
-        reply.fulfill result
-        # terminate with result value
-        result
-      end
-    end
-
-    expect(add_once_actor.ask_op { |a| [1, 2, a] }.value!.value!).to eq 3
-    # expect(add_once_actor.ask_operation(%w(ab cd)).reason).to be_a_kind_of RuntimeError
-    expect(add_once_actor.termination.value!).to eq 3
-
-    def pair_adder(actor)
-      (actor.receive & actor.receive).then do |(value1, answer1), (value2, answer2)|
-        result = value1 + value2
-        answer1.fulfill result if answer1
-        answer2.fulfill result if answer2
-        pair_adder actor
-      end
-    end
-
-    pair_adder = Concurrent::ProcessingActor.act { |a| pair_adder a }
-    pair_adder.ask_op { |a| [2, a] }
-    answer = pair_adder.ask_op { |a| [3, a] }.value!
-    expect(answer.value!).to eq 5
-    expect((pair_adder.ask_op { |a| ['a', a] }.value! & pair_adder.ask_op { |a| ['b', a] }.value!).value!).to eq %w[ab ab]
-    expect((pair_adder.ask_op { |a| ['a', a] }.value! | pair_adder.ask_op { |a| ['b', a] }.value!).value!).to eq 'ab'
   end
 end

--- a/spec/concurrent/require_all_files_separately.rb
+++ b/spec/concurrent/require_all_files_separately.rb
@@ -1,0 +1,29 @@
+RSpec.describe 'Every file', if: ENV['ISOLATED'] do
+  it 'can be required on its own' do
+    root = File.expand_path('../..', __dir__)
+    require_paths = []
+    dirs = ["#{root}/lib/concurrent-ruby", "#{root}/lib/concurrent-ruby-edge"]
+    dirs.each do |dir|
+      Dir.glob("#{dir}/**/*.rb") do |file|
+        require_path = file[dir.size + 1...-3]
+        private_file = %w[ruby_ java_ jruby_ truffleruby_].any? { |prefix|
+          File.basename(require_path).start_with?(prefix)
+        }
+        unless private_file
+          require_paths << require_path
+        end
+      end
+    end
+
+    require_paths.each do |require_path|
+      # An easy way to see the output and backtrace without RSpec formatting it
+      # raise require_path unless system RbConfig.ruby, '-w', '-e', 'require ARGV.first', require_path
+
+      # puts require_path
+      out = IO.popen([RbConfig.ruby, '-w', '-e', 'require ARGV.first', require_path], err: [:child, :out], &:read)
+      status = $?
+      expect(out).to eq ""
+      expect(status).to be_success
+    end
+  end
+end

--- a/spec/concurrent/scheduled_task_spec.rb
+++ b/spec/concurrent/scheduled_task_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/scheduled_task'
+require 'concurrent/atomic/count_down_latch'
 require 'timecop'
 require_relative 'concern/dereferenceable_shared'
 require_relative 'concern/obligation_shared'

--- a/spec/concurrent/set_spec.rb
+++ b/spec/concurrent/set_spec.rb
@@ -1,4 +1,6 @@
-require 'set'
+require 'concurrent/set'
+require 'concurrent/atomic/cyclic_barrier'
+
 module Concurrent
   RSpec.describe Set do
     let!(:set) { described_class.new }

--- a/spec/concurrent/settable_struct_spec.rb
+++ b/spec/concurrent/settable_struct_spec.rb
@@ -1,4 +1,5 @@
 require_relative 'struct_shared'
+require 'concurrent/settable_struct'
 
 module Concurrent
   RSpec.describe SettableStruct do

--- a/spec/concurrent/thread_safe/no_unsafe_spec.rb
+++ b/spec/concurrent/thread_safe/no_unsafe_spec.rb
@@ -1,4 +1,6 @@
-if defined?(JRUBY_VERSION) && ENV['TEST_NO_UNSAFE']
+require 'concurrent/utility/engine'
+
+if Concurrent.on_jruby? && ENV['TEST_NO_UNSAFE']
   # to be used like this: rake test TEST_NO_UNSAFE=true
   load 'test/package.jar'
   java_import 'thread_safe.SecurityManager'

--- a/spec/concurrent/thread_safe/synchronized_delegator_spec.rb
+++ b/spec/concurrent/thread_safe/synchronized_delegator_spec.rb
@@ -1,4 +1,4 @@
-require 'concurrent/thread_safe/synchronized_delegator.rb'
+require 'concurrent/thread_safe/synchronized_delegator'
 
 module Concurrent
   RSpec.describe SynchronizedDelegator do

--- a/spec/concurrent/throttle_spec.rb
+++ b/spec/concurrent/throttle_spec.rb
@@ -1,5 +1,5 @@
-require 'concurrent/edge/promises'
 require 'thread'
+require 'concurrent/edge/throttle'
 
 RSpec.describe 'Concurrent' do
   describe 'Throttle' do

--- a/spec/concurrent/timer_task_spec.rb
+++ b/spec/concurrent/timer_task_spec.rb
@@ -1,5 +1,6 @@
 require_relative 'concern/dereferenceable_shared'
 require_relative 'concern/observable_shared'
+require 'concurrent/timer_task'
 
 module Concurrent
 

--- a/spec/concurrent/tvar_spec.rb
+++ b/spec/concurrent/tvar_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/tvar'
+
 module Concurrent
 
   RSpec.describe TVar do

--- a/spec/concurrent/utility/processor_count_spec.rb
+++ b/spec/concurrent/utility/processor_count_spec.rb
@@ -1,3 +1,5 @@
+require 'concurrent/utility/processor_counter'
+
 module Concurrent
 
   RSpec.describe '#processor_count' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,11 +26,6 @@ if ENV['NO_PATH']
   end
 end
 
-require 'concurrent'
-require 'concurrent-edge'
-
-Concurrent.use_simple_logger Logger::FATAL
-
 require_relative 'support/example_group_extensions'
 require_relative 'support/threadsafe_test'
 
@@ -43,6 +38,13 @@ RSpec.configure do |config|
 
   config.include Concurrent::TestHelpers
   config.extend Concurrent::TestHelpers
+
+  config.before :all do
+    # Only configure logging if it has been required, to make sure the necessary require's are in place
+    if Concurrent.respond_to? :use_simple_logger
+      Concurrent.use_simple_logger Logger::FATAL
+    end
+  end
 
   config.before :each do
     expect(!defined?(@created_threads) || @created_threads.nil? || @created_threads.empty?).to be_truthy

--- a/spec/support/example_group_extensions.rb
+++ b/spec/support/example_group_extensions.rb
@@ -1,5 +1,4 @@
 require 'rbconfig'
-require 'concurrent/synchronization'
 
 module Concurrent
   module TestHelpers
@@ -15,12 +14,6 @@ module Concurrent
         v2 = yield(v2)
       end
       return (v1 - v2).abs
-    end
-
-    include Utility::EngineDetector
-
-    def use_c_extensions?
-      Concurrent.allow_c_extensions?
     end
 
     def monotonic_interval


### PR DESCRIPTION
* Fixes #934.

On top of https://github.com/ruby-concurrency/concurrent-ruby/pull/982

Notes:
I didn't find a builtin RSpec way to run each spec in a separate process. Probably we make our own rake task for that.
Locally, can use https://stackoverflow.com/questions/39902641/run-each-rspec-spec-file-individually or `for f in spec/**/*_spec.rb; do; bundle exec rspec $f || break; done`

TODO:
* [x] Audit usages of `defined?` and `const_defined?` and `on_jruby?`
* [x] Add test for `require 'concurrent'` and `require 'concurrent-edge'`
* [x] Add test for require any file under lib?
* [x] Update README