### PR TITLE
Update the list of maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,8 +367,10 @@ best practice is to depend on `concurrent-ruby` and let users to decide if they 
 
 ## Maintainers
 
-* [Benoit Daloze](https://github.com/eregon) — Maintainer.
-* We are looking for more `concurrent-ruby` maintainers.
+* [Benoit Daloze](https://github.com/eregon)
+* [Matthew Draper](https://github.com/matthewd)
+* [Rafael França](https://github.com/rafaelfranca)
+* [Samuel Williams](https://github.com/ioquatix)
 
 ### Special Thanks to
 


### PR DESCRIPTION
cc @matthewd @rafaelfranca @ioquatix

I contacted each of you and you agreed to help maintain concurrent-ruby, thank you!
Contribute as you feel you can, I know we are all also busy with other projects as well.
concurrent-ruby is a fairly mature and stable project, so I think it shouldn't require much maintenance.

I suggest to use PRs for all changes, except trivial typos or minor doc updates or so, to give others a chance to review.
Please in general wait for a review from some other maintainer before merging (unless it's trivial).
There tends to be some non-obvious complications in this gem due to supporting the various Ruby implementations with different code paths, and the docs are not always clear about every feature a class supports, which is why I think it's good to be careful and have reviews.