### PR TITLE
Restore compatibility with `RubyThreadLocalVar`.

### DIFF
--- a/lib/concurrent-ruby/concurrent/atomic/thread_local_var.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/thread_local_var.rb
@@ -108,4 +108,9 @@ module Concurrent
       end
     end
   end
+
+  # @!visibility private
+  # Retained for compatibility, see <https://github.com/ruby-concurrency/concurrent-ruby/issues/986> for more details.
+  RubyThreadLocalVar = ThreadLocalVar
+  deprecate_constant :RubyThreadLocalVar
 end


### PR DESCRIPTION
Fixes <https://github.com/ruby-concurrency/concurrent-ruby/issues/986>.

@joshcooper can you please check this will fix your issue.