### PR TITLE
Optimize Concurrent::Map#[] on CRuby by letting the backing Hash handle the default_proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Current
 
+* (#989) Optimize `Concurrent::Map#[]` on CRuby by letting the backing Hash handle the `default_proc`.
+
 ## Release v1.2.0 (23 Jan 2023)
 
 * (#962) Fix ReentrantReadWriteLock to use the same granularity for locals as for Mutex it uses.

--- a/examples/benchmark_map.rb
+++ b/examples/benchmark_map.rb
@@ -1,35 +1,35 @@
 #!/usr/bin/env ruby
 
-require 'benchmark'
-require 'concurrent'
+require 'benchmark/ips'
+require 'concurrent/map'
 
-hash  = {}
+hash = {}
 map = Concurrent::Map.new
 
 ENTRIES = 10_000
 
 ENTRIES.times do |i|
-  hash[i]  = i
+  hash[i] = i
   map[i] = i
 end
 
-TESTS = 40_000_000
-Benchmark.bmbm do |results|
-  key = rand(10_000)
+TESTS = 1_000
+key = 2732 # srand(0) and rand(10_000)
 
+Benchmark.ips do |results|
   results.report('Hash#[]') do
-    TESTS.times { hash[key] }
+    hash[key]
   end
 
   results.report('Map#[]') do
-    TESTS.times { map[key] }
+    map[key]
   end
 
   results.report('Hash#each_pair') do
-    (TESTS / ENTRIES).times { hash.each_pair {|k,v| v} }
+    hash.each_pair { |k,v| v }
   end
 
   results.report('Map#each_pair') do
-    (TESTS / ENTRIES).times { map.each_pair {|k,v| v} }
+    map.each_pair { |k,v| v }
   end
 end

--- a/lib/concurrent-ruby/concurrent/collection/map/mri_map_backend.rb
+++ b/lib/concurrent-ruby/concurrent/collection/map/mri_map_backend.rb
@@ -9,8 +9,8 @@ module Concurrent
     # @!visibility private
     class MriMapBackend < NonConcurrentMapBackend
 
-      def initialize(options = nil)
-        super(options)
+      def initialize(options = nil, &default_proc)
+        super(options, &default_proc)
         @write_lock = Mutex.new
       end
 

--- a/lib/concurrent-ruby/concurrent/map.rb
+++ b/lib/concurrent-ruby/concurrent/map.rb
@@ -46,6 +46,12 @@ module Concurrent
     #   @note Atomic methods taking a block do not allow the `self` instance
     #     to be used within the block. Doing so will cause a deadlock.
 
+    # @!method []=(key, value)
+    #   Set a value with key
+    #   @param [Object] key
+    #   @param [Object] value
+    #   @return [Object] the new value
+
     # @!method compute_if_absent(key)
     #   Compute and store new value for key if the key is absent.
     #   @param [Object] key
@@ -119,41 +125,38 @@ module Concurrent
     #   @return [true, false] true if deleted
     #   @!macro map.atomic_method
 
-    #
-    def initialize(options = nil, &block)
-      if options.kind_of?(::Hash)
-        validate_options_hash!(options)
-      else
-        options = nil
+    # NonConcurrentMapBackend handles default_proc natively
+    unless defined?(Collection::NonConcurrentMapBackend) and self < Collection::NonConcurrentMapBackend
+
+      # @param [Hash, nil] options options to set the :initial_capacity or :load_factor. Ignored on some Rubies.
+      # @param [Proc] default_proc Optional block to compute the default value if the key is not set, like `Hash#default_proc`
+      def initialize(options = nil, &default_proc)
+        if options.kind_of?(::Hash)
+          validate_options_hash!(options)
+        else
+          options = nil
+        end
+
+        super(options)
+        @default_proc = default_proc
       end
 
-      super(options)
-      @default_proc = block
-    end
-
-    # Get a value with key
-    # @param [Object] key
-    # @return [Object] the value
-    def [](key)
-      if value = super # non-falsy value is an existing mapping, return it right away
-        value
-        # re-check is done with get_or_default(key, NULL) instead of a simple !key?(key) in order to avoid a race condition, whereby by the time the current thread gets to the key?(key) call
-        # a key => value mapping might have already been created by a different thread (key?(key) would then return true, this elsif branch wouldn't be taken and an incorrent +nil+ value
-        # would be returned)
-        # note: nil == value check is not technically necessary
-      elsif @default_proc && nil == value && NULL == (value = get_or_default(key, NULL))
-        @default_proc.call(self, key)
-      else
-        value
+      # Get a value with key
+      # @param [Object] key
+      # @return [Object] the value
+      def [](key)
+        if value = super # non-falsy value is an existing mapping, return it right away
+          value
+          # re-check is done with get_or_default(key, NULL) instead of a simple !key?(key) in order to avoid a race condition, whereby by the time the current thread gets to the key?(key) call
+          # a key => value mapping might have already been created by a different thread (key?(key) would then return true, this elsif branch wouldn't be taken and an incorrent +nil+ value
+          # would be returned)
+          # note: nil == value check is not technically necessary
+        elsif @default_proc && nil == value && NULL == (value = get_or_default(key, NULL))
+          @default_proc.call(self, key)
+        else
+          value
+        end
       end
-    end
-
-    # Set a value with key
-    # @param [Object] key
-    # @param [Object] value
-    # @return [Object] the new value
-    def []=(key, value)
-      super
     end
 
     alias_method :get, :[]

--- a/spec/concurrent/map_spec.rb
+++ b/spec/concurrent/map_spec.rb
@@ -777,8 +777,8 @@ module Concurrent
         end
         expect_no_size_change cache do
           expect_size_change 1, dupped do
-            expect(:default_value).to eq dupped[:d]
-            expect(false).to          eq cache.key?(:d)
+            expect(dupped[:d]).to eq :default_value
+            expect(cache.key?(:d)).to eq false
           end
         end
       end


### PR DESCRIPTION
    * On ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]
      Before:
      Hash#[]     14.477M (± 2.7%) i/s -     72.882M in   5.038078s
       Map#[]      7.837M (± 1.7%) i/s -     39.947M in   5.098411s
      After:
      Hash#[]     14.340M (± 1.5%) i/s -     72.074M in   5.027414s
       Map#[]      9.840M (± 0.8%) i/s -     50.106M in   5.092390s

With this, `Concurrent::Map#[]` on CRuby is just:
```ruby
      def [](key)
        @backend[key] # @backend is the Hash
      end
```
i.e., just one extra call and ivar read compared to `Hash#[]`.