### PR TITLE
Add `require 'fiber'` for `Fiber.current` usage.

### DIFF
--- a/lib/concurrent-ruby/concurrent/atomic/locals.rb
+++ b/lib/concurrent-ruby/concurrent/atomic/locals.rb
@@ -1,6 +1,8 @@
 require 'concurrent/utility/engine'
 require 'concurrent/constants'
 
+require 'fiber'
+
 module Concurrent
   # @!visibility private
   # @!macro internal_implementation_note


### PR DESCRIPTION
Fixes <https://github.com/ruby-concurrency/concurrent-ruby/issues/962>.