### PR TITLE
Revert "Prefer `Process.pid` over `$$`"

### DIFF
--- a/lib/concurrent-ruby/concurrent/async.rb
+++ b/lib/concurrent-ruby/concurrent/async.rb
@@ -290,7 +290,7 @@ module Concurrent
         @delegate = delegate
         @queue = []
         @executor = Concurrent.global_io_executor
-        @ruby_pid = Process.pid
+        @ruby_pid = $$
       end
 
       # Delegates method calls to the wrapped object.
@@ -346,9 +346,9 @@ module Concurrent
       end
 
       def reset_if_forked
-        if Process.pid != @ruby_pid
+        if $$ != @ruby_pid
           @queue.clear
-          @ruby_pid = Process.pid
+          @ruby_pid = $$
         end
       end
     end

--- a/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb
@@ -138,7 +138,7 @@ module Concurrent
       @completed_task_count = 0
       @largest_length       = 0
       @workers_counter      = 0
-      @ruby_pid             = Process.pid # detects if Ruby has forked
+      @ruby_pid             = $$ # detects if Ruby has forked
 
       @gc_interval  = opts.fetch(:gc_interval, @idletime / 2.0).to_i # undocumented
       @next_gc_time = Concurrent.monotonic_time + @gc_interval
@@ -287,7 +287,7 @@ module Concurrent
     end
 
     def ns_reset_if_forked
-      if Process.pid != @ruby_pid
+      if $$ != @ruby_pid
         @queue.clear
         @ready.clear
         @pool.clear
@@ -295,7 +295,7 @@ module Concurrent
         @completed_task_count = 0
         @largest_length       = 0
         @workers_counter      = 0
-        @ruby_pid             = Process.pid
+        @ruby_pid             = $$
       end
     end
 

--- a/lib/concurrent-ruby/concurrent/executor/timer_set.rb
+++ b/lib/concurrent-ruby/concurrent/executor/timer_set.rb
@@ -76,7 +76,7 @@ module Concurrent
       @task_executor      = Options.executor_from_options(opts) || Concurrent.global_io_executor
       @timer_executor     = SingleThreadExecutor.new
       @condition          = Event.new
-      @ruby_pid           = Process.pid # detects if Ruby has forked
+      @ruby_pid           = $$ # detects if Ruby has forked
     end
 
     # Post the task to the internal queue.
@@ -127,10 +127,10 @@ module Concurrent
     end
 
     def ns_reset_if_forked
-      if Process.pid != @ruby_pid
+      if $$ != @ruby_pid
         @queue.clear
         @condition.reset
-        @ruby_pid = Process.pid
+        @ruby_pid = $$
       end
     end
 


### PR DESCRIPTION
Reverts ruby-concurrency/concurrent-ruby#991
Since it's significantly slower on existing Ruby releases.
See comments there for details.