### PR TITLE
Fix TimerTask `:execution_interval` docs

### DIFF
--- a/lib/concurrent-ruby/concurrent/timer_task.rb
+++ b/lib/concurrent-ruby/concurrent/timer_task.rb
@@ -159,7 +159,7 @@ module Concurrent
     #
     # @!macro timer_task_initialize
     #   @param [Hash] opts the options defining task execution.
-    #   @option opts [Integer] :execution_interval number of seconds between
+    #   @option opts [Float] :execution_interval number of seconds between
     #     task executions (default: EXECUTION_INTERVAL)
     #   @option opts [Boolean] :run_now Whether to run the task immediately
     #     upon instantiation or to wait until the first #  execution_interval


### PR DESCRIPTION
This seems to be a mistake in the docs. Looking under the hood at the `ScheduledTask` class, you can see that Float is perfectly fine and can be passed as an execution interval. This PR changes `Integer` to `Float` in the method description to avoid any confusion.

https://github.com/ruby-concurrency/concurrent-ruby/blob/e7ff945661a93a2e094b3259f23ccb1b3eea9bcf/lib/concurrent-ruby/concurrent/scheduled_task.rb#L167

I've also checked that it actually works with floats:


```ruby
Concurrent::TimerTask.execute({:execution_interval => 0.1}) { puts Time.now.to_f }

1682345298.779785
1682345298.881609
1682345298.9855418
1682345299.091567
1682345299.1970491
1682345299.302599
1682345299.407186
1682345299.510379
1682345299.6152
1682345299.720865
1682345299.826708
1682345299.933086
1682345300.0387928
1682345300.144703
1682345300.2506618
1682345300.353
1682345300.4590552
```
