### PR TITLE
Have ScheduledTask raise ArgumentError if provided executor has fallback policy of `:abort`

### DIFF
--- a/lib/concurrent-ruby/concurrent/scheduled_task.rb
+++ b/lib/concurrent-ruby/concurrent/scheduled_task.rb
@@ -189,6 +189,8 @@ module Concurrent
         @task = task
         @time = nil
         @executor = Options.executor_from_options(opts) || Concurrent.global_io_executor
+        raise ArgumentError.new("cannot use an executor with fallback_policy: :abort") if @executor.fallback_policy == :abort
+
         self.observers = Collection::CopyOnNotifyObserverSet.new
       end
     end

--- a/spec/concurrent/scheduled_task_spec.rb
+++ b/spec/concurrent/scheduled_task_spec.rb
@@ -75,6 +75,15 @@ module Concurrent
         }.to raise_error(ArgumentError)
       end
 
+      it 'raises an exception if the executor fallback policy is :abort' do
+        executor = Concurrent::ThreadPoolExecutor.new(fallback_policy: :abort)
+        expect {
+          ScheduledTask.new(1, executor: :abort){ nil }
+        }.to raise_error(ArgumentError)
+
+        executor.shutdown
+      end
+
       it 'sets the initial state to :unscheduled' do
         task = ScheduledTask.new(1){ nil }
         expect(task).to be_unscheduled


### PR DESCRIPTION
Closes #889 