### PR TITLE
Allow TimerSet to safely handle an executor raising `RejectedExecutionError`

### DIFF
--- a/lib/concurrent-ruby/concurrent/executor/timer_set.rb
+++ b/lib/concurrent-ruby/concurrent/executor/timer_set.rb
@@ -3,7 +3,7 @@ require 'concurrent/atomic/event'
 require 'concurrent/collection/non_concurrent_priority_queue'
 require 'concurrent/executor/executor_service'
 require 'concurrent/executor/single_thread_executor'
-
+require 'concurrent/errors'
 require 'concurrent/options'
 
 module Concurrent
@@ -162,7 +162,11 @@ module Concurrent
           # queue now must have the same pop time, or a closer one, as
           # when we peeked).
           task = synchronize { @queue.pop }
-          task.executor.post { task.process_task }
+          begin
+            task.executor.post { task.process_task }
+          rescue RejectedExecutionError
+            # ignore and continue
+          end
         else
           @condition.wait([diff, 60].min)
         end


### PR DESCRIPTION
Fixes #889

The TimerSet creates a reactor-like loop to pop scheduled tasks off a queue at their appropriate time. If the task's executor has a fallback policy of `:abort`, the executor can raise a `Concurrent::RejectedExecutionError` within the loop and break it. This PR introduces a rescue to handle and discard that exception.

I think a `RejectedExecutionError` is the only exception that the executor is _expected_ to raise, but this could be turned into rescuing any StandardError (either with a rescue or wrapping further in a `SafeTaskExecutor` (that introduces even more blocks and locks).

Also, this only rescues the exception within the loop that handles future-scheduled tasks. There is a magic `0.01`-seconds in the TimerSet which will cause the task to be executed immediately rather than deferred which I did not wrap:

https://github.com/ruby-concurrency/concurrent-ruby/blob/ee0ea41a3c66e5c5f578831e4a66d722a40211bd/lib/concurrent-ruby/concurrent/executor/timer_set.rb#L97-L100