### PR TITLE
Create method ThreadPoolExecutor#active_count to expose the number of threads that are actively executing tasks

### DIFF
--- a/lib/concurrent-ruby/concurrent/executor/fixed_thread_pool.rb
+++ b/lib/concurrent-ruby/concurrent/executor/fixed_thread_pool.rb
@@ -39,6 +39,10 @@ module Concurrent
   #   The number of tasks that have been completed by the pool since construction.
   #   @return [Integer] The number of tasks that have been completed by the pool since construction.
 
+  # @!macro thread_pool_executor_method_active_count
+  #   The number of threads that are actively executing tasks.
+  #   @return [Integer] The number of threads that are actively executing tasks.
+
   # @!macro thread_pool_executor_attr_reader_idletime
   #   The number of seconds that a thread may be idle before being reclaimed.
   #   @return [Integer] The number of seconds that a thread may be idle before being reclaimed.

--- a/lib/concurrent-ruby/concurrent/executor/java_thread_pool_executor.rb
+++ b/lib/concurrent-ruby/concurrent/executor/java_thread_pool_executor.rb
@@ -73,6 +73,11 @@ if Concurrent.on_jruby?
         @executor.getCompletedTaskCount
       end
 
+      # @!macro thread_pool_executor_method_active_count
+      def active_count
+        @executor.getActiveCount
+      end
+
       # @!macro thread_pool_executor_attr_reader_idletime
       def idletime
         @executor.getKeepAliveTime(java.util.concurrent.TimeUnit::SECONDS)

--- a/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb
+++ b/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb
@@ -61,6 +61,13 @@ module Concurrent
       synchronize { @completed_task_count }
     end
 
+    # @!macro thread_pool_executor_method_active_count
+    def active_count
+      synchronize do
+        @pool.length - @ready.length
+      end
+    end
+
     # @!macro executor_service_method_can_overflow_question
     def can_overflow?
       synchronize { ns_limited_queue? }


### PR DESCRIPTION
Connects to #684.

~~I called it "available" because `ready` means the thread has already been created but is idle, which isn't inclusive of uncreated workers that could still be added to the pool.~~

This exposes the equivalent of the Java ThreadPoolExecutor's [`getActiveCount`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html#getActiveCount--): "Returns the approximate number of threads that are actively executing tasks."

