### PR TITLE
Fix TimerTask example output

### DIFF
--- a/lib/concurrent-ruby/concurrent/timer_task.rb
+++ b/lib/concurrent-ruby/concurrent/timer_task.rb
@@ -101,6 +101,7 @@ module Concurrent
   #   #=> Boom! Boom!
   #   #=> Boom! Boom! Boom!
   #   #=> Boom! Boom! Boom! Boom!
+  #   #=> Boom! Boom! Boom! Boom! Boom!
   #   #=> Stopping...
   #
   # @example Observation


### PR DESCRIPTION
The correct number of booms _is_ 5. Noted in https://github.com/ruby-concurrency/concurrent-ruby/pull/996#discussion_r1252858025