### PR TITLE
Fix broken CI due to rake-compiler error on Ruby < 2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'concurrent-ruby-ext', Concurrent::VERSION, options.merge(platform: :mri)
 
 group :development do
   gem 'rake', '~> 13.0'
-  gem 'rake-compiler', '~> 1.0', '>= 1.0.7'
+  gem 'rake-compiler', '~> 1.0', '>= 1.0.7', '!= 1.2.4'
   gem 'rake-compiler-dock', '~> 1.0'
   gem 'pry', '~> 0.11', platforms: :mri
 end


### PR DESCRIPTION
The recently released rake-compiler 1.2.4 breaks compatibility with Ruby 2.5 and below. It is causing concurrent-ruby CI jobs to fail with errors like this:

```
NoMethodError: undefined method `cleanpath' for "tmp/x86_64-linux/concurrent_ruby_ext/2.3.8":String
```

The rake-compiler regression has been reported here:

https://github.com/rake-compiler/rake-compiler/issues/224

As a workaround, this PR updates the ruby-concurrent Gemfile to avoid rake-compiler 1.2.4. This should fix the broken CI jobs.