### PR TITLE
Fix compile error on FreeBSD 14

### DIFF
--- a/ext/concurrent-ruby-ext/atomic_reference.c
+++ b/ext/concurrent-ruby-ext/atomic_reference.c
@@ -105,7 +105,7 @@ VALUE ir_compare_and_set(volatile VALUE self, VALUE expect_value, VALUE new_valu
     return Qtrue;
   }
 #else
-  if (__sync_bool_compare_and_swap(&DATA_PTR(self), expect_value, new_value)) {
+  if (__sync_bool_compare_and_swap(&DATA_PTR(self), (void *)expect_value, (void *)new_value)) {
     return Qtrue;
   }
 #endif


### PR DESCRIPTION
```
compiling atomic_reference.c
atomic_reference.c:108:53: error: incompatible integer to pointer conversion passing 'VALUE' (aka 'unsigned long') to parameter of type 'void *' [-Wint-conversion]
  if (__sync_bool_compare_and_swap(&DATA_PTR(self), expect_value, new_value)) {
                                                    ^~~~~~~~~~~~
atomic_reference.c:108:67: error: incompatible integer to pointer conversion passing 'VALUE' (aka 'unsigned long') to parameter of type 'void *' [-Wint-conversion]
  if (__sync_bool_compare_and_swap(&DATA_PTR(self), expect_value, new_value)) {
                                                                  ^~~~~~~~~
2 errors generated.
*** Error code 1
```