### PR TITLE
Add `mutex_m` as a runtime dependancy | Run CI against Ruby head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, jruby, truffleruby]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, head, jruby, truffleruby]
 
     env:
       JAVA_OPTS: '-Xmx1024m'

--- a/concurrent-ruby.gemspec
+++ b/concurrent-ruby.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.metadata["source_code_uri"] = "https://github.com/ruby-concurrency/concurrent-ruby"
   s.metadata["changelog_uri"] = "https://github.com/ruby-concurrency/concurrent-ruby/blob/master/CHANGELOG.md"
   s.required_ruby_version = '>= 2.3'
+  # s.add_runtime_dependency 'mutex_m'
 end


### PR DESCRIPTION
Context: https://github.com/puma/puma/pull/3320