### PR TITLE
cgroup support for physical_processor_count

### DIFF
--- a/lib/concurrent-ruby/concurrent/utility/processor_counter.rb
+++ b/lib/concurrent-ruby/concurrent/utility/processor_counter.rb
@@ -36,8 +36,9 @@ module Concurrent
               when /darwin\d\d/
                 IO.popen("/usr/sbin/sysctl -n hw.physicalcpu", &:read).to_i
               when /linux/
-                if Dir.exist?("/sys/fs/cgroup/cpu,cpuacct") && (cfs_quota_us = IO.read("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us").to_i) > 0
-                  (cfs_quota_us / IO.read("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us").to_i.to_f).ceil
+                # https://kernel.googlesource.com/pub/scm/linux/kernel/git/glommer/memcg/+/cpu_stat/Documentation/cgroups/cpu.txt
+                if Dir.exist?("/sys/fs/cgroup/cpu,cpuacct") && (cfs_quota_us = File.read("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us").to_i) > 0
+                  (cfs_quota_us / File.read("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us").to_f).ceil
                 else
                   cores = {} # unique physical ID / core ID combinations
                   phy   = 0

--- a/lib/concurrent-ruby/concurrent/utility/processor_counter.rb
+++ b/lib/concurrent-ruby/concurrent/utility/processor_counter.rb
@@ -36,17 +36,21 @@ module Concurrent
               when /darwin\d\d/
                 IO.popen("/usr/sbin/sysctl -n hw.physicalcpu", &:read).to_i
               when /linux/
-                cores = {} # unique physical ID / core ID combinations
-                phy   = 0
-                IO.read("/proc/cpuinfo").scan(/^physical id.*|^core id.*/) do |ln|
-                  if ln.start_with?("physical")
-                    phy = ln[/\d+/]
-                  elsif ln.start_with?("core")
-                    cid        = phy + ":" + ln[/\d+/]
-                    cores[cid] = true if not cores[cid]
+                if Dir.exist?("/sys/fs/cgroup/cpu,cpuacct") && (cfs_quota_us = IO.read("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us").to_i) > 0
+                  (cfs_quota_us / IO.read("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us").to_i.to_f).ceil
+                else
+                  cores = {} # unique physical ID / core ID combinations
+                  phy   = 0
+                  IO.read("/proc/cpuinfo").scan(/^physical id.*|^core id.*/) do |ln|
+                    if ln.start_with?("physical")
+                      phy = ln[/\d+/]
+                    elsif ln.start_with?("core")
+                      cid        = phy + ":" + ln[/\d+/]
+                      cores[cid] = true if not cores[cid]
+                    end
                   end
+                  cores.count
                 end
-                cores.count
               when /mswin|mingw/
                 require 'win32ole'
                 result_set = WIN32OLE.connect("winmgmts://").ExecQuery(


### PR DESCRIPTION
As rails depends on `physical_processor_count` to spin up the right number of puma workers, rails will fall over in a containerized environment where cgroups are used to limit cpu time. This pr is an attempt to accurately reflect the available cpu cores when the ruby process is running inside a cgroup.