### PR TITLE
Advance "latest" ruby in isolated ci test job to 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.3, 3.3 ] # oldest and latest CRuby
+        ruby: [ 2.3, ruby ] # oldest and latest CRuby
     env:
       RUBYOPT: '-w'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.3, 3.2 ] # oldest and latest CRuby
+        ruby: [ 2.3, 3.3 ] # oldest and latest CRuby
     env:
       RUBYOPT: '-w'
     steps:


### PR DESCRIPTION
Reviewing #1021 as part of the latest patch release I noticed that a 2nd CI job had been previously [configured](https://github.com/ruby-concurrency/concurrent-ruby/commit/fa452a48d65f0128af0ffc2ea7a7c392b9f2cbc7) to test both the "oldest and latest CRuby". 
This is a simple PR to realign the intended CRuby test coverage.
Feel free to merge or simply incorporate the small change into any other PR 🔢 