### PR TITLE
Align Java Executor Service behavior for `shuttingdown?`, `shutdown?`

### DIFF
--- a/lib/concurrent-ruby/concurrent/executor/java_executor_service.rb
+++ b/lib/concurrent-ruby/concurrent/executor/java_executor_service.rb
@@ -57,15 +57,11 @@ if Concurrent.on_jruby?
       end
 
       def ns_shuttingdown?
-        if @executor.respond_to? :isTerminating
-          @executor.isTerminating
-        else
-          false
-        end
+        @executor.isShutdown && !@executor.isTerminated
       end
 
       def ns_shutdown?
-        @executor.isShutdown || @executor.isTerminated
+        @executor.isTerminated
       end
 
       class Job

--- a/spec/concurrent/executor/immediate_executor_spec.rb
+++ b/spec/concurrent/executor/immediate_executor_spec.rb
@@ -7,6 +7,6 @@ module Concurrent
 
     subject { ImmediateExecutor.new }
 
-    it_should_behave_like :executor_service
+    it_should_behave_like :executor_service, immediate_type: true
   end
 end

--- a/spec/concurrent/executor/indirect_immediate_executor_spec.rb
+++ b/spec/concurrent/executor/indirect_immediate_executor_spec.rb
@@ -7,7 +7,7 @@ module Concurrent
 
     subject { IndirectImmediateExecutor.new }
 
-    it_should_behave_like :executor_service
+    it_should_behave_like :executor_service, immediate_type: true
 
     it "runs its tasks synchronously" do
       start = Time.now

--- a/spec/concurrent/executor/serialized_execution_spec.rb
+++ b/spec/concurrent/executor/serialized_execution_spec.rb
@@ -8,6 +8,6 @@ module Concurrent
 
     subject { SerializedExecutionDelegator.new(ImmediateExecutor.new) }
 
-    it_should_behave_like :executor_service
+    it_should_behave_like :executor_service, immediate_type: true
   end
 end


### PR DESCRIPTION
Fixes #1041 

- `shuttingdown?` now uses `isShutdown && !isTerminated`
- `shutdown?` now accurately represents when all tasks have terminated
- ~~`kill` now waits for all tasks to terminate (it waits indefinitely; I'm not sure if it's possible for that to hang on Java)~~ Extracted `#kill` change to #1044 