### PR TITLE
ThreadPoolExecutor `kill` will `wait_for_termination` in JRuby

### DIFF
--- a/lib/concurrent-ruby/concurrent/executor/java_executor_service.rb
+++ b/lib/concurrent-ruby/concurrent/executor/java_executor_service.rb
@@ -46,8 +46,9 @@ if Concurrent.on_jruby?
       def kill
         synchronize do
           @executor.shutdownNow
-          nil
         end
+        wait_for_termination
+        nil
       end
 
       private


### PR DESCRIPTION
This fixes an inconsistency in behavior in ThreadPoolExecutor in Ruby and JRuby.

Extracted from #1042, explained in #1041.