### PR TITLE
Prepare the 1.3.1 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Current
 
+## Release v1.3.1 (28 May 2024)
+
+* Release 1.3.0 was broken when pushed to RubyGems. 1.3.1 is a packaging fix.
+
 ## Release v1.3.0 (28 May 2024)
 
 * (#1042) Align Java Executor Service behavior for `shuttingdown?`, `shutdown?`

--- a/docs-source/signpost.md
+++ b/docs-source/signpost.md
@@ -3,7 +3,7 @@
 Pick a `concurrent-ruby` version:
 
 * [master](./master/index.html)
-* [1.3.0 with edge 0.7.0](./1.2.3/index.html)
+* [1.3.1 with edge 0.7.0](./1.2.3/index.html)
 * [1.1.10 with edge 0.6.0](./1.1.10/index.html)
 * [1.1.9 with edge 0.6.0](./1.1.9/index.html)
 * [1.1.8 with edge 0.6.0](./1.1.8/index.html)

--- a/lib/concurrent-ruby/concurrent/version.rb
+++ b/lib/concurrent-ruby/concurrent/version.rb
@@ -1,3 +1,3 @@
 module Concurrent
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
I messed up publishing the 1.3.0 release. 1.3.1 is a small bump to ensure unique versions.