### PR TITLE
Remove dependency on `win32ole`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,20 +6,24 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 10
 
     strategy:
       fail-fast: false
       matrix:
         ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, jruby, truffleruby]
+        os: [ubuntu]
+        include:
+          - ruby: 3.3
+            os: windows
 
     env:
       JAVA_OPTS: '-Xmx1024m'
       RUBYOPT: '-w'
       JRUBY_OPTS: '--dev'
 
-    name: "Tests: Ruby ${{ matrix.ruby }}"
+    name: "Tests: Ruby ${{ matrix.ruby }} - ${{ matrix.os }}"
     steps:
     - name: Clone Repo
       uses: actions/checkout@v4

--- a/spec/concurrent/channel/integration_spec.rb
+++ b/spec/concurrent/channel/integration_spec.rb
@@ -68,7 +68,7 @@ STDOUT
     end
 
     specify 'default-selection.rb' do
-      skip('flaky') if Concurrent.on_jruby? || Concurrent.on_truffleruby?
+      skip('flaky') if Concurrent.on_jruby? || Concurrent.on_truffleruby? || Concurrent.on_windows?
 expected = <<-STDOUT
     .
     .

--- a/spec/concurrent/promises_spec.rb
+++ b/spec/concurrent/promises_spec.rb
@@ -758,6 +758,7 @@ RSpec.describe 'Concurrent::Promises' do
   describe 'value!' do
     %w[with without].each do |timeout|
       it "does not return spuriously #{timeout} timeout" do
+        skip "SIGHUP not supported" if Concurrent.on_windows?
         # https://github.com/ruby-concurrency/concurrent-ruby/issues/1015
         trapped = false
         original_handler = Signal.trap(:SIGHUP) { trapped = true }


### PR DESCRIPTION
This will become bundled in Ruby 3.5

Unfortunately there is no portable way of checking for this. The wmic command is deprecated, though I don't observe this myself on W11 (yet?)

Closes #1048

The powershell variant will work in at least releases from 2012 (Windows 8):
https://learn.microsoft.com/en-us/previous-versions/powershell/module/cimcmdlets/get-ciminstance?view=powershell-3.0
https://learn.microsoft.com/en-us/previous-versions/powershell/module/microsoft.powershell.utility/select-object?view=powershell-3.0
https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.4

There are no docs from earlier so I can't say about versions from before that. Maybe supporting 12 year old versions is good enough and `wmic` doesn't even need to be used? Let me know.

This is overall very defensive in what could happen because I'm not primarily developing on windows. 