### PR TITLE
Improve speed for windows `Get-CimInstance`

### DIFF
--- a/lib/concurrent-ruby/concurrent/utility/processor_counter.rb
+++ b/lib/concurrent-ruby/concurrent/utility/processor_counter.rb
@@ -69,7 +69,7 @@ module Concurrent
                 cores.count
               when /mswin|mingw/
                 # Get-CimInstance introduced in PowerShell 3 or earlier: https://learn.microsoft.com/en-us/previous-versions/powershell/module/cimcmdlets/get-ciminstance?view=powershell-3.0
-                result = run('powershell -command "Get-CimInstance -ClassName Win32_Processor  | Select-Object -Property NumberOfCores"')
+                result = run('powershell -command "Get-CimInstance -ClassName Win32_Processor -Property NumberOfCores | Select-Object -Property NumberOfCores"')
                 if !result || $?.exitstatus != 0
                   # fallback to deprecated wmic for older systems
                   result = run("wmic cpu get NumberOfCores")


### PR DESCRIPTION
This is a small followup for #1051.

In terms of the previous code, the powershell invocation currently does `select * from Win32_Processor` which is slower. I missed this in the other PR, this improves the speed when detection runs on windows.

The pipe is still needed since that command returns all properties anyways, they are just empty/not computed.