### PR TITLE
Add `Concurrent.cpu_requests` that is cgroups aware.

### DIFF
--- a/spec/concurrent/utility/processor_count_spec.rb
+++ b/spec/concurrent/utility/processor_count_spec.rb
@@ -92,4 +92,26 @@ module Concurrent
     end
 
   end
+
+  RSpec.describe '#cpu_shares' do
+    let(:counter) { Concurrent::Utility::ProcessorCounter.new }
+
+    it 'returns a float when cgroups v2 sets a cpu.weight' do
+      expect(RbConfig::CONFIG).to receive(:[]).with("target_os").and_return("linux")
+      expect(File).to receive(:exist?).with("/sys/fs/cgroup/cpu.weight").and_return(true)
+
+      expect(File).to receive(:read).with("/sys/fs/cgroup/cpu.weight").and_return("10000\n")
+      expect(counter.cpu_shares).to be == 256.0
+    end
+
+    it 'returns a float if cgroups v1 sets a cpu.shares' do
+      expect(RbConfig::CONFIG).to receive(:[]).with("target_os").and_return("linux")
+      expect(File).to receive(:exist?).with("/sys/fs/cgroup/cpu.weight").and_return(false)
+      expect(File).to receive(:exist?).with("/sys/fs/cgroup/cpu/cpu.shares").and_return(true)
+
+      expect(File).to receive(:read).with("/sys/fs/cgroup/cpu/cpu.shares").and_return("512\n")
+      expect(counter.cpu_shares).to be == 0.5
+    end
+
+  end
 end


### PR DESCRIPTION
In K8s environments, cpu requests are often more useful than limits, but concurrent-ruby currently lacks a related method, so I've added it. Below are links to articles about the usefulness of cpu requests.

- https://medium.com/directeam/kubernetes-resources-under-the-hood-part-3-6ee7d6015965
- https://x.com/thockin/status/1134193838841401345