### PR TITLE
Fix the return value of `Concurrent.available_processor_count` when `cpu.cfs_quota_us` is -1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Current
 
+* (#1060) Fix bug with return value of `Concurrent.available_processor_count` when `cpu.cfs_quota_us` is -1.
+
 ## Release v1.3.3 (9 June 2024)
 
 * (#1053) Improve the speed of `Concurrent.physical_processor_count` on Windows.

--- a/lib/concurrent-ruby/concurrent/utility/processor_counter.rb
+++ b/lib/concurrent-ruby/concurrent/utility/processor_counter.rb
@@ -112,7 +112,9 @@ module Concurrent
           elsif File.exist?("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us")
             # cgroups v1: https://kernel.googlesource.com/pub/scm/linux/kernel/git/glommer/memcg/+/cpu_stat/Documentation/cgroups/cpu.txt
             max = File.read("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us").to_i
-            return nil if max == 0
+            # If the cpu.cfs_quota_us is -1, cgroup does not adhere to any CPU time restrictions
+            # https://docs.kernel.org/scheduler/sched-bwc.html#management
+            return nil if max <= 0
             period = File.read("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us").to_f
             max / period
           end

--- a/spec/concurrent/utility/processor_count_spec.rb
+++ b/spec/concurrent/utility/processor_count_spec.rb
@@ -56,6 +56,15 @@ module Concurrent
       expect(counter.cpu_quota).to be_nil
     end
 
+    it 'returns nil if cgroups v1 and cpu.cfs_quota_us is -1' do
+      expect(RbConfig::CONFIG).to receive(:[]).with("target_os").and_return("linux")
+      expect(File).to receive(:exist?).with("/sys/fs/cgroup/cpu.max").and_return(false)
+      expect(File).to receive(:exist?).with("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us").and_return(true)
+
+      expect(File).to receive(:read).with("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us").and_return("-1\n")
+      expect(counter.cpu_quota).to be_nil
+    end
+
     it 'returns a float if cgroups v1 sets a limit' do
       expect(RbConfig::CONFIG).to receive(:[]).with("target_os").and_return("linux")
       expect(File).to receive(:exist?).with("/sys/fs/cgroup/cpu.max").and_return(false)


### PR DESCRIPTION

I tried to use `Concurrent.available_processor_count` in `parallel` gem, but we got some feedback `Concurrent.available_processor_count` returned a negative value.
https://github.com/grosser/parallel/pull/348#issuecomment-2275859126 
https://github.com/grosser/parallel/issues/349#issuecomment-2275953547

According to the https://docs.kernel.org/scheduler/sched-bwc.html#management, The default value of `cpu.cfs_quota_us` is -1. In that case, cgroup does not adhere to any CPU time restrictions.

This PR adds the case of `cpu.cfs_quota_us` is -1 to `#cpu_quota` to return processor count from `Concurrent.available_processor_count` in that case.