### PR TITLE
Remove dependency on logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ To use the tools in the Edge gem it must be required separately:
 require 'concurrent-edge'
 ```
 
-If the library does not behave as expected, `Concurrent.use_stdlib_logger(Logger::DEBUG)` could 
+If the library does not behave as expected, `Concurrent.use_simple_logger(:DEBUG)` could
 help to reveal the problem.
 
 ## Installation

--- a/docs-source/actor/celluloid_benchmark.rb
+++ b/docs-source/actor/celluloid_benchmark.rb
@@ -7,11 +7,7 @@ require 'celluloid/autostart'
 # require 'stackprof'
 # require 'profiler'
 
-logger                          = Logger.new($stderr)
-logger.level                    = Logger::INFO
-Concurrent.configuration.logger = lambda do |level, progname, message = nil, &block|
-  logger.add level, message, progname, &block
-end
+Concurrent.use_simple_logger(:INFO)
 
 scale       = 1
 ADD_TO      = (100 * scale).to_i

--- a/docs-source/actor/io.in.rb
+++ b/docs-source/actor/io.in.rb
@@ -1,7 +1,6 @@
 require 'concurrent'
 
-# logger = Logger.new(STDOUT)
-# Concurrent.configuration.logger = logger.method(:add)
+# Concurrent.use_simple_logger(:WARN, STDOUT)
 
 # First option is to use operation pool
 

--- a/docs-source/actor/io.out.rb
+++ b/docs-source/actor/io.out.rb
@@ -1,7 +1,6 @@
 require 'concurrent'                               # => false
 
-# logger = Logger.new(STDOUT)
-# Concurrent.configuration.logger = logger.method(:add)
+# Concurrent.use_simple_logger(:WARN, STDOUT)
 
 # First option is to use operation pool
 

--- a/docs-source/actor/main.md
+++ b/docs-source/actor/main.md
@@ -124,12 +124,12 @@ Spawned actor cannot be garbage-collected until it's terminated. There is a refe
 
 Actors are running on shared thread poll which allows user to create many actors cheaply.
 Downside is that these actors cannot be directly used to do IO or other blocking operations.
-Blocking operations could starve the `default_task_pool`. However there are two options:
+Blocking operations could starve the `global_fast_executor`. However there are two options:
 
-- Create an regular actor which will schedule blocking operations in `global_operation_pool`
+- Create an regular actor which will schedule blocking operations in `global_io_executor`
   (which is intended for blocking operations) sending results back to self in messages.
-- Create an actor using `global_operation_pool` instead of `global_task_pool`, e.g.
-  `AnIOActor.spawn name: :blocking, executor: Concurrent.configuration.global_operation_pool`.
+- Create an actor using `global_io_executor` instead of `global_fast_executor`, e.g.
+  `AnIOActor.spawn name: :blocking, executor: Concurrent.global_io_executor`.
   
 ### Example
   

--- a/examples/init.rb
+++ b/examples/init.rb
@@ -4,4 +4,4 @@ def do_stuff(*args)
   :stuff
 end
 
-Concurrent.use_simple_logger Logger::DEBUG
+Concurrent.use_simple_logger :DEBUG

--- a/lib/concurrent-ruby-edge/concurrent/actor/context.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/context.rb
@@ -84,7 +84,7 @@ module Concurrent
         Reference
       end
 
-      # override to se different default executor, e.g. to change it to global_operation_pool
+      # override to se different default executor, e.g. to change it to global_fast_executor
       # @return [Executor]
       def default_executor
         Concurrent.global_io_executor
@@ -109,7 +109,7 @@ module Concurrent
       # @example by option hash
       #   inc2 = AdHoc.spawn(name:     'increment by 2',
       #                      args:     [2],
-      #                      executor: Concurrent.configuration.global_task_pool) do |increment_by|
+      #                      executor: Concurrent.global_fast_executor) do |increment_by|
       #     lambda { |number| number + increment_by }
       #   end
       #   inc2.ask!(2) # => 4

--- a/lib/concurrent-ruby-edge/concurrent/actor/internal_delegations.rb
+++ b/lib/concurrent-ruby-edge/concurrent/actor/internal_delegations.rb
@@ -1,11 +1,11 @@
-require 'logger'
+require 'concurrent/concern/logging'
 require 'concurrent/actor/public_delegations'
 
 module Concurrent
   module Actor
     module InternalDelegations
       include PublicDelegations
-      include Logger::Severity
+      include Concurrent::Concern::Logging
 
       # @see Core#children
       def children

--- a/lib/concurrent-ruby-edge/concurrent/edge/erlang_actor.rb
+++ b/lib/concurrent-ruby-edge/concurrent/edge/erlang_actor.rb
@@ -674,7 +674,7 @@ module Concurrent
       end
 
       def tell_op(message)
-        log Logger::DEBUG, @Pid, told: message
+        log DEBUG, @Pid, told: message
         if (mailbox = @Mailbox)
           mailbox.push_op(message).then { @Pid }
         else
@@ -683,7 +683,7 @@ module Concurrent
       end
 
       def tell(message, timeout = nil)
-        log Logger::DEBUG, @Pid, told: message
+        log DEBUG, @Pid, told: message
         if (mailbox = @Mailbox)
           timed_out = mailbox.push message, timeout
           timeout ? timed_out : @Pid
@@ -693,7 +693,7 @@ module Concurrent
       end
 
       def ask(message, timeout, timeout_value)
-        log Logger::DEBUG, @Pid, asked: message
+        log DEBUG, @Pid, asked: message
         if @Terminated.resolved?
           raise NoActor.new(@Pid)
         else
@@ -724,7 +724,7 @@ module Concurrent
       end
 
       def ask_op(message, probe)
-        log Logger::DEBUG, @Pid, asked: message
+        log DEBUG, @Pid, asked: message
         if @Terminated.resolved?
           probe.reject NoActor.new(@Pid), false
         else
@@ -1029,7 +1029,7 @@ module Concurrent
       end
 
       def after_termination(final_reason)
-        log Logger::DEBUG, @Pid, terminated: final_reason
+        log DEBUG, @Pid, terminated: final_reason
         clean_reply NoActor.new(@Pid)
         while true
           message = @Mailbox.try_pop NOTHING
@@ -1071,7 +1071,7 @@ module Concurrent
         inner_run(*args, &body).
             run(Run::TEST).
             then(&method(:after_termination)).
-            rescue { |e| log Logger::ERROR, e }
+            rescue { |e| log ERROR, e }
       end
 
       def receive(*rules, timeout: nil, timeout_value: nil, keep: false, &given_block)
@@ -1163,7 +1163,7 @@ module Concurrent
                          end
 
         message_future.then(start, self) do |message, s, _actor|
-          log Logger::DEBUG, pid, got: message
+          log DEBUG, pid, got: message
           catch(JUMP) do
             if (message = consume_signal(message)) == NOTHING
               @timeout = [@timeout + s - Concurrent.monotonic_time, 0].max if s
@@ -1230,7 +1230,7 @@ module Concurrent
         matcher       = -> m { m.is_a?(Ask) ? rules_matcher === m.message : rules_matcher === m }
         while true
           message = @Mailbox.pop_matching(matcher, timeout, TIMEOUT)
-          log Logger::DEBUG, pid, got: message
+          log DEBUG, pid, got: message
           unless (message = consume_signal(message)) == NOTHING
             rules.each do |rule, job|
               return eval_task(message, job) if rule === message
@@ -1535,7 +1535,7 @@ module Concurrent
     def self.create(type, channel, environment, name, executor)
       actor = KLASS_MAP.fetch(type).new(channel, environment, name, executor)
     ensure
-      log Logger::DEBUG, actor.pid, created: caller[1] if actor
+      log Concern::Logging::DEBUG, actor.pid, created: caller[1] if actor
     end
 
     KLASS_MAP = {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,7 @@ RSpec.configure do |config|
   config.before :all do
     # Only configure logging if it has been required, to make sure the necessary require's are in place
     if Concurrent.respond_to? :use_simple_logger
-      Concurrent.use_simple_logger Logger::FATAL
+      Concurrent.use_simple_logger :FATAL
     end
   end
 


### PR DESCRIPTION
* To fix the Ruby 3.3.5 warnings: https://github.com/ruby-concurrency/concurrent-ruby/issues/1061
* concurrent-ruby only uses 7 constants from Logger, so just copy those over.

This should be fully compatible and address the warnings.
Only if one uses the long-deprecated `Concurrent.create_stdlib_logger` they might need to add `logger` to their Gemfile.