### PR TITLE
Avoid error when member is present on ancestor class

### DIFF
--- a/lib/concurrent-ruby/concurrent/synchronization/abstract_struct.rb
+++ b/lib/concurrent-ruby/concurrent/synchronization/abstract_struct.rb
@@ -157,7 +157,7 @@ module Concurrent
           end
         end
         members.each_with_index do |member, index|
-          clazz.send :remove_method, member if clazz.instance_methods.include? member
+          clazz.send :remove_method, member if clazz.instance_methods(false).include? member
           clazz.send(:define_method, member) do
             @values[index]
           end

--- a/spec/concurrent/struct_shared.rb
+++ b/spec/concurrent/struct_shared.rb
@@ -26,6 +26,18 @@ RSpec.shared_examples :struct do
       expect(clazz.ancestors).to include described_class
     end
 
+    it 'ignores methods on ancestor classes' do
+      ancestor = described_class.ancestors.first
+      ancestor.class_eval { def foo; end }
+
+      clazz = described_class.new(:foo)
+      expect{ described_class.const_get(clazz.to_s) }.to raise_error(NameError)
+      expect(clazz).to be_a Class
+      expect(clazz.ancestors).to include described_class
+
+      ancestor.send :remove_method, :foo
+    end
+
     it 'raises an exception when given an invalid class name' do
       expect{ described_class.new('lowercase') }.to raise_error(NameError)
       expect{ described_class.new('_') }.to raise_error(NameError)

--- a/spec/concurrent/struct_shared.rb
+++ b/spec/concurrent/struct_shared.rb
@@ -27,13 +27,15 @@ RSpec.shared_examples :struct do
     end
 
     it 'ignores methods on ancestor classes' do
-      ancestor = described_class.ancestors.first
-      ancestor.class_eval { def foo; end }
+      ancestor = described_class.ancestors.last
+      ancestor.class_eval { def foo(bar); end }
 
       clazz = described_class.new(:foo)
-      expect{ described_class.const_get(clazz.to_s) }.to raise_error(NameError)
-      expect(clazz).to be_a Class
-      expect(clazz.ancestors).to include described_class
+      struct = clazz.new
+
+      expect(struct).to respond_to :foo
+      method = struct.method(:foo)
+      expect(method.arity).to eq 0
 
       ancestor.send :remove_method, :foo
     end


### PR DESCRIPTION
Fix #1067 

Niche case - when clearing class members for new definition, avoid trying to remove members present on ancestor classes.

I'm happy to make any updates for style or structure if needed - I've added a spec that does fail without this fix, very happy to receive feedback if it would fit better in a different location or with different emphasis. 