### PR TITLE
Mark RubySingleThreadExecutor as a SerialExecutorService

### DIFF
--- a/lib/concurrent-ruby/concurrent/executor/ruby_single_thread_executor.rb
+++ b/lib/concurrent-ruby/concurrent/executor/ruby_single_thread_executor.rb
@@ -1,4 +1,5 @@
 require 'concurrent/executor/ruby_thread_pool_executor'
+require 'concurrent/executor/serial_executor_service'
 
 module Concurrent
 
@@ -6,6 +7,7 @@ module Concurrent
   # @!macro abstract_executor_service_public_api
   # @!visibility private
   class RubySingleThreadExecutor < RubyThreadPoolExecutor
+    include SerialExecutorService
 
     # @!macro single_thread_executor_method_initialize
     def initialize(opts = {})


### PR DESCRIPTION
This resolves #1069.

However, I'm still not 100% sure if the `RubySingleThreadExecutor` is *actually* serialized. From my understanding of the code, it is, but there may be edge-cases I'm missing (such as when the thread dies).

As such, I'd still appreciate if someone who knows the (intended) RubyThreadPoolExecutor semantics to review this.