### PR TITLE
Set rake-compiler source and target to Java 8

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,8 @@ ENV['JRUBY_HOME'] = ENV['CONCURRENT_JRUBY_HOME'] if ENV['CONCURRENT_JRUBY_HOME']
 Rake::JavaExtensionTask.new('concurrent_ruby', core_gemspec) do |ext|
   ext.ext_dir = 'ext/concurrent-ruby'
   ext.lib_dir = 'lib/concurrent-ruby/concurrent'
+  ext.source_version = '8'
+  ext.target_version = '8'
 end
 
 if RUBY_ENGINE == 'ruby'


### PR DESCRIPTION
This patch forces rake-compiler to emit bytecode for Java 8 level of JVM. rake-compiler currently defaults to Java 1.7 source and target, but that version is no longer supported by recent JDKs such as Java 21 (see https://github.com/rake-compiler/rake-compiler/pull/242 for a patch to update rake-compiler).

This patch sets our minimum Java level to 8, bypassing the default in rake-compiler and allowing builds on Java 21+.