### PR TITLE
Less aggressive async pruning for RubyThreadPoolExecutor

### DIFF
--- a/lib/concurrent-ruby/concurrent/executor/fixed_thread_pool.rb
+++ b/lib/concurrent-ruby/concurrent/executor/fixed_thread_pool.rb
@@ -12,7 +12,7 @@ module Concurrent
   # @!macro thread_pool_executor_constant_default_max_queue_size
   #   Default maximum number of tasks that may be added to the task queue.
 
-  # @!macro thread_pool_executor_constant_default_thread_timeout
+  # @!macro thread_pool_executor_constant_default_thread_idle_timeout
   #   Default maximum number of seconds a thread in the pool may remain idle
   #   before being reclaimed.
 

--- a/lib/concurrent-ruby/concurrent/executor/java_thread_pool_executor.rb
+++ b/lib/concurrent-ruby/concurrent/executor/java_thread_pool_executor.rb
@@ -18,7 +18,7 @@ if Concurrent.on_jruby?
       # @!macro thread_pool_executor_constant_default_max_queue_size
       DEFAULT_MAX_QUEUE_SIZE = 0
 
-      # @!macro thread_pool_executor_constant_default_thread_timeout
+      # @!macro thread_pool_executor_constant_default_thread_idle_timeout
       DEFAULT_THREAD_IDLETIMEOUT = 60
 
       # @!macro thread_pool_executor_constant_default_synchronous

--- a/spec/concurrent/executor/cached_thread_pool_spec.rb
+++ b/spec/concurrent/executor/cached_thread_pool_spec.rb
@@ -158,9 +158,7 @@ module Concurrent
             latch = Concurrent::CountDownLatch.new(4)
             4.times { subject.post { sleep 0.1; latch.count_down } }
             expect(latch.wait(1)).to be true
-            sleep 0.2
-            subject.post {}
-            sleep 0.2
+            sleep 36
             expect(subject.length).to be < 4
           end
 

--- a/spec/concurrent/executor/ruby_thread_pool_executor_spec.rb
+++ b/spec/concurrent/executor/ruby_thread_pool_executor_spec.rb
@@ -56,56 +56,49 @@ module Concurrent
       end
 
       before(:each) do
-        @now = Concurrent.monotonic_time
-        allow(Concurrent).to receive(:monotonic_time) { @now }
-
         @group1 = prepare_thread_group(5)
         @group2 = prepare_thread_group(5)
       end
 
       def eventually(mutex: nil, timeout: 5, &block)
-          start = Time.now
-          while Time.now - start < timeout
-            begin
-              if mutex
-                mutex.synchronize do
-                  return yield
-                end
-              else
+        start = Time.now
+        while Time.now - start < timeout
+          begin
+            if mutex
+              mutex.synchronize do
                 return yield
               end
-            rescue Exception => last_failure
+            else
+              return yield
             end
-            Thread.pass
+          rescue Exception => last_failure
           end
-          raise last_failure
+          Thread.pass
+        end
+        raise last_failure
       end
 
-      it "triggers pruning when posting work if the last prune happened more than gc_interval ago" do
+      it "triggers pruning if the thread idletimes have elapsed and the prunetime has elapsed" do
         wakeup_thread_group(@group1)
-        @now += 6
+        sleep 36
         wakeup_thread_group(@group2)
-        subject.post { }
 
         eventually { expect(@group1.threads).to all(have_attributes(status: false)) }
         eventually { expect(@group2.threads).to all(have_attributes(status: 'sleep')) }
       end
 
-      it "does not trigger pruning when posting work if the last prune happened less than gc_interval ago" do
+      it "does not trigger pruning if the thread idletimes have elapsed but the prunetime has not elapsed" do
         wakeup_thread_group(@group1)
-        @now += 3
-        subject.prune_pool
-        @now += 3
+        sleep 6
         wakeup_thread_group(@group2)
-        subject.post { }
 
-        eventually { expect(@group1.threads).to all(have_attributes(status: false)) }
+        eventually { expect(@group1.threads).to all(have_attributes(status: 'sleep')) }
         eventually { expect(@group2.threads).to all(have_attributes(status: 'sleep')) }
       end
 
       it "reclaims threads that have been idle for more than idletime seconds" do
         wakeup_thread_group(@group1)
-        @now += 6
+        sleep 6
         wakeup_thread_group(@group2)
         subject.prune_pool
 
@@ -116,7 +109,7 @@ module Concurrent
       it "keeps at least min_length workers" do
         wakeup_thread_group(@group1)
         wakeup_thread_group(@group2)
-        @now += 12
+        sleep 12
         subject.prune_pool
         all_threads = @group1.threads + @group2.threads
         eventually do


### PR DESCRIPTION
Fixes https://github.com/ruby-concurrency/concurrent-ruby/issues/1066

<details>
<summary>Issue script output with this patch</summary>

```ruby
0
4
4
4
1
pool should ideally be scaled up here
4
1
1
1
4
4
4
1
1
1
1
```
</details>

Adds a pruner thread to `RubyThreadPoolExecutor` with the intention of making pruning a lot less aggressive which should reduce the likelihood of prematurely scaling down the size of the pool right after being assigned a large workload.