### PR TITLE
Fix mistakes in MVar documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -66,7 +66,7 @@ There are a few guidelines which we follow when adding features. Consider that s
 
 #### Write Documentation
 
-Document any external behavior in the [README](README.md).
+Document any external behavior in the [README](../README.md).
 
 #### Commit Changes
 
@@ -106,7 +106,7 @@ git push origin my-feature-branch -f
 
 #### Update CHANGELOG
 
-Update the [CHANGELOG](CHANGELOG.md) with a description of what you have changed.
+Update the [CHANGELOG](../CHANGELOG.md) with a description of what you have changed.
 
 #### Check on Your Pull Request
 

--- a/lib/concurrent-ruby/concurrent/mvar.rb
+++ b/lib/concurrent-ruby/concurrent/mvar.rb
@@ -9,7 +9,7 @@ module Concurrent
   # queue of length one, or a special kind of mutable variable.
   #
   # On top of the fundamental `#put` and `#take` operations, we also provide a
-  # `#mutate` that is atomic with respect to operations on the same instance.
+  # `#modify` that is atomic with respect to operations on the same instance.
   # These operations all support timeouts.
   #
   # We also support non-blocking operations `#try_put!` and `#try_take!`, a
@@ -87,7 +87,7 @@ module Concurrent
       @mutex.synchronize do
         wait_for_full(timeout)
 
-        # if we timeoud out we'll still be empty
+        # If we timed out we'll still be empty
         if unlocked_full?
           yield @value
         else
@@ -116,10 +116,10 @@ module Concurrent
     end
 
     # Atomically `take`, yield the value to a block for transformation, and then
-    # `put` the transformed value. Returns the transformed value. A timeout can
+    # `put` the transformed value. Returns the pre-transform value. A timeout can
     # be set to limit the time spent blocked, in which case it returns `TIMEOUT`
     # if the time is exceeded.
-    # @return [Object] the transformed value, or `TIMEOUT`
+    # @return [Object] the pre-transform value, or `TIMEOUT`
     def modify(timeout = nil)
       raise ArgumentError.new('no block given') unless block_given?
 


### PR DESCRIPTION
Fixes a couple of mistakes in documentation:
- `#modify`'s documentation *very* incorrectly said that it returns modified value, when that's not the case;
- class's docs referenced `#mutate` instead of `#modify`;
- typo in a comment.

Additionally, links to README and CHANGELOG are fixed in contributing guidelines, previously they linked to non-existent files.