### PR TITLE
Return the Promises waiter count for inspection

### DIFF
--- a/lib/concurrent-ruby/concurrent/promises.rb
+++ b/lib/concurrent-ruby/concurrent/promises.rb
@@ -726,7 +726,7 @@ module Concurrent
       # For inspection.
       # @!visibility private
       def waiting_threads
-        @Waiters.each.to_a
+        @Waiters.value
       end
 
       # @!visibility private

--- a/spec/concurrent/promises_spec.rb
+++ b/spec/concurrent/promises_spec.rb
@@ -612,12 +612,18 @@ RSpec.describe 'Concurrent::Promises' do
       expect(event.waiting_threads).to eq 0
 
       waiter = Thread.new { event.wait }
-      Thread.pass until waiter.status == "sleep"
+      begin
+        Thread.pass until waiter.status == "sleep"
 
-      expect(event.waiting_threads).to eq 1
-    ensure
-      event&.resolve(false)
-      waiter&.join
+        expect(event.waiting_threads).to eq 1
+
+        event.resolve(false)
+        waiter.join
+        expect(event.waiting_threads).to eq 0
+      ensure
+        event.resolve(false)
+        waiter.join
+      end
     end
 
     specify "#wait" do

--- a/spec/concurrent/promises_spec.rb
+++ b/spec/concurrent/promises_spec.rb
@@ -607,6 +607,19 @@ RSpec.describe 'Concurrent::Promises' do
   end
 
   describe 'ResolvableEvent' do
+    specify "#waiting_threads" do
+      event = resolvable_event
+      expect(event.waiting_threads).to eq 0
+
+      waiter = Thread.new { event.wait }
+      Thread.pass until waiter.status == "sleep"
+
+      expect(event.waiting_threads).to eq 1
+    ensure
+      event&.resolve(false)
+      waiter&.join
+    end
+
     specify "#wait" do
       event = resolvable_event
       expect(event.wait(0, false)).to be_falsey


### PR DESCRIPTION
Returns the AtomicFixnum value used by the lock-free event waiter registry. The current inspection path calls each on AtomicFixnum and raises instead of reporting the count.

Verified by focused Promises specs and models; the review composite passes 2,796 examples with no failures.