### PR TITLE
Release TVar locks for all exceptions

### DIFF
--- a/lib/concurrent-ruby/concurrent/tvar.rb
+++ b/lib/concurrent-ruby/concurrent/tvar.rb
@@ -111,7 +111,7 @@ module Concurrent
           rescue Transaction::LeaveError => e
             transaction.abort
             break result
-          rescue => e
+          rescue Exception => e
             transaction.abort
             raise e
           end

--- a/lib/concurrent-ruby/concurrent/tvar.rb
+++ b/lib/concurrent-ruby/concurrent/tvar.rb
@@ -111,9 +111,9 @@ module Concurrent
           rescue Transaction::LeaveError => e
             transaction.abort
             break result
-          rescue Exception => e
+          rescue Exception
             transaction.abort
-            raise e
+            raise
           end
           # If we can commit, break out of the loop
 

--- a/spec/concurrent/tvar_spec.rb
+++ b/spec/concurrent/tvar_spec.rb
@@ -48,6 +48,22 @@ module Concurrent
       }.to raise_error(StandardError, 'This is an error!')
     end
 
+    it 'aborts and releases locks for exceptions outside StandardError' do
+      t = TVar.new(0)
+      error = Interrupt.new('This is an interrupt!')
+
+      expect {
+        Concurrent::atomically do
+          t.value = 1
+          raise error
+        end
+      }.to raise_error(error)
+
+      expect(t.value).to eq 0
+      expect { Concurrent::atomically { t.value = 2 } }.not_to raise_error
+      expect(t.value).to eq 2
+    end
+
     it 'retries on abort' do
       count = 0
 


### PR DESCRIPTION
Aborts the transaction before re-raising exceptions outside StandardError as well, preventing TVar locks from remaining held after Interrupt, SystemExit, or other Exception subclasses.

Verified by focused TVar specs and models; the review composite passes 2,796 examples with no failures.