### PR TITLE
Fix unused variable warning

### DIFF
--- a/lib/concurrent-ruby/concurrent/tvar.rb
+++ b/lib/concurrent-ruby/concurrent/tvar.rb
@@ -105,10 +105,10 @@ module Concurrent
 
           begin
             result = yield
-          rescue Transaction::AbortError => e
+          rescue Transaction::AbortError
             transaction.abort
             result = Transaction::ABORTED
-          rescue Transaction::LeaveError => e
+          rescue Transaction::LeaveError
             transaction.abort
             break result
           rescue Exception


### PR DESCRIPTION
```sh
$ RUBYOPT=-w bundle exec ruby -r "concurrent/tvar"
/home/user/Documents/concurrent-ruby/lib/concurrent-ruby/concurrent/tvar.rb:108: warning: assigned but unused variable - e
```